### PR TITLE
[S1/H4] State machine helpers for picking + receiving transitions

### DIFF
--- a/repositories/picking_task_repository.go
+++ b/repositories/picking_task_repository.go
@@ -21,6 +21,28 @@ type PickingTaskRepository struct {
 	DB *gorm.DB
 }
 
+// validPickingTransitions declara las transiciones permitidas de status.
+// Los estados finales (completed, completed_with_differences, cancelled, abandoned)
+// no aparecen como claves porque no tienen transición saliente.
+var validPickingTransitions = map[string]map[string]bool{
+	"open":        {"assigned": true, "in_progress": true, "cancelled": true, "abandoned": true},
+	"assigned":    {"open": true, "in_progress": true, "cancelled": true, "abandoned": true},
+	"in_progress": {"completed": true, "completed_with_differences": true, "cancelled": true, "abandoned": true},
+}
+
+// isValidPickingTransition retorna true si el cambio de status es permitido.
+// No-op (mismo → mismo) siempre es true.
+// Desde estados finales no hay transición saliente → false.
+func isValidPickingTransition(current, next string) bool {
+	if current == next {
+		return true
+	}
+	if allowed, ok := validPickingTransitions[current]; ok {
+		return allowed[next]
+	}
+	return false
+}
+
 func (r *PickingTaskRepository) GetAllPickingTasks() ([]responses.PickingTaskView, *responses.InternalResponse) {
 	var tasks []responses.PickingTaskView
 

--- a/repositories/picking_task_state_machine_test.go
+++ b/repositories/picking_task_state_machine_test.go
@@ -1,0 +1,72 @@
+package repositories
+
+import (
+	"testing"
+)
+
+func TestIsValidPickingTransition(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		next    string
+		want    bool
+	}{
+		// ── Transiciones válidas desde open ───────────────────────────────────
+		{"open → assigned", "open", "assigned", true},
+		{"open → in_progress", "open", "in_progress", true},
+		{"open → cancelled", "open", "cancelled", true},
+		{"open → abandoned", "open", "abandoned", true},
+
+		// ── Transiciones válidas desde assigned ───────────────────────────────
+		{"assigned → open (des-asignar)", "assigned", "open", true},
+		{"assigned → in_progress", "assigned", "in_progress", true},
+		{"assigned → cancelled", "assigned", "cancelled", true},
+		{"assigned → abandoned", "assigned", "abandoned", true},
+
+		// ── Transiciones válidas desde in_progress ────────────────────────────
+		{"in_progress → completed", "in_progress", "completed", true},
+		{"in_progress → completed_with_differences", "in_progress", "completed_with_differences", true},
+		{"in_progress → cancelled", "in_progress", "cancelled", true},
+		{"in_progress → abandoned", "in_progress", "abandoned", true},
+
+		// ── No-op: mismo → mismo (siempre true) ──────────────────────────────
+		{"no-op open", "open", "open", true},
+		{"no-op assigned", "assigned", "assigned", true},
+		{"no-op in_progress", "in_progress", "in_progress", true},
+		{"no-op completed", "completed", "completed", true},
+		{"no-op completed_with_differences", "completed_with_differences", "completed_with_differences", true},
+		{"no-op cancelled", "cancelled", "cancelled", true},
+		{"no-op abandoned", "abandoned", "abandoned", true},
+
+		// ── Estados finales: sin transición saliente ──────────────────────────
+		{"completed → open (final)", "completed", "open", false},
+		{"completed → in_progress (final)", "completed", "in_progress", false},
+		{"completed_with_differences → open (final)", "completed_with_differences", "open", false},
+		{"cancelled → in_progress (final)", "cancelled", "in_progress", false},
+		{"cancelled → open (final)", "cancelled", "open", false},
+		{"abandoned → open (final)", "abandoned", "open", false},
+		{"abandoned → in_progress (final)", "abandoned", "in_progress", false},
+
+		// ── Transiciones inválidas entre estados no-finales ───────────────────
+		{"open → completed (salta in_progress)", "open", "completed", false},
+		{"open → completed_with_differences (salta)", "open", "completed_with_differences", false},
+		{"in_progress → open (no retroactivo)", "in_progress", "open", false},
+		{"in_progress → assigned (no retroactivo)", "in_progress", "assigned", false},
+		{"assigned → completed (salta in_progress)", "assigned", "completed", false},
+
+		// ── Estado desconocido como origen ────────────────────────────────────
+		{"unknown origin", "foo", "open", false},
+		{"unknown origin and next", "foo", "bar", false},
+		{"empty strings", "", "", true}, // no-op: "" == "" → true
+		{"empty origin, non-empty next", "", "open", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isValidPickingTransition(tt.current, tt.next)
+			if got != tt.want {
+				t.Errorf("isValidPickingTransition(%q, %q) = %v, want %v", tt.current, tt.next, got, tt.want)
+			}
+		})
+	}
+}

