### PR TITLE
[S1/M1] DB migrations — reserved_qty + password reset + lots unique

### DIFF
--- a/db/migrations/000017_sprint_s1_reserved_qty_and_password_reset.down.sql
+++ b/db/migrations/000017_sprint_s1_reserved_qty_and_password_reset.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_lots_sku_lot_number_active_unique;
+ALTER TABLE public.inventory DROP CONSTRAINT IF EXISTS chk_reserved_non_negative;
+ALTER TABLE public.inventory DROP COLUMN IF EXISTS reserved_qty;
+DROP TABLE IF EXISTS public.password_reset_tokens;

--- a/db/migrations/000017_sprint_s1_reserved_qty_and_password_reset.up.sql
+++ b/db/migrations/000017_sprint_s1_reserved_qty_and_password_reset.up.sql
@@ -1,0 +1,37 @@
+-- ============================================================
+-- Sprint S1: reserved_qty en inventory + password reset tokens
+--            + unicidad de lote por SKU (A4)
+-- ============================================================
+
+-- 1. Agregar reserved_qty a inventory
+ALTER TABLE public.inventory
+  ADD COLUMN IF NOT EXISTS reserved_qty NUMERIC(10,3) NOT NULL DEFAULT 0;
+
+-- Solo validar que no sea negativo — el límite superior se maneja en app code.
+-- Un constraint CHECK (reserved_qty <= quantity) causaría errores en transacciones
+-- donde se actualiza quantity y reserved_qty en pasos separados dentro del mismo tx.
+ALTER TABLE public.inventory
+  ADD CONSTRAINT chk_reserved_non_negative
+    CHECK (reserved_qty >= 0);
+
+-- 2. Tabla para tokens de reset de contraseña
+CREATE TABLE IF NOT EXISTS public.password_reset_tokens (
+  id           VARCHAR NOT NULL,
+  user_id      VARCHAR NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  token        VARCHAR NOT NULL UNIQUE,
+  expires_at   TIMESTAMPTZ NOT NULL,
+  used_at      TIMESTAMPTZ,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_token ON public.password_reset_tokens(token);
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user_id ON public.password_reset_tokens(user_id);
+
+-- 3. A4: Unicidad de lote por SKU (lot_number + sku únicos para lotes no archivados)
+-- Permite re-usar un lot_number si el lote anterior con ese número fue archivado
+-- (ej: lote completado y cerrado, luego un nuevo pedido con mismo nombre).
+-- Requiere que la columna lots.status exista (ya existe, default 'pending').
+CREATE UNIQUE INDEX IF NOT EXISTS idx_lots_sku_lot_number_active_unique
+  ON public.lots(sku, lot_number)
+  WHERE status IS NULL OR status != 'archived';


### PR DESCRIPTION
## Bloque M1 — Migraciones DB (Sprint S1, Wave 1)

### Qué incluye

**Migration 000017** `sprint_s1_reserved_qty_and_password_reset`

1. **`reserved_qty` en `inventory`** — columna `NUMERIC(10,3) NOT NULL DEFAULT 0` + constraint `chk_reserved_non_negative` (>= 0). El límite superior (`<= quantity`) no se pone en DB para evitar errores en transacciones que actualizan ambos valores en pasos separados.

2. **Tabla `password_reset_tokens`** — `id` PK, `user_id` FK→users (CASCADE DELETE), `token` UNIQUE, `expires_at`, `used_at`, `created_at`. Índices en `token` y `user_id`.

3. **Unique index parcial `idx_lots_sku_lot_number_active_unique`** — sobre `lots(sku, lot_number)` con filtro `WHERE status IS NULL OR status != 'archived'` (A4). Permite reusar un lot_number si el lote anterior fue archivado.

### Verificación

- ✅ Pre-flight check: 0 duplicados en `lots` (fresh DB dev)
- ✅ `make migrate-up` aplicó 000017 sin errores
- ✅ Schema verificado: `reserved_qty` + constraint presentes en `inventory`; `password_reset_tokens` con columnas e índices correctos; unique index en `lots`
- ✅ Rollback (`make migrate-down-1`): columna, tabla e índice eliminados limpiamente
- ✅ Re-apply: DB dejada en estado correcto

### No toca

- Código Go — cero cambios fuera de `db/migrations/`