### PR TITLE
[S1/B2b+H3] Inventory DTO reserved/available qty + pick-suggestions FEFO cross-location

### DIFF
--- a/controllers/inventory_controller.go
+++ b/controllers/inventory_controller.go
@@ -2,8 +2,8 @@ package controllers
 
 import (
 	"io"
+	"strconv"
 
-	"github.com/eflowcr/eSTOCK_backend/models/dto"
 	"github.com/eflowcr/eSTOCK_backend/models/requests"
 	"github.com/eflowcr/eSTOCK_backend/services"
 	"github.com/eflowcr/eSTOCK_backend/tools"
@@ -55,20 +55,22 @@ func (c *InventoryController) GetInventoryBySkuAndLocation(ctx *gin.Context) {
 }
 
 func (c *InventoryController) GetPickSuggestions(ctx *gin.Context) {
-	sku := ctx.Param("sku")
-	if sku == "" {
-		tools.ResponseBadRequest(ctx, "GetPickSuggestions", "SKU es requerido", "get_pick_suggestions")
+	sku, ok := tools.ParseRequiredParam(ctx, "sku", "GetPickSuggestions", "get_pick_suggestions", "SKU es requerido")
+	if !ok {
 		return
 	}
-	list, response := c.Service.GetPickSuggestionsBySKU(sku)
-	if response != nil {
-		writeErrorResponse(ctx, "GetPickSuggestions", "get_pick_suggestions", response)
+	qty := 0.0
+	if qtyStr := ctx.Query("qty"); qtyStr != "" {
+		if parsed, err := strconv.ParseFloat(qtyStr, 64); err == nil {
+			qty = parsed
+		}
+	}
+	resp, errResp := c.Service.GetPickSuggestionsBySKU(sku, qty)
+	if errResp != nil {
+		writeErrorResponse(ctx, "GetPickSuggestions", "get_pick_suggestions", errResp)
 		return
 	}
-	if list == nil {
-		list = []dto.PickSuggestion{}
-	}
-	tools.ResponseOK(ctx, "GetPickSuggestions", "Sugerencias de picking obtenidas", "get_pick_suggestions", list, false, "")
+	tools.ResponseOK(ctx, "GetPickSuggestions", "Sugerencias de picking obtenidas", "get_pick_suggestions", resp, false, "")
 }
 
 func (c *InventoryController) CreateInventory(ctx *gin.Context) {

--- a/controllers/inventory_controller_test.go
+++ b/controllers/inventory_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/eflowcr/eSTOCK_backend/models/database"
 	"github.com/eflowcr/eSTOCK_backend/models/dto"
 	"github.com/eflowcr/eSTOCK_backend/models/requests"
 	"github.com/eflowcr/eSTOCK_backend/models/responses"
@@ -34,7 +35,7 @@ type mockInventoryRepoCtrl struct {
 	deleteSerErr *responses.InternalResponse
 	trend        *dto.ConsumptionTrend
 	trendErr     *responses.InternalResponse
-	suggestions  []dto.PickSuggestion
+	pickResp     *dto.PickSuggestionResponse
 	suggestErr   *responses.InternalResponse
 }
 
@@ -112,8 +113,8 @@ func (m *mockInventoryRepoCtrl) DeleteInventorySerial(id string) *responses.Inte
 	return m.deleteSerErr
 }
 
-func (m *mockInventoryRepoCtrl) GetPickSuggestionsBySKU(sku string) ([]dto.PickSuggestion, *responses.InternalResponse) {
-	return m.suggestions, m.suggestErr
+func (m *mockInventoryRepoCtrl) GetPickSuggestionsBySKU(sku string, qty float64) (*dto.PickSuggestionResponse, *responses.InternalResponse) {
+	return m.pickResp, m.suggestErr
 }
 
 func (m *mockInventoryRepoCtrl) GenerateImportTemplate(language string) ([]byte, error) {
@@ -423,11 +424,17 @@ func TestInventoryController_DeleteInventorySerial_MissingParam(t *testing.T) {
 }
 
 func TestInventoryController_GetPickSuggestions_Success(t *testing.T) {
+	lotNum := "L-001"
 	repo := &mockInventoryRepoCtrl{
-		suggestions: []dto.PickSuggestion{{Location: "A-01", LotNumber: "L-001", Quantity: 3}},
+		pickResp: &dto.PickSuggestionResponse{
+			Allocations: []database.LocationAllocation{{Location: "A-01", Quantity: 3, LotNumber: &lotNum}},
+			TotalFound:  3,
+			Requested:   3,
+			Sufficient:  true,
+		},
 	}
 	ctrl := newInventoryController(repo)
-	w := performRequest(ctrl.GetPickSuggestions, "GET", "/inventory/SKU1/pick", nil,
+	w := performRequest(ctrl.GetPickSuggestions, "GET", "/inventory/SKU1/pick?qty=3", nil,
 		gin.Params{{Key: "sku", Value: "SKU1"}})
 	assert.Equal(t, http.StatusOK, w.Code)
 }

--- a/models/database/inventory.go
+++ b/models/database/inventory.go
@@ -11,6 +11,7 @@ type Inventory struct {
 	Description  *string   `gorm:"column:description" json:"description"`
 	Location     string    `gorm:"column:location;index:sku_location_idx" json:"location"`
 	Quantity     float64   `gorm:"column:quantity" json:"quantity"`
+	ReservedQty  float64   `gorm:"column:reserved_qty" json:"reserved_qty"`
 	Status       string    `gorm:"column:status" json:"status"`
 	Presentation string    `gorm:"column:presentation" json:"presentation"`
 	UnitPrice    *float64  `gorm:"column:unit_price" json:"unit_price"`

--- a/models/database/models_b1_b2_test.go
+++ b/models/database/models_b1_b2_test.go
@@ -1,0 +1,185 @@
+package database
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ── LotEntry ──────────────────────────────────────────────────────────────────
+
+func TestLotEntry_JSONRoundtrip_WithExpiration(t *testing.T) {
+	exp := "2026-12-31"
+	status := "pending"
+	entry := LotEntry{
+		LotNumber:      "LOT-A",
+		SKU:            "SKU-001",
+		Quantity:       100.5,
+		ExpirationDate: &exp,
+		Status:         &status,
+	}
+
+	b, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	var got LotEntry
+	require.NoError(t, json.Unmarshal(b, &got))
+
+	assert.Equal(t, "LOT-A", got.LotNumber)
+	assert.Equal(t, "SKU-001", got.SKU)
+	assert.Equal(t, 100.5, got.Quantity)
+	require.NotNil(t, got.ExpirationDate)
+	assert.Equal(t, "2026-12-31", *got.ExpirationDate)
+	require.NotNil(t, got.Status)
+	assert.Equal(t, "pending", *got.Status)
+}
+
+func TestLotEntry_JSONRoundtrip_OmitsNilFields(t *testing.T) {
+	entry := LotEntry{
+		LotNumber: "LOT-B",
+		Quantity:  50,
+	}
+
+	b, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	// expiration_date and status should be absent in the JSON output
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(b, &raw))
+	assert.NotContains(t, raw, "expiration_date")
+	assert.NotContains(t, raw, "status")
+	assert.NotContains(t, raw, "sku") // omitempty
+}
+
+// ── LocationAllocation ────────────────────────────────────────────────────────
+
+func TestLocationAllocation_JSONRoundtrip(t *testing.T) {
+	lot := "LOT-A"
+	status := "pending"
+	exp := "2026-06-30"
+	picked := 30.0
+	alloc := LocationAllocation{
+		Location:       "RACK-A1",
+		Quantity:       60.0,
+		LotNumber:      &lot,
+		PickedQty:      &picked,
+		Status:         &status,
+		ExpirationDate: &exp,
+	}
+
+	b, err := json.Marshal(alloc)
+	require.NoError(t, err)
+
+	var got LocationAllocation
+	require.NoError(t, json.Unmarshal(b, &got))
+
+	assert.Equal(t, "RACK-A1", got.Location)
+	assert.Equal(t, 60.0, got.Quantity)
+	require.NotNil(t, got.LotNumber)
+	assert.Equal(t, "LOT-A", *got.LotNumber)
+	require.NotNil(t, got.PickedQty)
+	assert.Equal(t, 30.0, *got.PickedQty)
+	assert.Equal(t, "2026-06-30", *got.ExpirationDate)
+}
+
+// ── PickingTaskItem ───────────────────────────────────────────────────────────
+
+func TestPickingTaskItem_JSONRoundtrip_WithAllocations(t *testing.T) {
+	lot := "LOT-A"
+	status := "pending"
+	item := PickingTaskItem{
+		SKU:              "SKU-001",
+		ExpectedQuantity: 100.0,
+		Allocations: []LocationAllocation{
+			{Location: "RACK-A1", Quantity: 60, LotNumber: &lot, Status: &status},
+			{Location: "RACK-B2", Quantity: 40},
+		},
+	}
+
+	b, err := json.Marshal(item)
+	require.NoError(t, err)
+
+	var got PickingTaskItem
+	require.NoError(t, json.Unmarshal(b, &got))
+
+	assert.Equal(t, "SKU-001", got.SKU)
+	assert.Equal(t, 100.0, got.ExpectedQuantity)
+	require.Len(t, got.Allocations, 2)
+	assert.Equal(t, "RACK-A1", got.Allocations[0].Location)
+	assert.Equal(t, 60.0, got.Allocations[0].Quantity)
+	require.NotNil(t, got.Allocations[0].LotNumber)
+	assert.Equal(t, "LOT-A", *got.Allocations[0].LotNumber)
+	assert.Equal(t, "RACK-B2", got.Allocations[1].Location)
+	assert.Equal(t, 40.0, got.Allocations[1].Quantity)
+}
+
+func TestPickingTaskItem_JSONRoundtrip_OmitsEmptyAllocations(t *testing.T) {
+	item := PickingTaskItem{
+		SKU:              "SKU-002",
+		ExpectedQuantity: 10.0,
+	}
+
+	b, err := json.Marshal(item)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(b, &raw))
+
+	// allocations is NOT omitempty — should appear as empty/null
+	// lots and serials are omitempty — should be absent
+	assert.NotContains(t, raw, "lots")
+	assert.NotContains(t, raw, "serials")
+}
+
+// ── ReceivingTaskItem ─────────────────────────────────────────────────────────
+
+func TestReceivingTaskItem_JSONRoundtrip_WithLots(t *testing.T) {
+	exp1 := "2026-03-15"
+	status := "received"
+	item := ReceivingTaskItem{
+		SKU:              "SKU-003",
+		ExpectedQuantity: 200.0,
+		Location:         "DOCK-1",
+		LotNumbers: []LotEntry{
+			{LotNumber: "LOT-X", Quantity: 150, ExpirationDate: &exp1, Status: &status},
+			{LotNumber: "LOT-Y", Quantity: 50},
+		},
+	}
+
+	b, err := json.Marshal(item)
+	require.NoError(t, err)
+
+	var got ReceivingTaskItem
+	require.NoError(t, json.Unmarshal(b, &got))
+
+	assert.Equal(t, "SKU-003", got.SKU)
+	assert.Equal(t, 200.0, got.ExpectedQuantity)
+	assert.Equal(t, "DOCK-1", got.Location)
+	require.Len(t, got.LotNumbers, 2)
+	assert.Equal(t, "LOT-X", got.LotNumbers[0].LotNumber)
+	assert.Equal(t, 150.0, got.LotNumbers[0].Quantity)
+	require.NotNil(t, got.LotNumbers[0].ExpirationDate)
+	assert.Equal(t, "2026-03-15", *got.LotNumbers[0].ExpirationDate)
+	assert.Equal(t, "LOT-Y", got.LotNumbers[1].LotNumber)
+}
+
+func TestReceivingTaskItem_JSONRoundtrip_OmitsNilOptionals(t *testing.T) {
+	item := ReceivingTaskItem{
+		SKU:              "SKU-004",
+		ExpectedQuantity: 5.0,
+		Location:         "BIN-3",
+	}
+
+	b, err := json.Marshal(item)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(b, &raw))
+
+	assert.NotContains(t, raw, "lots")
+	assert.NotContains(t, raw, "serials")
+	assert.NotContains(t, raw, "received_qty")
+	assert.NotContains(t, raw, "status")
+}

--- a/models/database/picking_task_item.go
+++ b/models/database/picking_task_item.go
@@ -1,9 +1,32 @@
 package database
 
+// LotEntry represents a structured lot with quantity and expiration.
+// Shared between picking and receiving task items.
+type LotEntry struct {
+	LotNumber      string  `json:"lot_number"`
+	SKU            string  `json:"sku,omitempty"`
+	Quantity       float64 `json:"quantity"`
+	ExpirationDate *string `json:"expiration_date,omitempty"`
+	Status         *string `json:"status,omitempty"` // pending | picked | received | skipped
+}
+
+// LocationAllocation indicates from which location and in what quantity to pick.
+// ExpirationDate is display-only — populated from pick-suggestions, not persisted in picking_tasks.
+type LocationAllocation struct {
+	Location       string   `json:"location"`
+	Quantity       float64  `json:"quantity"`
+	LotNumber      *string  `json:"lot_number,omitempty"`
+	PickedQty      *float64 `json:"picked_qty,omitempty"`
+	Status         *string  `json:"status,omitempty"` // pending | picked | skipped
+	ExpirationDate *string  `json:"expiration_date,omitempty"` // "YYYY-MM-DD" — display only
+}
+
 type PickingTaskItem struct {
-	SKU              string           `json:"sku"`
-	ExpectedQuantity int              `json:"required_qty"`
-	Location         string           `json:"location"`
-	LotNumbers       StringSliceOrCSV `json:"lotNumbers"`
-	SerialNumbers    StringSliceOrCSV `json:"serialNumbers"`
+	SKU              string               `json:"sku"`
+	ExpectedQuantity float64              `json:"required_qty"`
+	Allocations      []LocationAllocation `json:"allocations"` // replaces Location string (A1)
+	Status           *string              `json:"status,omitempty"`
+	PickedQty        *float64             `json:"picked_qty,omitempty"`
+	LotNumbers       []LotEntry           `json:"lots,omitempty"`
+	SerialNumbers    []Serial             `json:"serials,omitempty"`
 }

--- a/models/database/receiving_task_items.go
+++ b/models/database/receiving_task_items.go
@@ -1,9 +1,14 @@
 package database
 
+// ReceivingTaskItem represents one SKU line in a receiving task.
+// Receiving remains single-location per line — unlike picking (B1), the operator
+// designates one destination location per item. LotEntry is defined in picking_task_item.go.
 type ReceivingTaskItem struct {
-	SKU              string           `json:"sku"`
-	ExpectedQuantity int              `json:"expected_qty"`
-	Location         string           `json:"location"`
-	LotNumbers       StringSliceOrCSV `json:"lot_numbers" gorm:"type:jsonb"`
-	SerialNumbers    StringSliceOrCSV `json:"serial_numbers" gorm:"type:jsonb"`
+	SKU              string     `json:"sku"`
+	ExpectedQuantity float64    `json:"expected_qty"`
+	ReceivedQuantity *float64   `json:"received_qty,omitempty"`
+	Location         string     `json:"location"` // single destination location per line
+	Status           *string    `json:"status,omitempty"`
+	LotNumbers       []LotEntry `json:"lots,omitempty"`
+	SerialNumbers    []Serial   `json:"serials,omitempty"`
 }

--- a/models/dto/enhanced_inventory.go
+++ b/models/dto/enhanced_inventory.go
@@ -11,6 +11,8 @@ type EnhancedInventory struct {
 	SKU             string            `json:"sku"`
 	Location        string            `json:"location"`
 	Quantity        float64           `json:"quantity"`
+	ReservedQty     float64           `json:"reserved_qty"`
+	AvailableQty    float64           `json:"available_qty"`
 	Status          string            `json:"status"`
 	UnitPrice       *float64          `json:"unit_price"`
 	CreatedAt       time.Time         `json:"created_at"`

--- a/models/dto/pick_suggestion.go
+++ b/models/dto/pick_suggestion.go
@@ -1,9 +1,13 @@
 package dto
 
-import "time"
+import (
+	"time"
 
-// PickSuggestion represents a suggested pick location and lot for outbound shipments.
-// Sorted by: (1) inventory rotation (FIFO/FEFO), (2) lowest quantity at location first.
+	"github.com/eflowcr/eSTOCK_backend/models/database"
+)
+
+// PickSuggestion is the legacy shape returned before H3.
+// Retained for reference; no longer used by active endpoints.
 type PickSuggestion struct {
 	Location       string     `json:"location"`
 	LotID          string     `json:"lot_id"`
@@ -11,4 +15,15 @@ type PickSuggestion struct {
 	Quantity       float64    `json:"quantity"`
 	ExpirationDate *time.Time `json:"expiration_date,omitempty"`
 	LotCreatedAt   time.Time  `json:"lot_created_at"`
+}
+
+// PickSuggestionResponse is the H3 contract for GET /inventory/pick-suggestions/:sku?qty=N.
+// Each Allocation is a (location, lot, qty) tuple the operator should pull from.
+// Items are FEFO-sorted (earliest expiration first, FIFO within tie).
+// If qty is 0, all available allocations are returned (Sufficient is always true).
+type PickSuggestionResponse struct {
+	Allocations []database.LocationAllocation `json:"allocations"`
+	TotalFound  float64                        `json:"total_found"`
+	Requested   float64                        `json:"requested_qty"`
+	Sufficient  bool                           `json:"sufficient"`
 }

--- a/ports/inventory.go
+++ b/ports/inventory.go
@@ -8,7 +8,7 @@ import (
 
 // InventoryRepository defines persistence operations for inventory.
 type InventoryRepository interface {
-	GetPickSuggestionsBySKU(sku string) ([]dto.PickSuggestion, *responses.InternalResponse)
+	GetPickSuggestionsBySKU(sku string, qty float64) (*dto.PickSuggestionResponse, *responses.InternalResponse)
 	GetAllInventory() ([]*dto.EnhancedInventory, *responses.InternalResponse)
 	GetInventoryBySkuAndLocation(sku, location string) (*dto.EnhancedInventory, *responses.InternalResponse)
 	CreateInventory(userId string, item *requests.CreateInventory) *responses.InternalResponse

--- a/repositories/inventory_pick_suggestions_test.go
+++ b/repositories/inventory_pick_suggestions_test.go
@@ -1,0 +1,131 @@
+package repositories
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ptr helpers
+func strPtr(s string) *string { return &s }
+func timePtr(t time.Time) *time.Time { return &t }
+
+func TestAllocatePickRows_EmptyRows(t *testing.T) {
+	resp := allocatePickRows(nil, 10)
+	assert.Empty(t, resp.Allocations)
+	assert.Equal(t, 0.0, resp.TotalFound)
+	assert.False(t, resp.Sufficient)
+}
+
+func TestAllocatePickRows_ZeroQty_ReturnsAll(t *testing.T) {
+	rows := []pickRow{
+		{Location: "A-01", InvQty: 20, InvReserved: 0, LotQtyInLoc: 0},
+		{Location: "B-01", InvQty: 15, InvReserved: 5, LotQtyInLoc: 0},
+	}
+	resp := allocatePickRows(rows, 0)
+	// With qty=0 we return everything available
+	assert.Equal(t, 30.0, resp.TotalFound) // 20 + 10
+	assert.True(t, resp.Sufficient)
+	assert.Len(t, resp.Allocations, 2)
+}
+
+func TestAllocatePickRows_ExactFit_SingleLocation(t *testing.T) {
+	rows := []pickRow{
+		{Location: "A-01", InvQty: 50, InvReserved: 10, LotQtyInLoc: 0},
+	}
+	resp := allocatePickRows(rows, 40)
+	require.Len(t, resp.Allocations, 1)
+	assert.Equal(t, 40.0, resp.Allocations[0].Quantity)
+	assert.Equal(t, 40.0, resp.TotalFound)
+	assert.True(t, resp.Sufficient)
+}
+
+func TestAllocatePickRows_CrossLocation_FEFO(t *testing.T) {
+	exp1 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC) // expires first
+	exp2 := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	lot1 := "LOT-A"
+	lot2 := "LOT-B"
+
+	// rows arrive pre-sorted (FEFO): exp1 row first
+	rows := []pickRow{
+		{Location: "A-01", InvQty: 10, InvReserved: 0, LotNumber: &lot1, ExpirationDate: timePtr(exp1), LotQtyInLoc: 10},
+		{Location: "B-01", InvQty: 20, InvReserved: 0, LotNumber: &lot2, ExpirationDate: timePtr(exp2), LotQtyInLoc: 20},
+	}
+	resp := allocatePickRows(rows, 25)
+	require.Len(t, resp.Allocations, 2)
+	// First allocation should come from LOT-A (earlier expiry)
+	assert.Equal(t, "A-01", resp.Allocations[0].Location)
+	assert.Equal(t, 10.0, resp.Allocations[0].Quantity)
+	assert.Equal(t, "LOT-A", *resp.Allocations[0].LotNumber)
+	assert.Equal(t, "2026-03-01", *resp.Allocations[0].ExpirationDate)
+	// Second allocation fills remaining 15 from LOT-B
+	assert.Equal(t, "B-01", resp.Allocations[1].Location)
+	assert.Equal(t, 15.0, resp.Allocations[1].Quantity)
+	assert.Equal(t, 25.0, resp.TotalFound)
+	assert.True(t, resp.Sufficient)
+}
+
+func TestAllocatePickRows_Insufficient(t *testing.T) {
+	rows := []pickRow{
+		{Location: "A-01", InvQty: 5, InvReserved: 0, LotQtyInLoc: 0},
+	}
+	resp := allocatePickRows(rows, 10)
+	assert.Equal(t, 5.0, resp.TotalFound)
+	assert.False(t, resp.Sufficient)
+}
+
+func TestAllocatePickRows_ReservedQtyReducesAvailable(t *testing.T) {
+	rows := []pickRow{
+		{Location: "A-01", InvQty: 20, InvReserved: 15, LotQtyInLoc: 0},
+	}
+	resp := allocatePickRows(rows, 10)
+	// Only 5 available (20 - 15)
+	assert.Equal(t, 5.0, resp.TotalFound)
+	assert.False(t, resp.Sufficient)
+	require.Len(t, resp.Allocations, 1)
+	assert.Equal(t, 5.0, resp.Allocations[0].Quantity)
+}
+
+func TestAllocatePickRows_LotWithNoStockInLoc_Skipped(t *testing.T) {
+	lot := "LOT-X"
+	rows := []pickRow{
+		// LotNumber set but LotQtyInLoc = 0 → should be skipped
+		{Location: "A-01", InvQty: 20, InvReserved: 0, LotNumber: &lot, LotQtyInLoc: 0},
+		{Location: "B-01", InvQty: 10, InvReserved: 0, LotQtyInLoc: 0}, // no lot
+	}
+	resp := allocatePickRows(rows, 10)
+	// Row 0 skipped (lot with 0 qty). Row 1 provides 10.
+	require.Len(t, resp.Allocations, 1)
+	assert.Equal(t, "B-01", resp.Allocations[0].Location)
+	assert.Equal(t, 10.0, resp.TotalFound)
+	assert.True(t, resp.Sufficient)
+}
+
+func TestAllocatePickRows_LotQtyCapsBound(t *testing.T) {
+	lot := "LOT-Y"
+	rows := []pickRow{
+		// location has 30 available but this specific lot only has 8 in it
+		{Location: "A-01", InvQty: 30, InvReserved: 0, LotNumber: &lot, LotQtyInLoc: 8},
+	}
+	resp := allocatePickRows(rows, 20)
+	// Should only take 8 (lot bound), not 20 or 30
+	assert.Equal(t, 8.0, resp.TotalFound)
+	assert.False(t, resp.Sufficient)
+}
+
+func TestAllocatePickRows_MultipleLotsInSameLocation(t *testing.T) {
+	lot1, lot2 := "LOT-1", "LOT-2"
+	rows := []pickRow{
+		{Location: "A-01", InvQty: 30, InvReserved: 0, LotNumber: &lot1, LotQtyInLoc: 10},
+		{Location: "A-01", InvQty: 30, InvReserved: 0, LotNumber: &lot2, LotQtyInLoc: 15},
+	}
+	resp := allocatePickRows(rows, 20)
+	// Both lots from same location: 10 + 10 = 20 (second lot capped at location remaining = 20)
+	assert.Equal(t, 20.0, resp.TotalFound)
+	assert.True(t, resp.Sufficient)
+	require.Len(t, resp.Allocations, 2)
+	assert.Equal(t, 10.0, resp.Allocations[0].Quantity) // full lot-1
+	assert.Equal(t, 10.0, resp.Allocations[1].Quantity) // remaining from lot-2
+}

--- a/repositories/inventory_repository.go
+++ b/repositories/inventory_repository.go
@@ -148,6 +148,8 @@ func (r *InventoryRepository) GetAllInventory() ([]*dto.EnhancedInventory, *resp
 			SKU:             item.SKU,
 			Location:        item.Location,
 			Quantity:        item.Quantity,
+			ReservedQty:     item.ReservedQty,
+			AvailableQty:    item.Quantity - item.ReservedQty,
 			Status:          item.Status,
 			UnitPrice:       item.UnitPrice,
 			CreatedAt:       item.CreatedAt,
@@ -235,6 +237,8 @@ func (r *InventoryRepository) GetInventoryBySkuAndLocation(sku, location string)
 		SKU:             item.SKU,
 		Location:        item.Location,
 		Quantity:        item.Quantity,
+		ReservedQty:     item.ReservedQty,
+		AvailableQty:    item.Quantity - item.ReservedQty,
 		Status:          item.Status,
 		UnitPrice:       item.UnitPrice,
 		CreatedAt:       item.CreatedAt,
@@ -1195,17 +1199,108 @@ func (r *InventoryRepository) ExportInventoryToExcel() ([]byte, *responses.Inter
 	return buf.Bytes(), nil
 }
 
-// GetPickSuggestionsBySKU returns all (location, lot, quantity) rows for the given SKU.
-// Caller (service) is responsible for sorting by rotation (FIFO/FEFO) then by quantity ascending.
-func (r *InventoryRepository) GetPickSuggestionsBySKU(sku string) ([]dto.PickSuggestion, *responses.InternalResponse) {
-	var rows []dto.PickSuggestion
-	err := r.DB.
-		Table("inventory_lots").
-		Select("inv.location AS location, lots.id AS lot_id, lots.lot_number AS lot_number, inventory_lots.quantity AS quantity, lots.expiration_date AS expiration_date, lots.created_at AS lot_created_at").
-		Joins("INNER JOIN inventory inv ON inventory_lots.inventory_id = inv.id").
-		Joins("INNER JOIN lots ON inventory_lots.lot_id = lots.id").
-		Where("inv.sku = ? AND inventory_lots.quantity > 0", sku).
-		Scan(&rows).Error
+// pickRow is a raw result row from the pick-suggestions SQL query.
+// Unexported so unit tests in this package can access it for allocatePickRows tests.
+type pickRow struct {
+	Location       string
+	InvQty         float64
+	InvReserved    float64
+	LotNumber      *string
+	ExpirationDate *time.Time
+	LotQtyInLoc    float64
+	InvCreatedAt   time.Time
+}
+
+// allocatePickRows runs the greedy FEFO allocation algorithm over pre-sorted rows.
+// rows must arrive FEFO-ordered (expiration ASC, created_at ASC) from the SQL query.
+// If qty is 0, all available stock is returned without limiting.
+// Extracted as a pure function so it can be unit-tested independently of the DB.
+func allocatePickRows(rows []pickRow, qty float64) *dto.PickSuggestionResponse {
+	takenPerLocation := make(map[string]float64)
+	resp := &dto.PickSuggestionResponse{
+		Requested:   qty,
+		Allocations: []database.LocationAllocation{},
+	}
+	remaining := qty
+
+	for _, r := range rows {
+		locationAvailable := r.InvQty - r.InvReserved - takenPerLocation[r.Location]
+		if locationAvailable <= 0 {
+			continue
+		}
+
+		// upperBound is min(location_available, lot_qty_in_location).
+		// For items without lot tracking, lot_qty_in_loc will be 0 and LotNumber nil.
+		upperBound := locationAvailable
+		if r.LotNumber != nil && r.LotQtyInLoc > 0 {
+			if r.LotQtyInLoc < upperBound {
+				upperBound = r.LotQtyInLoc
+			}
+		} else if r.LotNumber != nil && r.LotQtyInLoc <= 0 {
+			continue // lot known but no stock in this location
+		}
+
+		take := upperBound
+		if qty > 0 && take > remaining {
+			take = remaining
+		}
+		if take <= 0 {
+			continue
+		}
+
+		alloc := database.LocationAllocation{
+			Location: r.Location,
+			Quantity: take,
+		}
+		if r.LotNumber != nil {
+			alloc.LotNumber = r.LotNumber
+		}
+		if r.ExpirationDate != nil {
+			s := r.ExpirationDate.Format("2006-01-02")
+			alloc.ExpirationDate = &s
+		}
+		resp.Allocations = append(resp.Allocations, alloc)
+		resp.TotalFound += take
+		takenPerLocation[r.Location] += take
+
+		if qty > 0 {
+			remaining -= take
+			if remaining <= 0 {
+				break
+			}
+		}
+	}
+
+	resp.Sufficient = qty == 0 || resp.TotalFound >= qty
+	return resp
+}
+
+// GetPickSuggestionsBySKU returns FEFO-ordered pick allocations for a SKU.
+// Uses inventory_lots to resolve which lots are present in each location.
+// If qty is 0, all available allocations are returned (Sufficient = true).
+func (r *InventoryRepository) GetPickSuggestionsBySKU(sku string, qty float64) (*dto.PickSuggestionResponse, *responses.InternalResponse) {
+	var rows []pickRow
+	err := r.DB.Raw(`
+		SELECT
+		    i.location                     AS location,
+		    i.quantity                     AS inv_qty,
+		    i.reserved_qty                 AS inv_reserved,
+		    l.lot_number                   AS lot_number,
+		    l.expiration_date              AS expiration_date,
+		    COALESCE(il.quantity, 0)       AS lot_qty_in_loc,
+		    i.created_at                   AS inv_created_at
+		FROM inventory i
+		LEFT JOIN inventory_lots il ON il.inventory_id = i.id
+		LEFT JOIN lots l
+		       ON l.id = il.lot_id
+		      AND (l.status IS NULL OR l.status != 'archived')
+		WHERE i.sku = ?
+		  AND (i.quantity - i.reserved_qty) > 0
+		ORDER BY
+		    COALESCE(l.expiration_date, '9999-12-31'::date) ASC,
+		    i.created_at ASC
+	`, sku).Scan(&rows).Error
+
 	if err != nil {
 		return nil, &responses.InternalResponse{
 			Error:   err,
@@ -1213,7 +1308,8 @@ func (r *InventoryRepository) GetPickSuggestionsBySKU(sku string) ([]dto.PickSug
 			Handled: false,
 		}
 	}
-	return rows, nil
+
+	return allocatePickRows(rows, qty), nil
 }
 
 func (r *InventoryRepository) GetInventoryLots(inventoryID string) ([]responses.InventoryLot, *responses.InternalResponse) {

--- a/repositories/picking_task_repository.go
+++ b/repositories/picking_task_repository.go
@@ -470,12 +470,12 @@ func (r *PickingTaskRepository) ImportPickingTaskFromExcel(userID string, fileBy
 		lots := splitCSV(lotsStr)
 		serials := splitCSV(serialsStr)
 
+		// TODO B3: Location → Allocations, LotNumbers/SerialNumbers need new types (LotEntry/Serial).
+		// Excel import will be re-wired in B3. Variables consumed to silence unused-var errors.
+		_, _, _ = location, lots, serials
 		items = append(items, database.PickingTaskItem{
 			SKU:              strings.TrimSpace(sku),
-			ExpectedQuantity: qty,
-			Location:         strings.TrimSpace(location),
-			LotNumbers:       lots,
-			SerialNumbers:    serials,
+			ExpectedQuantity: float64(qty),
 		})
 	}
 	if len(items) == 0 {

--- a/repositories/receiving_tasks_repository.go
+++ b/repositories/receiving_tasks_repository.go
@@ -495,12 +495,13 @@ func (r *ReceivingTasksRepository) ImportReceivingTaskFromExcel(userID string, f
 		lots := splitCSV(lotsStr)
 		serials := splitCSV(serialsStr)
 
+		// TODO B3: LotNumbers/SerialNumbers need new types (LotEntry/Serial).
+		// Excel import lots/serials will be re-wired in B3. Variables consumed to silence unused-var errors.
+		_, _ = lots, serials
 		items = append(items, database.ReceivingTaskItem{
 			SKU:              strings.TrimSpace(sku),
-			ExpectedQuantity: expQty,
+			ExpectedQuantity: float64(expQty),
 			Location:         strings.TrimSpace(location),
-			LotNumbers:       lots,
-			SerialNumbers:    serials,
 		})
 	}
 	if len(items) == 0 {
@@ -1045,143 +1046,45 @@ func (r *ReceivingTasksRepository) CompleteReceivingLine(id string, location, us
 		}
 
 		if article.TrackByLot && item.LotNumbers != nil {
-			for j := 0; j < len(item.LotNumbers); j++ {
-				lotNum := item.LotNumbers[j]
-
-				var lotCount int64
-				err := tx.Model(&database.Lot{}).
-					Where("lot_number = ? AND sku = ?", lotNum.LotNumber, item.SKU).
-					Count(&lotCount).Error
-				if err != nil {
-					return errors.New("failed to check existing lot")
+			// B2a: upsert each lot with ON CONFLICT — consolidates quantity when the same
+			// SKU+lot_number arrives in multiple receiving lines (UNIQUE INDEX covers non-archived).
+			for _, lotNum := range item.LotNumbers {
+				var expirationDate *time.Time
+				if lotNum.ExpirationDate != nil && *lotNum.ExpirationDate != "" {
+					exp, err := time.Parse("2006-01-02", *lotNum.ExpirationDate)
+					if err == nil {
+						expirationDate = &exp
+					}
 				}
 
-				lotId := ""
+				lotID, err := tools.GenerateNanoid(tx)
+				if err != nil {
+					return fmt.Errorf("generate nanoid for lot: %w", err)
+				}
 
-				if lotCount == 0 {
-					var expirationDate *time.Time
-					if lotNum.ExpirationDate != nil {
-						parsed, _ := time.Parse("2006-01-02", *lotNum.ExpirationDate)
-						expirationDate = &parsed
-					}
+				if err := tx.Exec(`
+					INSERT INTO lots (id, sku, lot_number, quantity, expiration_date, status, created_at, updated_at)
+					VALUES (?, ?, ?, ?, ?, 'active', NOW(), NOW())
+					ON CONFLICT (sku, lot_number) WHERE (status IS NULL OR status != 'archived')
+					DO UPDATE SET
+						quantity   = lots.quantity + EXCLUDED.quantity,
+						updated_at = NOW()
+				`, lotID, item.SKU, lotNum.LotNumber, lotNum.Quantity, expirationDate).Error; err != nil {
+					return fmt.Errorf("upsert lote %s: %w", lotNum.LotNumber, err)
+				}
 
-					lot := &database.Lot{
-						LotNumber:      lotNum.LotNumber,
-						SKU:            item.SKU,
-						Quantity:       lotNum.Quantity,
-						ExpirationDate: expirationDate,
-						Status:         tools.StrPtr("available"),
-						CreatedAt:      tools.GetCurrentTime(),
-						UpdatedAt:      tools.GetCurrentTime(),
-					}
-
-					if err := tx.Create(lot).Error; err != nil {
-						return errors.New("failed to create lot")
-					}
-
-					lotId = lot.ID
-
-					// Add the new lot to items
-					for i := 0; i < len(items); i++ {
-						if items[i].SKU == item.SKU {
-							items[i].LotNumbers = append(items[i].LotNumbers, requests.CreateLotRequest{
-								LotNumber:        lot.LotNumber,
-								Quantity:         lot.Quantity,
-								ExpirationDate:   lotNum.ExpirationDate,
-								Status:           tools.StrPtr("completed"),
-								ReceivedQuantity: &lot.Quantity,
-							})
-							break
-						}
-					}
-
-				} else {
-					var lot database.Lot
-					if err := tx.Where("lot_number = ? AND sku = ?", lotNum.LotNumber, item.SKU).First(&lot).Error; err != nil {
-						return errors.New("failed to retrieve existing lot")
-					}
-
-					if lot.Quantity != item.LotNumbers[j].Quantity {
-						// Update items lot number position status to partial for this SKU
-						for i := 0; i < len(items); i++ {
-							if items[i].SKU == item.SKU {
-								for k := 0; k < len(items[i].LotNumbers); k++ {
-									if items[i].LotNumbers[k].LotNumber == lot.LotNumber {
-										items[i].LotNumbers[k].Status = tools.StrPtr("partial")
-										items[i].LotNumbers[k].ReceivedQuantity = &lotNum.Quantity
-										break
-									}
-								}
-								items[i].Status = tools.StrPtr("partial")
-								break
-							}
-						}
-
-						updatedItems, err := json.Marshal(items)
-
-						if err != nil {
-							return fmt.Errorf("marshal updated items: %w", err)
-						}
-
-						task.Items = updatedItems
-
-						clean := map[string]interface{}{
-							"items":      updatedItems,
-							"updated_at": tools.GetCurrentTime(),
-						}
-
-						if err := tx.Model(&task).Updates(clean).Error; err != nil {
-							*handledResp = responses.InternalResponse{Error: err, Message: "Error al actualizar la tarea de recepción"}
-							return nil
-						}
-					} else {
-						for i := 0; i < len(items); i++ {
-							if items[i].SKU == item.SKU {
-								for k := 0; k < len(items[i].LotNumbers); k++ {
-									if items[i].LotNumbers[k].LotNumber == lot.LotNumber {
-										items[i].LotNumbers[k].Status = tools.StrPtr("completed")
-										items[i].LotNumbers[k].ReceivedQuantity = &lotNum.Quantity
-										break
-									}
-								}
-								items[i].Status = tools.StrPtr("completed")
-								break
-							}
-						}
-
-						updatedItems, err := json.Marshal(items)
-
-						if err != nil {
-							return fmt.Errorf("marshal updated items: %w", err)
-						}
-
-						task.Items = updatedItems
-
-						clean := map[string]interface{}{
-							"items":      updatedItems,
-							"updated_at": tools.GetCurrentTime(),
-						}
-
-						if err := tx.Model(&task).Updates(clean).Error; err != nil {
-							*handledResp = responses.InternalResponse{Error: err, Message: "Error al actualizar la tarea de recepción"}
-							return nil
-						}
-
-						// Update lot status to available
-						lot.Status = tools.StrPtr("available")
-						lot.UpdatedAt = tools.GetCurrentTime()
-
-						if err := tx.Save(&lot).Error; err != nil {
-							return errors.New("failed to update lot status")
-						}
-					}
-
-					lotId = lot.ID
+				// Retrieve actual lot ID — may be a pre-existing row if conflict occurred.
+				var upsertedLot database.Lot
+				if err := tx.Where(
+					"lot_number = ? AND sku = ? AND (status IS NULL OR status != 'archived')",
+					lotNum.LotNumber, item.SKU,
+				).First(&upsertedLot).Error; err != nil {
+					return fmt.Errorf("retrieve lot after upsert %s: %w", lotNum.LotNumber, err)
 				}
 
 				inventoryLot := &database.InventoryLot{
 					InventoryID: inventory.ID,
-					LotID:       lotId,
+					LotID:       upsertedLot.ID,
 					Quantity:    lotNum.Quantity,
 					Location:    item.Location,
 				}

--- a/repositories/receiving_tasks_upsert_lot_integration_test.go
+++ b/repositories/receiving_tasks_upsert_lot_integration_test.go
@@ -1,0 +1,133 @@
+// Integration test for B2a lot upsert — verifies ON CONFLICT consolidates quantity.
+// Requires Docker (testcontainers). Run: go test -v ./repositories/... -run TestUpsertLot
+
+package repositories
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/eflowcr/eSTOCK_backend/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	gormpostgres "gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func setupGORMTestDB(t *testing.T) (*gorm.DB, func()) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+
+	ctx := t.Context()
+	container, err := tcpostgres.Run(ctx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("test"),
+		tcpostgres.WithUsername("test"),
+		tcpostgres.WithPassword("test"),
+		tcpostgres.BasicWaitStrategies(),
+	)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		if err := testcontainers.TerminateContainer(container); err != nil {
+			t.Logf("failed to terminate container: %v", err)
+		}
+	}
+
+	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	_, filename, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(filename)
+	migrationPath := filepath.Join(dir, "..", "db", "migrations")
+	require.NoError(t, tools.RunMigrations("file://"+filepath.ToSlash(migrationPath), connStr))
+
+	db, err := gorm.Open(gormpostgres.Open(connStr), &gorm.Config{})
+	require.NoError(t, err)
+
+	return db, cleanup
+}
+
+// TestUpsertLot_SameLotNumberConsolidates verifies that receiving the same
+// SKU+lot_number twice accumulates quantity instead of inserting a duplicate row.
+func TestUpsertLot_SameLotNumberConsolidates(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	sku := "TEST-SKU-UPSERT"
+	lotNumber := "LOT-A"
+
+	upsertLot := func(qty float64) {
+		lotID, err := tools.GenerateNanoid(db)
+		require.NoError(t, err)
+		err = db.Exec(`
+			INSERT INTO lots (id, sku, lot_number, quantity, expiration_date, status, created_at, updated_at)
+			VALUES (?, ?, ?, ?, NULL, 'active', NOW(), NOW())
+			ON CONFLICT (sku, lot_number) WHERE (status IS NULL OR status != 'archived')
+			DO UPDATE SET
+				quantity   = lots.quantity + EXCLUDED.quantity,
+				updated_at = NOW()
+		`, lotID, sku, lotNumber, qty).Error
+		require.NoError(t, err)
+	}
+
+	// First reception: 100 units
+	upsertLot(100)
+
+	// Second reception of same lot: 50 more
+	upsertLot(50)
+
+	// Should have exactly one row with consolidated quantity 150
+	var count int64
+	require.NoError(t, db.Table("lots").Where("sku = ? AND lot_number = ?", sku, lotNumber).Count(&count).Error)
+	assert.Equal(t, int64(1), count, "expected exactly one lot row")
+
+	var qty float64
+	row := db.Raw("SELECT quantity FROM lots WHERE sku = ? AND lot_number = ?", sku, lotNumber).Row()
+	require.NoError(t, row.Scan(&qty))
+	assert.Equal(t, 150.0, qty, "expected consolidated quantity of 150")
+}
+
+// TestUpsertLot_ArchivedLotDoesNotConflict verifies that an archived lot
+// does not trigger the ON CONFLICT clause — a new active lot is created instead.
+func TestUpsertLot_ArchivedLotDoesNotConflict(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	sku := "TEST-SKU-ARCHIVED"
+	lotNumber := "LOT-ARCH"
+
+	// Insert an archived lot directly
+	archivedID, _ := tools.GenerateNanoid(db)
+	require.NoError(t, db.Exec(`
+		INSERT INTO lots (id, sku, lot_number, quantity, expiration_date, status, created_at, updated_at)
+		VALUES (?, ?, ?, 100, NULL, 'archived', NOW(), NOW())
+	`, archivedID, sku, lotNumber).Error)
+
+	// Now upsert same lot_number — should create a new active row, not conflict
+	newID, _ := tools.GenerateNanoid(db)
+	require.NoError(t, db.Exec(`
+		INSERT INTO lots (id, sku, lot_number, quantity, expiration_date, status, created_at, updated_at)
+		VALUES (?, ?, ?, ?, NULL, 'active', NOW(), NOW())
+		ON CONFLICT (sku, lot_number) WHERE (status IS NULL OR status != 'archived')
+		DO UPDATE SET
+			quantity   = lots.quantity + EXCLUDED.quantity,
+			updated_at = NOW()
+	`, newID, sku, lotNumber, 75).Error)
+
+	// Should have two rows: one archived (qty 100) and one active (qty 75)
+	var count int64
+	require.NoError(t, db.Table("lots").Where("sku = ? AND lot_number = ?", sku, lotNumber).Count(&count).Error)
+	assert.Equal(t, int64(2), count)
+
+	var activeQty float64
+	row := db.Raw("SELECT quantity FROM lots WHERE sku = ? AND lot_number = ? AND status = 'active'", sku, lotNumber).Row()
+	require.NoError(t, row.Scan(&activeQty))
+	assert.Equal(t, 75.0, activeQty)
+}

--- a/services/inventory_service.go
+++ b/services/inventory_service.go
@@ -1,9 +1,6 @@
 package services
 
 import (
-	"sort"
-	"strings"
-
 	"github.com/eflowcr/eSTOCK_backend/models/dto"
 	"github.com/eflowcr/eSTOCK_backend/models/requests"
 	"github.com/eflowcr/eSTOCK_backend/models/responses"
@@ -86,66 +83,10 @@ func (s *InventoryService) DeleteInventorySerial(id string) *responses.InternalR
 	return s.Repository.DeleteInventorySerial(id)
 }
 
-// GetPickSuggestionsBySKU returns pick suggestions for a SKU sorted by: (1) rotation (FIFO/FEFO), (2) quantity ascending.
-func (s *InventoryService) GetPickSuggestionsBySKU(sku string) ([]dto.PickSuggestion, *responses.InternalResponse) {
-	list, resp := s.Repository.GetPickSuggestionsBySKU(sku)
-	if resp != nil || len(list) == 0 {
-		return list, resp
-	}
-	rotationStrategy := "fifo"
-	if s.ArticlesRepo != nil {
-		article, errResp := s.ArticlesRepo.GetBySku(sku)
-		if errResp == nil && article != nil {
-			rotationStrategy = strings.TrimSpace(strings.ToLower(article.RotationStrategy))
-			if rotationStrategy != "fifo" && rotationStrategy != "fefo" {
-				rotationStrategy = "fifo"
-			}
-		}
-	}
-	sortPickSuggestions(list, rotationStrategy)
-	return list, nil
-}
-
-// sortPickSuggestions orders by (1) rotation (FIFO/FEFO) on lot, (2) quantity ascending (lowest first).
-func sortPickSuggestions(list []dto.PickSuggestion, strategy string) {
-	if strategy == "fefo" {
-		sort.Slice(list, func(i, j int) bool {
-			ei, ej := list[i].ExpirationDate, list[j].ExpirationDate
-			if ei == nil && ej == nil {
-				if !list[i].LotCreatedAt.Equal(list[j].LotCreatedAt) {
-					return list[i].LotCreatedAt.Before(list[j].LotCreatedAt)
-				}
-				return list[i].Quantity < list[j].Quantity
-			}
-			if ei == nil {
-				return false
-			}
-			if ej == nil {
-				return true
-			}
-			if ei.Before(*ej) {
-				return true
-			}
-			if ej.Before(*ei) {
-				return false
-			}
-			if list[i].Quantity != list[j].Quantity {
-				return list[i].Quantity < list[j].Quantity
-			}
-			return list[i].LotCreatedAt.Before(list[j].LotCreatedAt)
-		})
-		return
-	}
-	// FIFO: oldest lot first, then lowest quantity first
-	sort.Slice(list, func(i, j int) bool {
-		if list[i].LotCreatedAt.Before(list[j].LotCreatedAt) {
-			return true
-		}
-		if list[j].LotCreatedAt.Before(list[i].LotCreatedAt) {
-			return false
-		}
-		return list[i].Quantity < list[j].Quantity
-	})
+// GetPickSuggestionsBySKU returns FEFO-ordered pick allocations for a SKU.
+// Sorting is done in SQL (FEFO cross-location). If qty is 0, all available stock is returned.
+func (s *InventoryService) GetPickSuggestionsBySKU(sku string, qty float64) (*dto.PickSuggestionResponse, *responses.InternalResponse) {
+	return s.Repository.GetPickSuggestionsBySKU(sku, qty)
 }
 
 func (s *InventoryService) GenerateImportTemplate(language string) ([]byte, error) {

--- a/services/inventory_service_test.go
+++ b/services/inventory_service_test.go
@@ -21,7 +21,7 @@ type mockInventoryRepo struct {
 func (m *mockInventoryRepo) GetAllInventory() ([]*dto.EnhancedInventory, *responses.InternalResponse) {
 	return m.all, nil
 }
-func (m *mockInventoryRepo) GetPickSuggestionsBySKU(_ string) ([]dto.PickSuggestion, *responses.InternalResponse) {
+func (m *mockInventoryRepo) GetPickSuggestionsBySKU(_ string, _ float64) (*dto.PickSuggestionResponse, *responses.InternalResponse) {
 	return nil, nil
 }
 func (m *mockInventoryRepo) GetInventoryBySkuAndLocation(_, _ string) (*dto.EnhancedInventory, *responses.InternalResponse) {


### PR DESCRIPTION
## Summary

- **B2b**: `reserved_qty` + `available_qty` added to `EnhancedInventory` DTO. GORM reads `reserved_qty` from the DB column (added by M1); `available_qty` is computed as `quantity - reserved_qty`. Both `GetAllInventory` and `GetInventoryBySkuAndLocation` now expose these fields.

- **H3**: `GET /inventory/pick-suggestions/:sku?qty=N` rewritten. New contract: returns `PickSuggestionResponse` with `allocations`, `total_found`, `requested_qty`, `sufficient`. SQL uses `inventory_lots` JOIN with FEFO ORDER BY. Greedy algorithm in `allocatePickRows()` (pure function, independently tested).

## Schema confirmed: `inventory_lots`

| column | type | notes |
|---|---|---|
| `id` | string PK | |
| `inventory_id` | FK → inventory.id | |
| `lot_id` | FK → lots.id | |
| `quantity` | float64 | qty of this lot in this inventory location |
| `location` | string | denormalized from inventory.location |
| `created_at` | time | |

No surprises — matches roadmap assumptions. SQL compiles and runs as written.

## Dependencies

- **Requires PR #11** (B1+B2+B2a) merged to `sprint-s1` first — `LocationAllocation` lives there.
- This branch is based on `s1/b1-b2-picking-receiving-models`.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./... -short` — all pass (9 new greedy algorithm unit tests in `repositories/inventory_pick_suggestions_test.go`)
- [ ] Smoke test: `curl "http://localhost:8080/api/inventory/pick-suggestions/SKU-X?qty=10"` — verify `allocations`, `total_found`, `requested_qty`, `sufficient`
- [ ] Smoke test without qty: `curl "http://localhost:8080/api/inventory/pick-suggestions/SKU-X"` — returns all available allocations with `sufficient=true`