--- a/repositories/receiving_task_state_machine_test.go
+++ b/repositories/receiving_task_state_machine_test.go
@@ -1,0 +1,61 @@
+package repositories
+
+import (
+	"testing"
+)
+
+func TestIsValidReceivingTransition(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		next    string
+		want    bool
+	}{
+		// ── Transiciones válidas desde open ───────────────────────────────────
+		{"open → in_progress", "open", "in_progress", true},
+		{"open → cancelled", "open", "cancelled", true},
+
+		// ── Transiciones válidas desde in_progress ────────────────────────────
+		{"in_progress → completed", "in_progress", "completed", true},
+		{"in_progress → completed_with_differences", "in_progress", "completed_with_differences", true},
+		{"in_progress → cancelled", "in_progress", "cancelled", true},
+
+		// ── No-op: mismo → mismo (siempre true) ──────────────────────────────
+		{"no-op open", "open", "open", true},
+		{"no-op in_progress", "in_progress", "in_progress", true},
+		{"no-op completed", "completed", "completed", true},
+		{"no-op completed_with_differences", "completed_with_differences", "completed_with_differences", true},
+		{"no-op cancelled", "cancelled", "cancelled", true},
+
+		// ── Estados finales: sin transición saliente ──────────────────────────
+		{"completed → open (final)", "completed", "open", false},
+		{"completed → in_progress (final)", "completed", "in_progress", false},
+		{"completed_with_differences → open (final)", "completed_with_differences", "open", false},
+		{"cancelled → open (final)", "cancelled", "open", false},
+		{"cancelled → in_progress (final)", "cancelled", "in_progress", false},
+
+		// ── Transiciones inválidas entre estados no-finales ───────────────────
+		{"open → completed (salta in_progress)", "open", "completed", false},
+		{"open → completed_with_differences (salta)", "open", "completed_with_differences", false},
+		{"in_progress → open (no retroactivo)", "in_progress", "open", false},
+
+		// ── Receiving no tiene abandoned ──────────────────────────────────────
+		{"open → abandoned (no existe en receiving)", "open", "abandoned", false},
+		{"in_progress → abandoned (no existe en receiving)", "in_progress", "abandoned", false},
+
+		// ── Estado desconocido como origen ────────────────────────────────────
+		{"unknown origin", "foo", "open", false},
+		{"unknown origin and next", "foo", "bar", false},
+		{"empty strings", "", "", true}, // no-op: "" == "" → true
+		{"empty origin, non-empty next", "", "open", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isValidReceivingTransition(tt.current, tt.next)
+			if got != tt.want {
+				t.Errorf("isValidReceivingTransition(%q, %q) = %v, want %v", tt.current, tt.next, got, tt.want)
+			}
+		})
+	}
+}

--- a/repositories/receiving_tasks_repository.go
+++ b/repositories/receiving_tasks_repository.go
@@ -22,6 +22,27 @@ type ReceivingTasksRepository struct {
 	DB *gorm.DB
 }
 
+// validReceivingTransitions declara las transiciones permitidas de status.
+// Receiving no tiene 'abandoned' (el cron no limpia recepciones — la mercancía física manda).
+// Los estados finales (completed, completed_with_differences, cancelled) no tienen transición saliente.
+var validReceivingTransitions = map[string]map[string]bool{
+	"open":        {"in_progress": true, "cancelled": true},
+	"in_progress": {"completed": true, "completed_with_differences": true, "cancelled": true},
+}
+
+// isValidReceivingTransition retorna true si el cambio de status es permitido.
+// No-op (mismo → mismo) siempre es true.
+// Desde estados finales no hay transición saliente → false.
+func isValidReceivingTransition(current, next string) bool {
+	if current == next {
+		return true
+	}
+	if allowed, ok := validReceivingTransitions[current]; ok {
+		return allowed[next]
+	}
+	return false
+}
+
 func (r *ReceivingTasksRepository) GetAllReceivingTasks() ([]responses.ReceivingTasksView, *responses.InternalResponse) {
 	var tasks []responses.ReceivingTasksView
 


### PR DESCRIPTION
## Resumen

Bloque H4 (Wave 3, Track B) — helpers de validación de state machine para picking y receiving tasks.

### Qué se agrega

**`repositories/picking_task_repository.go`**
- `var validPickingTransitions` — mapa explícito de transiciones permitidas
- `func isValidPickingTransition(current, next string) bool` — validador; no-op siempre true; estados finales → false

**`repositories/receiving_tasks_repository.go`**
- `var validReceivingTransitions` — análogo (sin `abandoned` — receiving no lo tiene)
- `func isValidReceivingTransition(current, next string) bool`

**Tests table-driven**
- `repositories/picking_task_state_machine_test.go` — 36 casos
- `repositories/receiving_task_state_machine_test.go` — 24 casos
- Cubren: transiciones válidas, estados finales sin salida, no-op (mismo→mismo), estado desconocido como origen, `abandoned` inexistente en receiving

### Qué NO se toca

- Ningún método existente (`UpdatePickingTask`, `CompleteReceivingLine`, etc.)
- Frontend
- Migrations / modelos DB

### Nota para Wave 4

B3 (`UpdatePickingTask` rewrite), H5 (`CompletePickingTask`), y B5 (`completed_with_differences` en receiving) invocarán estos helpers directamente.

## Test plan

- [x] `go build ./...` — limpio
- [x] `go vet ./...` — limpio  
- [x] `go test ./repositories/... -run "TestIsValid" -v` — 60/60 PASS
- [x] Verificado que `validPickingTransitions` refleja exactamente el roadmap (incluyendo `assigned → open` para des-asignar)
- [x] Verificado que `validReceivingTransitions` no incluye `abandoned`