### PR TITLE
[S1/H1+H2+B3+H5] Core lazy reservations + parser legacy + full complete (Wave 4)

### DIFF
--- a/controllers/picking_task_controller.go
+++ b/controllers/picking_task_controller.go
@@ -15,25 +15,19 @@ type PickingTasksController struct {
 }
 
 func NewPickingTasksController(service services.PickingTaskService, jwtSecret string) *PickingTasksController {
-	return &PickingTasksController{
-		Service:   service,
-		JWTSecret: jwtSecret,
-	}
+	return &PickingTasksController{Service: service, JWTSecret: jwtSecret}
 }
 
 func (c *PickingTasksController) GetAllPickingTasks(ctx *gin.Context) {
 	tasks, response := c.Service.GetAllPickingTasks()
-
 	if response != nil {
 		writeErrorResponse(ctx, "GetAllPickingTasks", "get_all_picking_tasks", response)
 		return
 	}
-
 	if len(tasks) == 0 {
 		tools.ResponseOK(ctx, "GetAllPickingTasks", "No se encontraron tareas de picking", "get_all_picking_tasks", nil, false, "")
 		return
 	}
-
 	tools.ResponseOK(ctx, "GetAllPickingTasks", "Tareas de picking recuperadas con éxito", "get_all_picking_tasks", tasks, false, "")
 }
 
@@ -42,19 +36,15 @@ func (c *PickingTasksController) GetPickingTaskByID(ctx *gin.Context) {
 	if !ok {
 		return
 	}
-
 	task, response := c.Service.GetPickingTaskByID(id)
-
 	if response != nil {
 		writeErrorResponse(ctx, "GetPickingTaskByID", "get_picking_task_by_id", response)
 		return
 	}
-
 	if task == nil {
 		tools.ResponseNotFound(ctx, "GetPickingTaskByID", "Tarea de picking no encontrada", "get_picking_task_by_id")
 		return
 	}
-
 	tools.ResponseOK(ctx, "GetPickingTaskByID", "Tarea de picking recuperada con éxito", "get_picking_task_by_id", task, false, "")
 }
 
@@ -69,9 +59,8 @@ func (c *PickingTasksController) CreatePickingTask(ctx *gin.Context) {
 		return
 	}
 
-	token := ctx.Request.Header.Get("Authorization")
-	userId, userIdErr := tools.GetUserId(c.JWTSecret, token)
-	if userIdErr != nil {
+	userId, err := tools.GetUserId(c.JWTSecret, ctx.Request.Header.Get("Authorization"))
+	if err != nil {
 		tools.ResponseUnauthorized(ctx, "GetUserId", "Token inválido", "invalid_token")
 		return
 	}
@@ -81,8 +70,26 @@ func (c *PickingTasksController) CreatePickingTask(ctx *gin.Context) {
 		writeErrorResponse(ctx, "CreatePickingTask", "create_picking_task", response)
 		return
 	}
-
 	tools.ResponseCreated(ctx, "CreatePickingTask", "Tarea de picking creada con éxito", "create_picking_task", nil, false, "")
+}
+
+// StartPickingTask transitions the task to in_progress and applies lazy reservations (B3a).
+func (c *PickingTasksController) StartPickingTask(ctx *gin.Context) {
+	id, ok := tools.ParseRequiredParam(ctx, "id", "StartPickingTask", "start_picking_task", "ID de tarea inválido")
+	if !ok {
+		return
+	}
+	userId, err := tools.GetUserId(c.JWTSecret, ctx.Request.Header.Get("Authorization"))
+	if err != nil {
+		tools.ResponseUnauthorized(ctx, "GetUserId", "Token inválido", "invalid_token")
+		return
+	}
+
+	if resp := c.Service.StartPickingTask(ctx.Request.Context(), id, userId); resp != nil {
+		writeErrorResponse(ctx, "StartPickingTask", "start_picking_task", resp)
+		return
+	}
+	tools.ResponseOK(ctx, "StartPickingTask", "Picking iniciado — stock reservado", "start_picking_task", nil, false, "")
 }
 
 func (c *PickingTasksController) UpdatePickingTask(ctx *gin.Context) {
@@ -92,25 +99,99 @@ func (c *PickingTasksController) UpdatePickingTask(ctx *gin.Context) {
 	}
 
 	var data map[string]interface{}
-
 	if err := ctx.ShouldBindJSON(&data); err != nil {
 		tools.ResponseBadRequest(ctx, "UpdatePickingTask", "Cuerpo de solicitud inválido", "update_picking_task")
 		return
 	}
 
-	response := c.Service.UpdatePickingTask(id, data)
+	userId, err := tools.GetUserId(c.JWTSecret, ctx.Request.Header.Get("Authorization"))
+	if err != nil {
+		tools.ResponseUnauthorized(ctx, "GetUserId", "Token inválido", "invalid_token")
+		return
+	}
+
+	response := c.Service.UpdatePickingTask(ctx.Request.Context(), id, data, userId)
 	if response != nil {
 		writeErrorResponse(ctx, "UpdatePickingTask", "update_picking_task", response)
 		return
 	}
-
 	tools.ResponseOK(ctx, "UpdatePickingTask", "Tarea de picking actualizada con éxito", "update_picking_task", nil, false, "")
 }
 
+// CancelPickingTask sets status to cancelled (B3c).
+func (c *PickingTasksController) CancelPickingTask(ctx *gin.Context) {
+	id, ok := tools.ParseRequiredParam(ctx, "id", "CancelPickingTask", "cancel_picking_task", "ID de tarea inválido")
+	if !ok {
+		return
+	}
+	userId, err := tools.GetUserId(c.JWTSecret, ctx.Request.Header.Get("Authorization"))
+	if err != nil {
+		tools.ResponseUnauthorized(ctx, "GetUserId", "Token inválido", "invalid_token")
+		return
+	}
+
+	resp := c.Service.UpdatePickingTask(ctx.Request.Context(), id, map[string]interface{}{"status": "cancelled"}, userId)
+	if resp != nil {
+		writeErrorResponse(ctx, "CancelPickingTask", "cancel_picking_task", resp)
+		return
+	}
+	tools.ResponseOK(ctx, "CancelPickingTask", "Tarea de picking cancelada con éxito", "cancel_picking_task", nil, false, "")
+}
+
+// CompletePickingTask finalises all items using their allocations (H5).
+// The old :location URL parameter is ignored — locations come from item allocations.
+func (c *PickingTasksController) CompletePickingTask(ctx *gin.Context) {
+	id, ok := tools.ParseRequiredParam(ctx, "id", "CompletePickingTask", "complete_picking_task", "ID de tarea inválido")
+	if !ok {
+		return
+	}
+	userId, err := tools.GetUserId(c.JWTSecret, ctx.Request.Header.Get("Authorization"))
+	if err != nil {
+		tools.ResponseUnauthorized(ctx, "GetUserId", "Token inválido", "invalid_token")
+		return
+	}
+
+	response := c.Service.CompletePickingTask(ctx.Request.Context(), id, userId)
+	if response != nil {
+		writeErrorResponse(ctx, "CompletePickingTask", "complete_picking_task", response)
+		return
+	}
+	tools.ResponseOK(ctx, "CompletePickingTask", "Tarea de picking completada con éxito", "complete_picking_task", nil, false, "")
+}
+
+func (c *PickingTasksController) CompletePickingLine(ctx *gin.Context) {
+	id, ok := tools.ParseRequiredParam(ctx, "id", "CompletePickingLine", "complete_picking_line", "ID de tarea inválido")
+	if !ok {
+		return
+	}
+
+	var item requests.PickingTaskItemRequest
+	if err := ctx.ShouldBindJSON(&item); err != nil {
+		tools.ResponseBadRequest(ctx, "CompletePickingLine", "Datos de solicitud inválidos", "complete_picking_line")
+		return
+	}
+	if errs := tools.ValidateStruct(&item); errs != nil {
+		tools.ResponseValidationError(ctx, "CompletePickingLine", "complete_picking_line", errs)
+		return
+	}
+
+	userId, err := tools.GetUserId(c.JWTSecret, ctx.Request.Header.Get("Authorization"))
+	if err != nil {
+		tools.ResponseUnauthorized(ctx, "GetUserId", "Token inválido", "invalid_token")
+		return
+	}
+
+	response := c.Service.CompletePickingLine(ctx.Request.Context(), id, userId, item)
+	if response != nil {
+		writeErrorResponse(ctx, "CompletePickingLine", "complete_picking_line", response)
+		return
+	}
+	tools.ResponseOK(ctx, "CompletePickingLine", "Línea de picking completada con éxito", "complete_picking_line", nil, false, "")
+}
+
 func (c *PickingTasksController) ImportPickingTaskFromExcel(ctx *gin.Context) {
-	token := ctx.Request.Header.Get("Authorization")
-	userId, userIdErr := tools.GetUserId(c.JWTSecret, token)
-	if userIdErr != nil {
+	userId, err := tools.GetUserId(c.JWTSecret, ctx.Request.Header.Get("Authorization"))
+	if err != nil {
 		tools.ResponseUnauthorized(ctx, "GetUserId", "Token inválido", "invalid_token")
 		return
 	}
@@ -120,7 +201,6 @@ func (c *PickingTasksController) ImportPickingTaskFromExcel(ctx *gin.Context) {
 		tools.ResponseBadRequest(ctx, "ImportPickingTaskFromExcel", "Error al subir el archivo", "import_picking_task_from_excel")
 		return
 	}
-
 	file, err := fileHeader.Open()
 	if err != nil {
 		tools.ResponseBadRequest(ctx, "ImportPickingTaskFromExcel", "Error al abrir el archivo", "import_picking_task_from_excel")
@@ -139,7 +219,6 @@ func (c *PickingTasksController) ImportPickingTaskFromExcel(ctx *gin.Context) {
 		writeErrorResponse(ctx, "ImportPickingTaskFromExcel", "import_picking_task_from_excel", response)
 		return
 	}
-
 	tools.ResponseOK(ctx, "ImportPickingTaskFromExcel", "Tareas de picking importadas con éxito", "import_picking_task_from_excel", nil, false, "")
 }
 
@@ -161,98 +240,6 @@ func (c *PickingTasksController) ExportPickingTasksToExcel(ctx *gin.Context) {
 		writeErrorResponse(ctx, "ExportPickingTasksToExcel", "export_picking_tasks_to_excel", response)
 		return
 	}
-
 	ctx.Header("Content-Disposition", "attachment; filename=picking_tasks.xlsx")
 	ctx.Data(200, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", fileBytes)
-}
-
-// StartPickingTask sets status from open -> in_progress.
-func (c *PickingTasksController) StartPickingTask(ctx *gin.Context) {
-	id, ok := tools.ParseRequiredParam(ctx, "id", "StartPickingTask", "start_picking_task", "ID de tarea inválido")
-	if !ok {
-		return
-	}
-
-	resp := c.Service.UpdatePickingTask(id, map[string]interface{}{"status": "in_progress"})
-	if resp != nil {
-		writeErrorResponse(ctx, "StartPickingTask", "start_picking_task", resp)
-		return
-	}
-
-	tools.ResponseOK(ctx, "StartPickingTask", "Tarea de picking iniciada con éxito", "start_picking_task", nil, false, "")
-}
-
-// CancelPickingTask sets status to cancelled from open or in_progress.
-func (c *PickingTasksController) CancelPickingTask(ctx *gin.Context) {
-	id, ok := tools.ParseRequiredParam(ctx, "id", "CancelPickingTask", "cancel_picking_task", "ID de tarea inválido")
-	if !ok {
-		return
-	}
-
-	resp := c.Service.UpdatePickingTask(id, map[string]interface{}{"status": "cancelled"})
-	if resp != nil {
-		writeErrorResponse(ctx, "CancelPickingTask", "cancel_picking_task", resp)
-		return
-	}
-
-	tools.ResponseOK(ctx, "CancelPickingTask", "Tarea de picking cancelada con éxito", "cancel_picking_task", nil, false, "")
-}
-
-func (c *PickingTasksController) CompletePickingTask(ctx *gin.Context) {
-	id, ok := tools.ParseRequiredParam(ctx, "id", "CompletePickingTask", "complete_picking_task", "ID de tarea inválido")
-	if !ok {
-		return
-	}
-
-	location := ctx.Param("location")
-
-	token := ctx.Request.Header.Get("Authorization")
-	userId, userIdErr := tools.GetUserId(c.JWTSecret, token)
-	if userIdErr != nil {
-		tools.ResponseUnauthorized(ctx, "GetUserId", "Token inválido", "invalid_token")
-		return
-	}
-
-	response := c.Service.CompletePickingTask(id, location, userId)
-	if response != nil {
-		writeErrorResponse(ctx, "CompletePickingTask", "complete_picking_task", response)
-		return
-	}
-
-	tools.ResponseOK(ctx, "CompletePickingTask", "Tarea de picking completada con éxito", "complete_picking_task", nil, false, "")
-}
-
-func (c *PickingTasksController) CompletePickingLine(ctx *gin.Context) {
-	id, ok := tools.ParseRequiredParam(ctx, "id", "CompletePickingLine", "complete_picking_line", "ID de tarea inválido")
-	if !ok {
-		return
-	}
-
-	location := ctx.Param("location")
-
-	var item requests.PickingTaskItemRequest
-	if err := ctx.ShouldBindJSON(&item); err != nil {
-		tools.ResponseBadRequest(ctx, "CompletePickingLine", "Datos de solicitud inválidos", "complete_picking_line")
-		return
-	}
-	if errs := tools.ValidateStruct(&item); errs != nil {
-		tools.ResponseValidationError(ctx, "CompletePickingLine", "complete_picking_line", errs)
-		return
-	}
-
-	token := ctx.Request.Header.Get("Authorization")
-	userId, userIdErr := tools.GetUserId(c.JWTSecret, token)
-	if userIdErr != nil {
-		tools.ResponseUnauthorized(ctx, "GetUserId", "Token inválido", "invalid_token")
-		return
-	}
-
-	response := c.Service.CompletePickingLine(id, location, userId, item)
-
-	if response != nil {
-		writeErrorResponse(ctx, "CompletePickingLine", "complete_picking_line", response)
-		return
-	}
-
-	tools.ResponseOK(ctx, "CompletePickingLine", "Línea de picking completada con éxito", "complete_picking_line", nil, false, "")
 }

--- a/controllers/picking_task_controller_test.go
+++ b/controllers/picking_task_controller_test.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -16,17 +17,18 @@ import (
 // ─── mock repo ───────────────────────────────────────────────────────────────
 
 type mockPickingTaskRepoCtrl struct {
-	tasks      []responses.PickingTaskView
-	byID       map[string]*database.PickingTask
-	createErr  *responses.InternalResponse
-	updateErr  *responses.InternalResponse
-	importErr  *responses.InternalResponse
-	exportData []byte
-	exportErr  *responses.InternalResponse
-	completeErr *responses.InternalResponse
+	tasks           []responses.PickingTaskView
+	byID            map[string]*database.PickingTask
+	createErr       *responses.InternalResponse
+	startErr        *responses.InternalResponse
+	updateErr       *responses.InternalResponse
+	importErr       *responses.InternalResponse
+	exportData      []byte
+	exportErr       *responses.InternalResponse
+	completeErr     *responses.InternalResponse
 	completeLineErr *responses.InternalResponse
-	templateData []byte
-	templateErr  error
+	templateData    []byte
+	templateErr     error
 }
 
 func (m *mockPickingTaskRepoCtrl) GetAllPickingTasks() ([]responses.PickingTaskView, *responses.InternalResponse) {
@@ -46,7 +48,11 @@ func (m *mockPickingTaskRepoCtrl) CreatePickingTask(userId string, task *request
 	return m.createErr
 }
 
-func (m *mockPickingTaskRepoCtrl) UpdatePickingTask(id string, data map[string]interface{}) *responses.InternalResponse {
+func (m *mockPickingTaskRepoCtrl) StartPickingTask(_ context.Context, id, userId string) *responses.InternalResponse {
+	return m.startErr
+}
+
+func (m *mockPickingTaskRepoCtrl) UpdatePickingTask(_ context.Context, id string, data map[string]interface{}, userId string) *responses.InternalResponse {
 	return m.updateErr
 }
 
@@ -58,11 +64,11 @@ func (m *mockPickingTaskRepoCtrl) ExportPickingTasksToExcel() ([]byte, *response
 	return m.exportData, m.exportErr
 }
 
-func (m *mockPickingTaskRepoCtrl) CompletePickingTask(id string, location, userId string) *responses.InternalResponse {
+func (m *mockPickingTaskRepoCtrl) CompletePickingTask(_ context.Context, id, userId string) *responses.InternalResponse {
 	return m.completeErr
 }
 
-func (m *mockPickingTaskRepoCtrl) CompletePickingLine(id string, location, userId string, item requests.PickingTaskItemRequest) *responses.InternalResponse {
+func (m *mockPickingTaskRepoCtrl) CompletePickingLine(_ context.Context, id, userId string, item requests.PickingTaskItemRequest) *responses.InternalResponse {
 	return m.completeLineErr
 }
 
@@ -173,7 +179,9 @@ func TestPickingTasksController_CreatePickingTask_ServiceError(t *testing.T) {
 func TestPickingTasksController_UpdatePickingTask_Success(t *testing.T) {
 	ctrl := newPickingTasksController(&mockPickingTaskRepoCtrl{})
 	body := map[string]interface{}{"priority": "high"}
-	w := performRequest(ctrl.UpdatePickingTask, "PUT", "/picking-tasks/pt-1", body, gin.Params{{Key: "id", Value: "pt-1"}})
+	w := performRequestWithHeader(ctrl.UpdatePickingTask, "PUT", "/picking-tasks/pt-1", body,
+		gin.Params{{Key: "id", Value: "pt-1"}},
+		map[string]string{"Authorization": makeTestToken()})
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
@@ -190,52 +198,69 @@ func TestPickingTasksController_UpdatePickingTask_NotFound(t *testing.T) {
 	}
 	ctrl := newPickingTasksController(repo)
 	body := map[string]interface{}{"priority": "high"}
-	w := performRequest(ctrl.UpdatePickingTask, "PUT", "/picking-tasks/99", body, gin.Params{{Key: "id", Value: "99"}})
+	w := performRequestWithHeader(ctrl.UpdatePickingTask, "PUT", "/picking-tasks/99", body,
+		gin.Params{{Key: "id", Value: "99"}},
+		map[string]string{"Authorization": makeTestToken()})
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestPickingTasksController_StartPickingTask_Success(t *testing.T) {
 	ctrl := newPickingTasksController(&mockPickingTaskRepoCtrl{})
-	w := performRequest(ctrl.StartPickingTask, "POST", "/picking-tasks/pt-1/start", nil, gin.Params{{Key: "id", Value: "pt-1"}})
+	w := performRequestWithHeader(ctrl.StartPickingTask, "PATCH", "/picking-tasks/pt-1/start", nil,
+		gin.Params{{Key: "id", Value: "pt-1"}},
+		map[string]string{"Authorization": makeTestToken()})
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestPickingTasksController_StartPickingTask_Unauthorized(t *testing.T) {
+	ctrl := newPickingTasksController(&mockPickingTaskRepoCtrl{})
+	w := performRequest(ctrl.StartPickingTask, "PATCH", "/picking-tasks/pt-1/start", nil,
+		gin.Params{{Key: "id", Value: "pt-1"}})
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
 func TestPickingTasksController_StartPickingTask_MissingParam(t *testing.T) {
 	ctrl := newPickingTasksController(&mockPickingTaskRepoCtrl{})
-	w := performRequest(ctrl.StartPickingTask, "POST", "/picking-tasks//start", nil, gin.Params{{Key: "id", Value: ""}})
+	w := performRequestWithHeader(ctrl.StartPickingTask, "PATCH", "/picking-tasks//start", nil,
+		gin.Params{{Key: "id", Value: ""}},
+		map[string]string{"Authorization": makeTestToken()})
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestPickingTasksController_CancelPickingTask_Success(t *testing.T) {
 	ctrl := newPickingTasksController(&mockPickingTaskRepoCtrl{})
-	w := performRequest(ctrl.CancelPickingTask, "POST", "/picking-tasks/pt-1/cancel", nil, gin.Params{{Key: "id", Value: "pt-1"}})
+	w := performRequestWithHeader(ctrl.CancelPickingTask, "PATCH", "/picking-tasks/pt-1/cancel", nil,
+		gin.Params{{Key: "id", Value: "pt-1"}},
+		map[string]string{"Authorization": makeTestToken()})
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestPickingTasksController_CancelPickingTask_MissingParam(t *testing.T) {
 	ctrl := newPickingTasksController(&mockPickingTaskRepoCtrl{})
-	w := performRequest(ctrl.CancelPickingTask, "POST", "/picking-tasks//cancel", nil, gin.Params{{Key: "id", Value: ""}})
+	w := performRequestWithHeader(ctrl.CancelPickingTask, "PATCH", "/picking-tasks//cancel", nil,
+		gin.Params{{Key: "id", Value: ""}},
+		map[string]string{"Authorization": makeTestToken()})
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestPickingTasksController_CompletePickingTask_Success(t *testing.T) {
 	ctrl := newPickingTasksController(&mockPickingTaskRepoCtrl{})
-	w := performRequestWithHeader(ctrl.CompletePickingTask, "POST", "/picking-tasks/pt-1/complete", nil,
-		gin.Params{{Key: "id", Value: "pt-1"}, {Key: "location", Value: "A01"}},
+	w := performRequestWithHeader(ctrl.CompletePickingTask, "PATCH", "/picking-tasks/pt-1/complete", nil,
+		gin.Params{{Key: "id", Value: "pt-1"}},
 		map[string]string{"Authorization": makeTestToken()})
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestPickingTasksController_CompletePickingTask_Unauthorized(t *testing.T) {
 	ctrl := newPickingTasksController(&mockPickingTaskRepoCtrl{})
-	w := performRequest(ctrl.CompletePickingTask, "POST", "/picking-tasks/pt-1/complete", nil,
+	w := performRequest(ctrl.CompletePickingTask, "PATCH", "/picking-tasks/pt-1/complete", nil,
 		gin.Params{{Key: "id", Value: "pt-1"}})
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
 func TestPickingTasksController_CompletePickingTask_MissingParam(t *testing.T) {
 	ctrl := newPickingTasksController(&mockPickingTaskRepoCtrl{})
-	w := performRequestWithHeader(ctrl.CompletePickingTask, "POST", "/picking-tasks//complete", nil,
+	w := performRequestWithHeader(ctrl.CompletePickingTask, "PATCH", "/picking-tasks//complete", nil,
 		gin.Params{{Key: "id", Value: ""}},
 		map[string]string{"Authorization": makeTestToken()})
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -243,8 +268,14 @@ func TestPickingTasksController_CompletePickingTask_MissingParam(t *testing.T) {
 
 func TestPickingTasksController_CompletePickingLine_Success(t *testing.T) {
 	ctrl := newPickingTasksController(&mockPickingTaskRepoCtrl{})
-	body := requests.PickingTaskItemRequest{SKU: "SKU-001", Location: "A01", ExpectedQuantity: 5}
-	w := performRequestWithHeader(ctrl.CompletePickingLine, "POST", "/picking-tasks/pt-1/lines", body,
+	body := requests.PickingTaskItemRequest{
+		SKU:              "SKU-001",
+		ExpectedQuantity: 5,
+		Allocations: []database.LocationAllocation{
+			{Location: "LOC-A", Quantity: 5},
+		},
+	}
+	w := performRequestWithHeader(ctrl.CompletePickingLine, "PATCH", "/picking-tasks/pt-1/complete-line", body,
 		gin.Params{{Key: "id", Value: "pt-1"}},
 		map[string]string{"Authorization": makeTestToken()})
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -252,15 +283,22 @@ func TestPickingTasksController_CompletePickingLine_Success(t *testing.T) {
 
 func TestPickingTasksController_CompletePickingLine_Unauthorized(t *testing.T) {
 	ctrl := newPickingTasksController(&mockPickingTaskRepoCtrl{})
-	body := requests.PickingTaskItemRequest{SKU: "SKU-001", Location: "A01", ExpectedQuantity: 5}
-	w := performRequest(ctrl.CompletePickingLine, "POST", "/picking-tasks/pt-1/lines", body,
+	// Body must pass struct validation so the controller reaches the auth check.
+	body := requests.PickingTaskItemRequest{
+		SKU:              "SKU-001",
+		ExpectedQuantity: 5,
+		Allocations: []database.LocationAllocation{
+			{Location: "LOC-A", Quantity: 5},
+		},
+	}
+	w := performRequest(ctrl.CompletePickingLine, "PATCH", "/picking-tasks/pt-1/complete-line", body,
 		gin.Params{{Key: "id", Value: "pt-1"}})
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
 func TestPickingTasksController_CompletePickingLine_InvalidJSON(t *testing.T) {
 	ctrl := newPickingTasksController(&mockPickingTaskRepoCtrl{})
-	w := performRequestWithHeader(ctrl.CompletePickingLine, "POST", "/picking-tasks/pt-1/lines", nil,
+	w := performRequestWithHeader(ctrl.CompletePickingLine, "PATCH", "/picking-tasks/pt-1/complete-line", nil,
 		gin.Params{{Key: "id", Value: "pt-1"}},
 		map[string]string{"Authorization": makeTestToken()})
 	assert.Equal(t, http.StatusBadRequest, w.Code)

--- a/models/requests/create_picking_task_item.go
+++ b/models/requests/create_picking_task_item.go
@@ -1,13 +1,43 @@
 package requests
 
-import "github.com/eflowcr/eSTOCK_backend/models/database"
+import (
+	"fmt"
 
+	"github.com/eflowcr/eSTOCK_backend/models/database"
+)
+
+// PickingTaskItemRequest is the request body for a single picking task item.
+// With S1 A1 (cross-location), picking is described by Allocations (list of
+// location+qty pairs) instead of a single Location field.
 type PickingTaskItemRequest struct {
-	SKU               string             `json:"sku" validate:"required"`
-	ExpectedQuantity  int                `json:"required_qty" validate:"gte=0"`
-	Location          string             `json:"location" validate:"required"`
-	LotNumbers        []CreateLotRequest `json:"lots,omitempty"`
-	SerialNumbers     []database.Serial  `json:"serials,omitempty"`
-	Status            *string            `json:"status,omitempty"`
-	DeliveredQuantity *int               `json:"delivered_qty,omitempty"`
+	SKU              string                        `json:"sku" validate:"required"`
+	ExpectedQuantity float64                       `json:"required_qty" validate:"required,gt=0"`
+	Allocations      []database.LocationAllocation `json:"allocations" validate:"required,min=1,dive"`
+	LotNumbers       []database.LotEntry           `json:"lots,omitempty"`
+	SerialNumbers    []database.Serial             `json:"serials,omitempty"`
+	Status           *string                       `json:"status,omitempty"`
+	PickedQty        *float64                      `json:"picked_qty,omitempty"`
+}
+
+// CreatePickingTaskItemRequest is an alias kept for backwards compatibility with
+// callers that reference the old type name.
+type CreatePickingTaskItemRequest = PickingTaskItemRequest
+
+// ValidateAllocationSum confirms that the sum of all allocations equals
+// ExpectedQuantity (tolerance 0.001 for floating-point arithmetic).
+// The frontend validates this too (F2c) but the backend re-validates for
+// direct API callers.
+func (r PickingTaskItemRequest) ValidateAllocationSum() error {
+	sum := 0.0
+	for _, a := range r.Allocations {
+		sum += a.Quantity
+	}
+	diff := sum - r.ExpectedQuantity
+	if diff > 0.001 || diff < -0.001 {
+		return fmt.Errorf(
+			"suma de allocations (%.3f) no coincide con required_qty (%.3f) para SKU %s",
+			sum, r.ExpectedQuantity, r.SKU,
+		)
+	}
+	return nil
 }

--- a/ports/picking_task.go
+++ b/ports/picking_task.go
@@ -1,6 +1,8 @@
 package ports
 
 import (
+	"context"
+
 	"github.com/eflowcr/eSTOCK_backend/models/database"
 	"github.com/eflowcr/eSTOCK_backend/models/requests"
 	"github.com/eflowcr/eSTOCK_backend/models/responses"
@@ -11,10 +13,17 @@ type PickingTaskRepository interface {
 	GetAllPickingTasks() ([]responses.PickingTaskView, *responses.InternalResponse)
 	GetPickingTaskByID(id string) (*database.PickingTask, *responses.InternalResponse)
 	CreatePickingTask(userId string, task *requests.CreatePickingTaskRequest) *responses.InternalResponse
-	UpdatePickingTask(id string, data map[string]interface{}) *responses.InternalResponse
+	// StartPickingTask transitions the task to in_progress and applies lazy reservations (B3a).
+	StartPickingTask(ctx context.Context, id, userId string) *responses.InternalResponse
+	// UpdatePickingTask applies whitelist-filtered updates; recalculates reservations when items
+	// change while task is in_progress, and releases them on cancel (B3b/B3c).
+	UpdatePickingTask(ctx context.Context, id string, data map[string]interface{}, userId string) *responses.InternalResponse
 	ImportPickingTaskFromExcel(userID string, fileBytes []byte) *responses.InternalResponse
 	ExportPickingTasksToExcel() ([]byte, *responses.InternalResponse)
-	CompletePickingTask(id string, location, userId string) *responses.InternalResponse
-	CompletePickingLine(id string, location, userId string, item requests.PickingTaskItemRequest) *responses.InternalResponse
+	// CompletePickingTask finalises all items using allocations (H5).
+	// The old `location` parameter is removed; locations come from each item's allocations.
+	CompletePickingTask(ctx context.Context, id, userId string) *responses.InternalResponse
+	// CompletePickingLine finalises a single item using its allocations (B3d).
+	CompletePickingLine(ctx context.Context, id, userId string, item requests.PickingTaskItemRequest) *responses.InternalResponse
 	GenerateImportTemplate(language string) ([]byte, error)
 }

--- a/repositories/adjustments_repository.go
+++ b/repositories/adjustments_repository.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"math"
 	"strings"
 	"time"
@@ -201,6 +202,14 @@ func (r *AdjustmentsRepository) CreateAdjustment(userId string, adjustment reque
 
 		if newQuantity < 0 {
 			return errors.New("la cantidad de ajuste resulta en un inventario negativo")
+		}
+
+		// B3e (A6): block adjustment if new qty would fall below reserved_qty.
+		if newQuantity < inventory.ReservedQty {
+			return fmt.Errorf(
+				"no puede ajustar a %.2f — hay %.2f uds reservadas en pickings activos. Cancele los pickings antes de ajustar",
+				newQuantity, inventory.ReservedQty,
+			)
 		}
 
 		// Create the adjustment record

--- a/repositories/picking_task_b3_integration_test.go
+++ b/repositories/picking_task_b3_integration_test.go
@@ -1,0 +1,549 @@
+// Integration tests for Wave 4 (B3/H5) lazy reservations mechanics.
+// Requires Docker (testcontainers). Run: go test -v ./repositories/... -run TestPickingB3
+//
+// All tests share setupGORMTestDB (defined in receiving_tasks_upsert_lot_integration_test.go)
+// which spins up a Postgres 16 container and runs all migrations.
+
+package repositories
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/eflowcr/eSTOCK_backend/models/database"
+	"github.com/eflowcr/eSTOCK_backend/models/requests"
+	"github.com/eflowcr/eSTOCK_backend/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+func newPickingRepo(db *gorm.DB) *PickingTaskRepository {
+	return &PickingTaskRepository{DB: db}
+}
+
+// seedInventory inserts a single inventory row and returns its id.
+func seedInventory(t *testing.T, db *gorm.DB, sku, location string, qty, reserved float64) string {
+	t.Helper()
+	id, err := tools.GenerateNanoid(db)
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`
+		INSERT INTO inventory (id, sku, location, quantity, reserved_qty, status, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, 'active', NOW(), NOW())`,
+		id, sku, location, qty, reserved).Error)
+	return id
+}
+
+// seedArticle inserts a minimal article row so FK constraints are satisfied.
+func seedArticle(t *testing.T, db *gorm.DB, sku string) {
+	t.Helper()
+	id, err := tools.GenerateNanoid(db)
+	require.NoError(t, err)
+	db.Exec(`
+		INSERT INTO articles (id, sku, name, track_by_lot, track_by_serial, created_at, updated_at)
+		VALUES (?, ?, ?, false, false, NOW(), NOW())
+		ON CONFLICT (sku) DO NOTHING`, id, sku, "Test Article "+sku)
+}
+
+// seedUser inserts a minimal user row.
+func seedUser(t *testing.T, db *gorm.DB) string {
+	t.Helper()
+	id, err := tools.GenerateNanoid(db)
+	require.NoError(t, err)
+	db.Exec(`
+		INSERT INTO users (id, first_name, last_name, email, password, created_at, updated_at)
+		VALUES (?, 'Test', 'User', ?, 'hashed', NOW(), NOW())
+		ON CONFLICT (email) DO NOTHING`, id, id+"@test.com")
+	// Return actual ID (may differ if ON CONFLICT skipped insert)
+	var uid string
+	db.Raw("SELECT id FROM users WHERE email = ?", id+"@test.com").Scan(&uid)
+	if uid == "" {
+		uid = id
+	}
+	return uid
+}
+
+// seedPickingTask creates a picking_task and returns its id.
+func seedPickingTask(t *testing.T, db *gorm.DB, userID, status string, items interface{}) string {
+	t.Helper()
+	id, err := tools.GenerateNanoid(db)
+	require.NoError(t, err)
+	itemsJSON, _ := json.Marshal(items)
+	require.NoError(t, db.Exec(`
+		INSERT INTO picking_tasks (id, task_id, order_number, created_by, status, priority, items, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, 'normal', ?, NOW(), NOW())`,
+		id, "PICK-"+id[:6], "ORD-"+id[:6], userID, status, string(itemsJSON)).Error)
+	return id
+}
+
+// getInventory reads inventory row by id.
+func getInventory(t *testing.T, db *gorm.DB, id string) database.Inventory {
+	t.Helper()
+	var inv database.Inventory
+	require.NoError(t, db.Where("id = ?", id).First(&inv).Error)
+	return inv
+}
+
+func getInventoryBySKULoc(t *testing.T, db *gorm.DB, sku, location string) database.Inventory {
+	t.Helper()
+	var inv database.Inventory
+	require.NoError(t, db.Where("sku = ? AND location = ?", sku, location).First(&inv).Error)
+	return inv
+}
+
+func getPickingTask(t *testing.T, db *gorm.DB, id string) database.PickingTask {
+	t.Helper()
+	var task database.PickingTask
+	require.NoError(t, db.Where("id = ?", id).First(&task).Error)
+	return task
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// B3a — StartPickingTask
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestPickingB3_StartPickingTask_HappyPath(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	userID := seedUser(t, db)
+	seedArticle(t, db, "SKU-A")
+	invID := seedInventory(t, db, "SKU-A", "LOC-1", 100, 0)
+
+	items := []requests.PickingTaskItemRequest{
+		{SKU: "SKU-A", ExpectedQuantity: 30, Allocations: []database.LocationAllocation{
+			{Location: "LOC-1", Quantity: 30},
+		}},
+	}
+	taskID := seedPickingTask(t, db, userID, "open", items)
+
+	repo := newPickingRepo(db)
+	resp := repo.StartPickingTask(context.Background(), taskID, userID)
+	assert.Nil(t, resp, "StartPickingTask should succeed")
+
+	// inventory.reserved_qty must increase by 30.
+	inv := getInventory(t, db, invID)
+	assert.Equal(t, float64(30), inv.ReservedQty)
+
+	// task status must be in_progress.
+	task := getPickingTask(t, db, taskID)
+	assert.Equal(t, "in_progress", task.Status)
+}
+
+func TestPickingB3_StartPickingTask_InsufficientStock(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	userID := seedUser(t, db)
+	seedArticle(t, db, "SKU-B")
+	invID := seedInventory(t, db, "SKU-B", "LOC-1", 10, 0) // only 10 available
+
+	items := []requests.PickingTaskItemRequest{
+		{SKU: "SKU-B", ExpectedQuantity: 20, Allocations: []database.LocationAllocation{
+			{Location: "LOC-1", Quantity: 20}, // requesting more than available
+		}},
+	}
+	taskID := seedPickingTask(t, db, userID, "open", items)
+
+	repo := newPickingRepo(db)
+	resp := repo.StartPickingTask(context.Background(), taskID, userID)
+
+	require.NotNil(t, resp, "should return an error response")
+	assert.True(t, resp.Handled, "should be a handled (business) error")
+
+	// inventory must NOT have been modified.
+	inv := getInventory(t, db, invID)
+	assert.Equal(t, float64(0), inv.ReservedQty)
+
+	// task status must remain open.
+	task := getPickingTask(t, db, taskID)
+	assert.Equal(t, "open", task.Status)
+}
+
+func TestPickingB3_StartPickingTask_InvalidTransition(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	userID := seedUser(t, db)
+	seedArticle(t, db, "SKU-C")
+	seedInventory(t, db, "SKU-C", "LOC-1", 100, 0)
+
+	items := []requests.PickingTaskItemRequest{
+		{SKU: "SKU-C", ExpectedQuantity: 5, Allocations: []database.LocationAllocation{
+			{Location: "LOC-1", Quantity: 5},
+		}},
+	}
+	// Already completed — cannot start.
+	taskID := seedPickingTask(t, db, userID, "completed", items)
+
+	repo := newPickingRepo(db)
+	resp := repo.StartPickingTask(context.Background(), taskID, userID)
+
+	require.NotNil(t, resp)
+	assert.True(t, resp.Handled)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// B3b/B3c — UpdatePickingTask (reserve recalc + cancel releases)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestPickingB3_UpdatePickingTask_ReserveRecalc(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	userID := seedUser(t, db)
+	seedArticle(t, db, "SKU-D")
+	invID1 := seedInventory(t, db, "SKU-D", "LOC-1", 100, 30) // 30 already reserved
+	invID2 := seedInventory(t, db, "SKU-D", "LOC-2", 50, 0)
+
+	oldItems := []requests.PickingTaskItemRequest{
+		{SKU: "SKU-D", ExpectedQuantity: 30, Allocations: []database.LocationAllocation{
+			{Location: "LOC-1", Quantity: 30},
+		}},
+	}
+	taskID := seedPickingTask(t, db, userID, "in_progress", oldItems)
+
+	// Update items to use LOC-2 instead.
+	newItems := []requests.PickingTaskItemRequest{
+		{SKU: "SKU-D", ExpectedQuantity: 20, Allocations: []database.LocationAllocation{
+			{Location: "LOC-2", Quantity: 20},
+		}},
+	}
+	newItemsJSON, _ := json.Marshal(newItems)
+
+	repo := newPickingRepo(db)
+	resp := repo.UpdatePickingTask(context.Background(), taskID, map[string]interface{}{
+		"items": json.RawMessage(newItemsJSON),
+	}, userID)
+	assert.Nil(t, resp)
+
+	// LOC-1 reserved_qty must drop back to 0.
+	inv1 := getInventory(t, db, invID1)
+	assert.Equal(t, float64(0), inv1.ReservedQty)
+
+	// LOC-2 reserved_qty must increase by 20.
+	inv2 := getInventory(t, db, invID2)
+	assert.Equal(t, float64(20), inv2.ReservedQty)
+}
+
+func TestPickingB3_CancelPickingTask_ReleasesReservations(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	userID := seedUser(t, db)
+	seedArticle(t, db, "SKU-E")
+	invID := seedInventory(t, db, "SKU-E", "LOC-1", 100, 40)
+
+	items := []requests.PickingTaskItemRequest{
+		{SKU: "SKU-E", ExpectedQuantity: 40, Allocations: []database.LocationAllocation{
+			{Location: "LOC-1", Quantity: 40},
+		}},
+	}
+	taskID := seedPickingTask(t, db, userID, "in_progress", items)
+
+	repo := newPickingRepo(db)
+	resp := repo.UpdatePickingTask(context.Background(), taskID, map[string]interface{}{
+		"status": "cancelled",
+	}, userID)
+	assert.Nil(t, resp)
+
+	// reserved_qty must go back to 0.
+	inv := getInventory(t, db, invID)
+	assert.Equal(t, float64(0), inv.ReservedQty)
+
+	task := getPickingTask(t, db, taskID)
+	assert.Equal(t, "cancelled", task.Status)
+}
+
+func TestPickingB3_CancelPickingTask_FromOpen_NoReservationsToRelease(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	userID := seedUser(t, db)
+	seedArticle(t, db, "SKU-F")
+	invID := seedInventory(t, db, "SKU-F", "LOC-1", 100, 0)
+
+	items := []requests.PickingTaskItemRequest{
+		{SKU: "SKU-F", ExpectedQuantity: 10, Allocations: []database.LocationAllocation{
+			{Location: "LOC-1", Quantity: 10},
+		}},
+	}
+	taskID := seedPickingTask(t, db, userID, "open", items)
+
+	repo := newPickingRepo(db)
+	resp := repo.UpdatePickingTask(context.Background(), taskID, map[string]interface{}{
+		"status": "cancelled",
+	}, userID)
+	assert.Nil(t, resp)
+
+	// reserved_qty stays 0 (lazy — nothing was ever reserved).
+	inv := getInventory(t, db, invID)
+	assert.Equal(t, float64(0), inv.ReservedQty)
+}
+
+func TestPickingB3_UpdatePickingTask_InvalidTransition(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	userID := seedUser(t, db)
+	seedArticle(t, db, "SKU-G")
+
+	items := []requests.PickingTaskItemRequest{
+		{SKU: "SKU-G", ExpectedQuantity: 5, Allocations: []database.LocationAllocation{
+			{Location: "LOC-1", Quantity: 5},
+		}},
+	}
+	// cancelled → in_progress must be rejected.
+	taskID := seedPickingTask(t, db, userID, "cancelled", items)
+
+	repo := newPickingRepo(db)
+	resp := repo.UpdatePickingTask(context.Background(), taskID, map[string]interface{}{
+		"status": "in_progress",
+	}, userID)
+	require.NotNil(t, resp)
+	assert.True(t, resp.Handled)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// B3d — CompletePickingLine
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestPickingB3_CompletePickingLine_DecrementsAll(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	userID := seedUser(t, db)
+	seedArticle(t, db, "SKU-H")
+	invID := seedInventory(t, db, "SKU-H", "LOC-1", 100, 30)
+
+	items := []requests.PickingTaskItemRequest{
+		{SKU: "SKU-H", ExpectedQuantity: 30, Allocations: []database.LocationAllocation{
+			{Location: "LOC-1", Quantity: 30},
+		}},
+	}
+	taskID := seedPickingTask(t, db, userID, "in_progress", items)
+
+	incomingItem := requests.PickingTaskItemRequest{
+		SKU:              "SKU-H",
+		ExpectedQuantity: 30,
+		Allocations: []database.LocationAllocation{
+			{Location: "LOC-1", Quantity: 30},
+		},
+	}
+
+	repo := newPickingRepo(db)
+	resp := repo.CompletePickingLine(context.Background(), taskID, userID, incomingItem)
+	assert.Nil(t, resp)
+
+	inv := getInventory(t, db, invID)
+	// quantity decremented by pickedQty (30)
+	assert.Equal(t, float64(70), inv.Quantity)
+	// reserved_qty decremented by alloc.Quantity (30)
+	assert.Equal(t, float64(0), inv.ReservedQty)
+}
+
+func TestPickingB3_CompletePickingLine_PartialPick(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	userID := seedUser(t, db)
+	seedArticle(t, db, "SKU-I")
+	invID := seedInventory(t, db, "SKU-I", "LOC-1", 100, 20)
+
+	items := []requests.PickingTaskItemRequest{
+		{SKU: "SKU-I", ExpectedQuantity: 20, Allocations: []database.LocationAllocation{
+			{Location: "LOC-1", Quantity: 20},
+		}},
+	}
+	taskID := seedPickingTask(t, db, userID, "in_progress", items)
+
+	picked := float64(15)
+	incomingItem := requests.PickingTaskItemRequest{
+		SKU:              "SKU-I",
+		ExpectedQuantity: 20,
+		Allocations: []database.LocationAllocation{
+			{Location: "LOC-1", Quantity: 20, PickedQty: &picked},
+		},
+	}
+
+	repo := newPickingRepo(db)
+	resp := repo.CompletePickingLine(context.Background(), taskID, userID, incomingItem)
+	assert.Nil(t, resp)
+
+	inv := getInventory(t, db, invID)
+	// quantity decremented by pickedQty (15)
+	assert.Equal(t, float64(85), inv.Quantity)
+	// reserved_qty decremented by alloc.Quantity (20)
+	assert.Equal(t, float64(0), inv.ReservedQty)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// H5 — CompletePickingTask (full task)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestPickingB3_CompletePickingTask_HappyPath(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	userID := seedUser(t, db)
+	seedArticle(t, db, "SKU-J")
+	invID1 := seedInventory(t, db, "SKU-J", "LOC-1", 100, 20)
+	invID2 := seedInventory(t, db, "SKU-J", "LOC-2", 50, 10)
+
+	items := []requests.PickingTaskItemRequest{
+		{SKU: "SKU-J", ExpectedQuantity: 30, Allocations: []database.LocationAllocation{
+			{Location: "LOC-1", Quantity: 20},
+			{Location: "LOC-2", Quantity: 10},
+		}},
+	}
+	taskID := seedPickingTask(t, db, userID, "in_progress", items)
+
+	repo := newPickingRepo(db)
+	resp := repo.CompletePickingTask(context.Background(), taskID, userID)
+	assert.Nil(t, resp)
+
+	inv1 := getInventory(t, db, invID1)
+	assert.Equal(t, float64(80), inv1.Quantity)
+	assert.Equal(t, float64(0), inv1.ReservedQty)
+
+	inv2 := getInventory(t, db, invID2)
+	assert.Equal(t, float64(40), inv2.Quantity)
+	assert.Equal(t, float64(0), inv2.ReservedQty)
+
+	task := getPickingTask(t, db, taskID)
+	assert.Equal(t, "completed", task.Status)
+}
+
+func TestPickingB3_CompletePickingTask_WithDifferences(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	userID := seedUser(t, db)
+	seedArticle(t, db, "SKU-K")
+	invID := seedInventory(t, db, "SKU-K", "LOC-1", 100, 30)
+
+	picked := float64(25) // less than alloc.Quantity(30)
+	items := []requests.PickingTaskItemRequest{
+		{SKU: "SKU-K", ExpectedQuantity: 30, Allocations: []database.LocationAllocation{
+			{Location: "LOC-1", Quantity: 30, PickedQty: &picked},
+		}},
+	}
+	taskID := seedPickingTask(t, db, userID, "in_progress", items)
+
+	repo := newPickingRepo(db)
+	resp := repo.CompletePickingTask(context.Background(), taskID, userID)
+	assert.Nil(t, resp)
+
+	task := getPickingTask(t, db, taskID)
+	assert.Equal(t, "completed_with_differences", task.Status)
+
+	// quantity decremented by pickedQty (25), reserved by alloc.Quantity (30)
+	inv := getInventory(t, db, invID)
+	assert.Equal(t, float64(75), inv.Quantity)
+	assert.Equal(t, float64(0), inv.ReservedQty)
+}
+
+func TestPickingB3_CompletePickingTask_NotInProgress(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	userID := seedUser(t, db)
+	seedArticle(t, db, "SKU-L")
+
+	items := []requests.PickingTaskItemRequest{
+		{SKU: "SKU-L", ExpectedQuantity: 5, Allocations: []database.LocationAllocation{
+			{Location: "LOC-1", Quantity: 5},
+		}},
+	}
+	// open — cannot complete directly.
+	taskID := seedPickingTask(t, db, userID, "open", items)
+
+	repo := newPickingRepo(db)
+	resp := repo.CompletePickingTask(context.Background(), taskID, userID)
+	require.NotNil(t, resp)
+	assert.True(t, resp.Handled)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// B4 — validateNoExpiredLots
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestPickingB3_StartPickingTask_ExpiredLot(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	userID := seedUser(t, db)
+	seedArticle(t, db, "SKU-M")
+	seedInventory(t, db, "SKU-M", "LOC-1", 100, 0)
+
+	// Insert an expired lot.
+	lotID, _ := tools.GenerateNanoid(db)
+	yesterday := time.Now().Add(-24 * time.Hour).Format("2006-01-02")
+	db.Exec(`
+		INSERT INTO lots (id, sku, lot_number, quantity, expiration_date, status, created_at, updated_at)
+		VALUES (?, 'SKU-M', 'LOT-EXPIRED', 50, ?, 'active', NOW(), NOW())`,
+		lotID, yesterday)
+
+	lotNum := "LOT-EXPIRED"
+	items := []requests.PickingTaskItemRequest{
+		{SKU: "SKU-M", ExpectedQuantity: 10, Allocations: []database.LocationAllocation{
+			{Location: "LOC-1", Quantity: 10, LotNumber: &lotNum},
+		}},
+	}
+	taskID := seedPickingTask(t, db, userID, "open", items)
+
+	repo := newPickingRepo(db)
+	resp := repo.StartPickingTask(context.Background(), taskID, userID)
+	require.NotNil(t, resp, "should block expired lot")
+	assert.True(t, resp.Handled)
+
+	// Status must remain open.
+	task := getPickingTask(t, db, taskID)
+	assert.Equal(t, "open", task.Status)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// B3e — Adjustment blocked if new_qty < reserved_qty
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestPickingB3_Adjustment_BlockedIfBelowReserved(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	userID := seedUser(t, db)
+	seedArticle(t, db, "SKU-N")
+	seedInventory(t, db, "SKU-N", "LOC-1", 100, 40) // 40 reserved
+
+	repo := &AdjustmentsRepository{DB: db}
+	_, resp := repo.CreateAdjustment(userID, requests.CreateAdjustment{
+		SKU:                "SKU-N",
+		Location:           "LOC-1",
+		AdjustmentQuantity: -70, // would leave qty=30, but reserved=40
+		Reason:             "test",
+	})
+	require.NotNil(t, resp, "should block adjustment below reserved")
+}
+
+func TestPickingB3_Adjustment_AllowedIfAboveReserved(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	userID := seedUser(t, db)
+	seedArticle(t, db, "SKU-O")
+	seedInventory(t, db, "SKU-O", "LOC-1", 100, 40)
+
+	repo := &AdjustmentsRepository{DB: db}
+	_, resp := repo.CreateAdjustment(userID, requests.CreateAdjustment{
+		SKU:                "SKU-O",
+		Location:           "LOC-1",
+		AdjustmentQuantity: -50, // leaves qty=50, which is >= reserved=40
+		Reason:             "test",
+	})
+	assert.Nil(t, resp, "adjustment that keeps qty >= reserved should be allowed")
+}

--- a/repositories/picking_task_b3_unit_test.go
+++ b/repositories/picking_task_b3_unit_test.go
@@ -1,0 +1,229 @@
+// Unit tests for Wave 4 (B3/H1/H2/H5) that do NOT require a database.
+// Tests that need a DB are in picking_task_b3_integration_test.go.
+package repositories
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/eflowcr/eSTOCK_backend/models/database"
+	"github.com/eflowcr/eSTOCK_backend/models/requests"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// H1 — ValidateAllocationSum
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestValidateAllocationSum(t *testing.T) {
+	tests := []struct {
+		name    string
+		item    requests.PickingTaskItemRequest
+		wantErr bool
+	}{
+		{
+			name: "single allocation, exact match",
+			item: requests.PickingTaskItemRequest{
+				SKU:              "SKU-001",
+				ExpectedQuantity: 10,
+				Allocations: []database.LocationAllocation{
+					{Location: "LOC-A", Quantity: 10},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "two allocations, exact match",
+			item: requests.PickingTaskItemRequest{
+				SKU:              "SKU-001",
+				ExpectedQuantity: 15,
+				Allocations: []database.LocationAllocation{
+					{Location: "LOC-A", Quantity: 10},
+					{Location: "LOC-B", Quantity: 5},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "within float tolerance",
+			item: requests.PickingTaskItemRequest{
+				SKU:              "SKU-001",
+				ExpectedQuantity: 10.0,
+				Allocations: []database.LocationAllocation{
+					{Location: "LOC-A", Quantity: 9.9999},
+				},
+			},
+			wantErr: false, // diff 0.0001 < tolerance 0.001
+		},
+		{
+			name: "sum too small (over tolerance)",
+			item: requests.PickingTaskItemRequest{
+				SKU:              "SKU-001",
+				ExpectedQuantity: 10,
+				Allocations: []database.LocationAllocation{
+					{Location: "LOC-A", Quantity: 8},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "sum too large (over tolerance)",
+			item: requests.PickingTaskItemRequest{
+				SKU:              "SKU-001",
+				ExpectedQuantity: 10,
+				Allocations: []database.LocationAllocation{
+					{Location: "LOC-A", Quantity: 11},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.item.ValidateAllocationSum()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateAllocationSum() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// H2 — parsePickingItemsWithLegacyFallback
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestParsePickingItemsWithLegacyFallback_NewFormat(t *testing.T) {
+	// New format: items already have allocations — must pass through unchanged.
+	raw := json.RawMessage(`[
+		{
+			"sku": "SKU-001",
+			"required_qty": 10,
+			"allocations": [
+				{"location": "LOC-A", "quantity": 6},
+				{"location": "LOC-B", "quantity": 4}
+			]
+		}
+	]`)
+
+	items, err := parsePickingItemsWithLegacyFallback(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if len(items[0].Allocations) != 2 {
+		t.Errorf("expected 2 allocations, got %d", len(items[0].Allocations))
+	}
+}
+
+func TestParsePickingItemsWithLegacyFallback_LegacyFormat(t *testing.T) {
+	// Legacy format: item has "location" string but no "allocations" — must synthesize one allocation.
+	raw := json.RawMessage(`[
+		{
+			"sku": "SKU-001",
+			"required_qty": 5,
+			"location": "LOC-OLD"
+		}
+	]`)
+
+	items, err := parsePickingItemsWithLegacyFallback(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if len(items[0].Allocations) != 1 {
+		t.Fatalf("expected synthetic allocation, got %d", len(items[0].Allocations))
+	}
+	alloc := items[0].Allocations[0]
+	if alloc.Location != "LOC-OLD" {
+		t.Errorf("expected location LOC-OLD, got %s", alloc.Location)
+	}
+	if alloc.Quantity != 5 {
+		t.Errorf("expected quantity 5, got %.2f", alloc.Quantity)
+	}
+}
+
+func TestParsePickingItemsWithLegacyFallback_MixedFormat(t *testing.T) {
+	// First item is new format, second is legacy — both should work.
+	raw := json.RawMessage(`[
+		{
+			"sku": "SKU-001",
+			"required_qty": 10,
+			"allocations": [{"location": "LOC-A", "quantity": 10}]
+		},
+		{
+			"sku": "SKU-002",
+			"required_qty": 3,
+			"location": "LOC-B"
+		}
+	]`)
+
+	items, err := parsePickingItemsWithLegacyFallback(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	// First item untouched.
+	if len(items[0].Allocations) != 1 || items[0].Allocations[0].Location != "LOC-A" {
+		t.Errorf("first item allocation unexpected: %+v", items[0].Allocations)
+	}
+	// Second item synthesized.
+	if len(items[1].Allocations) != 1 || items[1].Allocations[0].Location != "LOC-B" {
+		t.Errorf("second item allocation unexpected: %+v", items[1].Allocations)
+	}
+}
+
+func TestParsePickingItemsWithLegacyFallback_EmptyLocation(t *testing.T) {
+	// Legacy item with empty location string — should not get a synthetic allocation.
+	raw := json.RawMessage(`[{"sku": "SKU-001", "required_qty": 5, "location": ""}]`)
+	items, err := parsePickingItemsWithLegacyFallback(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items[0].Allocations) != 0 {
+		t.Errorf("expected no allocation for empty location, got %d", len(items[0].Allocations))
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// sanitizePickingUpdatePayload
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestSanitizePickingUpdatePayload(t *testing.T) {
+	data := map[string]interface{}{
+		"id":         "should-be-filtered",
+		"task_id":    "should-be-filtered",
+		"created_at": "should-be-filtered",
+		"status":     "in_progress",
+		"notes":      "test",
+		"unknown":    "should-be-filtered",
+		"AssignedTo": "user-123",
+	}
+
+	clean := sanitizePickingUpdatePayload(data)
+
+	if _, ok := clean["id"]; ok {
+		t.Error("id should be filtered (protected)")
+	}
+	if _, ok := clean["task_id"]; ok {
+		t.Error("task_id should be filtered (protected)")
+	}
+	if _, ok := clean["unknown"]; ok {
+		t.Error("unknown fields should be filtered (not in whitelist)")
+	}
+	if clean["status"] != "in_progress" {
+		t.Errorf("status should be preserved, got %v", clean["status"])
+	}
+	if clean["notes"] != "test" {
+		t.Errorf("notes should be preserved, got %v", clean["notes"])
+	}
+	// AssignedTo camelCase should be normalised to assigned_to.
+	if _, ok := clean["assigned_to"]; !ok {
+		t.Error("AssignedTo should be normalised to assigned_to")
+	}
+}

--- a/repositories/picking_task_repository.go
+++ b/repositories/picking_task_repository.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,27 +13,28 @@ import (
 	"github.com/eflowcr/eSTOCK_backend/models/database"
 	"github.com/eflowcr/eSTOCK_backend/models/requests"
 	"github.com/eflowcr/eSTOCK_backend/models/responses"
+	"github.com/eflowcr/eSTOCK_backend/services"
 	"github.com/eflowcr/eSTOCK_backend/tools"
 	"github.com/xuri/excelize/v2"
 	"gorm.io/gorm"
 )
 
 type PickingTaskRepository struct {
-	DB *gorm.DB
+	DB           *gorm.DB
+	AuditService *services.AuditService // injected via wire for audit logging
 }
 
-// validPickingTransitions declara las transiciones permitidas de status.
-// Los estados finales (completed, completed_with_differences, cancelled, abandoned)
-// no aparecen como claves porque no tienen transición saliente.
+// validPickingTransitions declares the allowed status transitions.
+// Terminal states (completed, completed_with_differences, cancelled, abandoned)
+// have no outgoing transitions.
 var validPickingTransitions = map[string]map[string]bool{
 	"open":        {"assigned": true, "in_progress": true, "cancelled": true, "abandoned": true},
 	"assigned":    {"open": true, "in_progress": true, "cancelled": true, "abandoned": true},
 	"in_progress": {"completed": true, "completed_with_differences": true, "cancelled": true, "abandoned": true},
 }
 
-// isValidPickingTransition retorna true si el cambio de status es permitido.
-// No-op (mismo → mismo) siempre es true.
-// Desde estados finales no hay transición saliente → false.
+// isValidPickingTransition returns true when the status change is permitted.
+// Same-state (no-op) is always true. Terminal states have no outgoing transitions → false.
 func isValidPickingTransition(current, next string) bool {
 	if current == next {
 		return true
@@ -42,6 +44,182 @@ func isValidPickingTransition(current, next string) bool {
 	}
 	return false
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// H2 — parsePickingItemsWithLegacyFallback
+// ─────────────────────────────────────────────────────────────────────────────
+
+// parsePickingItemsWithLegacyFallback accepts both the new format (items with
+// allocations) and the old format (item with a single "location" string but no
+// allocations). Legacy items get a synthetic single-allocation so the rest of
+// the code can treat all items uniformly.
+func parsePickingItemsWithLegacyFallback(raw json.RawMessage) ([]requests.PickingTaskItemRequest, error) {
+	var items []requests.PickingTaskItemRequest
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return nil, err
+	}
+
+	// Second pass: check for legacy "location" field (items with no allocations).
+	var legacyPayload []map[string]interface{}
+	if err := json.Unmarshal(raw, &legacyPayload); err != nil {
+		// If this fails the first unmarshal was sufficient.
+		return items, nil
+	}
+
+	for i := range items {
+		if len(items[i].Allocations) == 0 && i < len(legacyPayload) {
+			if location, ok := legacyPayload[i]["location"].(string); ok && location != "" {
+				items[i].Allocations = []database.LocationAllocation{
+					{Location: location, Quantity: items[i].ExpectedQuantity},
+				}
+			}
+		}
+	}
+	return items, nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// B3 — Shared reservation helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// applyReservations increments reserved_qty for every allocation within tx.
+// Uses a conditional UPDATE so it fails fast (RowsAffected == 0) when there
+// is not enough available stock, without ever leaving inventory in a bad state.
+// The caller must propagate a sentinel error to trigger rollback.
+func (r *PickingTaskRepository) applyReservations(tx *gorm.DB, items []requests.PickingTaskItemRequest) *responses.InternalResponse {
+	for _, item := range items {
+		for _, alloc := range item.Allocations {
+			result := tx.Exec(`
+				UPDATE inventory
+				   SET reserved_qty = reserved_qty + ?,
+				       updated_at   = NOW()
+				 WHERE sku = ? AND location = ?
+				   AND (quantity - reserved_qty) >= ?
+			`, alloc.Quantity, item.SKU, alloc.Location, alloc.Quantity)
+
+			if result.Error != nil {
+				return &responses.InternalResponse{
+					Error:   fmt.Errorf("reservar %s @ %s: %w", item.SKU, alloc.Location, result.Error),
+					Message: "Error al reservar stock",
+					Handled: false,
+				}
+			}
+			if result.RowsAffected == 0 {
+				return &responses.InternalResponse{
+					Message: fmt.Sprintf(
+						"Stock insuficiente para %s en %s. No hay %.2f uds disponibles para reservar.",
+						item.SKU, alloc.Location, alloc.Quantity,
+					),
+					Handled:    true,
+					StatusCode: responses.StatusBadRequest,
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// releaseReservations decrements reserved_qty for every allocation within tx.
+// Uses GREATEST(0, ...) so releasing more than what is reserved is safe.
+func (r *PickingTaskRepository) releaseReservations(tx *gorm.DB, items []requests.PickingTaskItemRequest) *responses.InternalResponse {
+	for _, item := range items {
+		for _, alloc := range item.Allocations {
+			if err := tx.Exec(`
+				UPDATE inventory
+				   SET reserved_qty = GREATEST(0, reserved_qty - ?),
+				       updated_at   = NOW()
+				 WHERE sku = ? AND location = ?
+			`, alloc.Quantity, item.SKU, alloc.Location).Error; err != nil {
+				return &responses.InternalResponse{
+					Error:   fmt.Errorf("liberar %s @ %s: %w", item.SKU, alloc.Location, err),
+					Message: "Error al liberar reservas",
+					Handled: false,
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// validateNoExpiredLots checks the DB for any lot referenced in items that is
+// past its expiration date. This queries the DB rather than the request payload
+// so stale expiration dates in old drafts are caught correctly.
+func (r *PickingTaskRepository) validateNoExpiredLots(items []requests.PickingTaskItemRequest) *responses.InternalResponse {
+	today := time.Now().Truncate(24 * time.Hour)
+
+	type key struct{ SKU, Lot string }
+	refs := make(map[key]bool)
+	for _, item := range items {
+		for _, lot := range item.LotNumbers {
+			if lot.LotNumber != "" {
+				refs[key{item.SKU, lot.LotNumber}] = true
+			}
+		}
+		for _, alloc := range item.Allocations {
+			if alloc.LotNumber != nil && *alloc.LotNumber != "" {
+				refs[key{item.SKU, *alloc.LotNumber}] = true
+			}
+		}
+	}
+
+	for k := range refs {
+		var lot database.Lot
+		if err := r.DB.Where("sku = ? AND lot_number = ?", k.SKU, k.Lot).First(&lot).Error; err != nil {
+			continue // lot not in DB — validated elsewhere
+		}
+		if lot.ExpirationDate != nil && lot.ExpirationDate.Before(today) {
+			return &responses.InternalResponse{
+				Message: fmt.Sprintf(
+					"Lote %s (SKU %s) venció el %s. No puede pickearse.",
+					k.Lot, k.SKU, lot.ExpirationDate.Format("2006-01-02"),
+				),
+				Handled:    true,
+				StatusCode: responses.StatusBadRequest,
+			}
+		}
+	}
+	return nil
+}
+
+// sanitizePickingUpdatePayload applies the whitelist and key normalisation that
+// UpdatePickingTask used inline. Extracted as a helper so it can be reused.
+func sanitizePickingUpdatePayload(data map[string]interface{}) map[string]interface{} {
+	protected := map[string]bool{
+		"id":         true,
+		"task_id":    true,
+		"created_at": true,
+	}
+	whitelist := map[string]bool{
+		"assigned_to":  true,
+		"priority":     true,
+		"status":       true,
+		"notes":        true,
+		"items":        true,
+		"order_number": true,
+		"updated_at":   true,
+		"completed_at": true,
+	}
+
+	clean := make(map[string]interface{}, len(data)+2)
+	for k, v := range data {
+		key := strings.ToLower(k)
+		key = strings.ReplaceAll(key, "assignedto", "assigned_to")
+		key = strings.ReplaceAll(key, "ordernumber", "order_number")
+		key = strings.ReplaceAll(key, "outboundnumber", "order_number")
+		key = strings.ReplaceAll(key, "completedat", "completed_at")
+		key = strings.ReplaceAll(key, "updatedat", "updated_at")
+
+		if protected[key] || !whitelist[key] {
+			continue
+		}
+		clean[key] = v
+	}
+	return clean
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Read methods
+// ─────────────────────────────────────────────────────────────────────────────
 
 func (r *PickingTaskRepository) GetAllPickingTasks() ([]responses.PickingTaskView, *responses.InternalResponse) {
 	var tasks []responses.PickingTaskView
@@ -102,25 +280,19 @@ func (r *PickingTaskRepository) GetAllPickingTasks() ([]responses.PickingTaskVie
 			pt.completed_at;
 	`
 
-	err := r.DB.Raw(sqlRar).Scan(&tasks).Error
-
-	if err != nil {
+	if err := r.DB.Raw(sqlRar).Scan(&tasks).Error; err != nil {
 		return nil, &responses.InternalResponse{
 			Error:   err,
 			Message: "Error al obtener todas las tareas de picking",
 			Handled: false,
 		}
 	}
-
 	return tasks, nil
 }
 
 func (r *PickingTaskRepository) GetPickingTaskByID(id string) (*database.PickingTask, *responses.InternalResponse) {
 	var task database.PickingTask
-
-	err := r.DB.Table(database.PickingTask{}.TableName()).Where("id = ?", id).First(&task).Error
-
-	if err != nil {
+	if err := r.DB.Table(database.PickingTask{}.TableName()).Where("id = ?", id).First(&task).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, &responses.InternalResponse{
 				Message:    "Tarea de picking no encontrada",
@@ -134,9 +306,12 @@ func (r *PickingTaskRepository) GetPickingTaskByID(id string) (*database.Picking
 			Handled: false,
 		}
 	}
-
 	return &task, nil
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CreatePickingTask
+// ─────────────────────────────────────────────────────────────────────────────
 
 func (r *PickingTaskRepository) CreatePickingTask(userId string, task *requests.CreatePickingTaskRequest) *responses.InternalResponse {
 	handledResp := &responses.InternalResponse{}
@@ -147,17 +322,27 @@ func (r *PickingTaskRepository) CreatePickingTask(userId string, task *requests.
 		return handledResp
 	}
 
-	err := r.DB.Transaction(func(tx *gorm.DB) error {
-		// Check for unique OutboundNumber
-		var count int64
+	// Validate each item's allocations sum
+	for _, it := range items {
+		if err := it.ValidateAllocationSum(); err != nil {
+			*handledResp = responses.InternalResponse{Error: err, Message: err.Error(), Handled: true, StatusCode: responses.StatusBadRequest}
+			return handledResp
+		}
+	}
 
+	err := r.DB.Transaction(func(tx *gorm.DB) error {
+		var count int64
 		if err := tx.Model(&database.PickingTask{}).Where("order_number = ?", task.OutboundNumber).Count(&count).Error; err != nil {
 			*handledResp = responses.InternalResponse{Error: err, Message: "Error al verificar la unicidad del número de salida", Handled: false}
 			return nil
 		}
-
 		if count > 0 {
-			*handledResp = responses.InternalResponse{Error: fmt.Errorf("outbound number %s is already taken", task.OutboundNumber), Message: "El número de salida ya está en uso", Handled: true}
+			*handledResp = responses.InternalResponse{
+				Error:      fmt.Errorf("outbound number %s is already taken", task.OutboundNumber),
+				Message:    "El número de salida ya está en uso",
+				Handled:    true,
+				StatusCode: responses.StatusConflict,
+			}
 			return nil
 		}
 
@@ -165,9 +350,7 @@ func (r *PickingTaskRepository) CreatePickingTask(userId string, task *requests.
 		taskID := fmt.Sprintf("PICK-%06d", nowMillis%1_000_000)
 
 		articleCache := make(map[string]database.Article)
-
 		for i := range items {
-			// Asignar status inicial una sola vez
 			items[i].Status = tools.StrPtr("open")
 			sku := items[i].SKU
 
@@ -187,11 +370,9 @@ func (r *PickingTaskRepository) CreatePickingTask(userId string, task *requests.
 					items[i].LotNumbers[j].Status = tools.StrPtr("open")
 				}
 			}
-
 			if art.TrackBySerial {
 				for j := range items[i].SerialNumbers {
-					// Esto depende del tipo de Status
-					items[i].SerialNumbers[j].Status = *tools.StrPtr("open")
+					items[i].SerialNumbers[j].Status = "open"
 				}
 			}
 		}
@@ -238,122 +419,418 @@ func (r *PickingTaskRepository) CreatePickingTask(userId string, task *requests.
 	return nil
 }
 
-func (r *PickingTaskRepository) UpdatePickingTask(id string, data map[string]interface{}) *responses.InternalResponse {
-	var task database.PickingTask
-	if err := r.DB.First(&task, "id = ?", id).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return &responses.InternalResponse{Message: "Tarea de picking no encontrada", Handled: true}
+// ─────────────────────────────────────────────────────────────────────────────
+// B3a — StartPickingTask: applies lazy reservations
+// ─────────────────────────────────────────────────────────────────────────────
+
+func (r *PickingTaskRepository) StartPickingTask(ctx context.Context, id, userId string) *responses.InternalResponse {
+	var handledResp *responses.InternalResponse
+
+	txErr := r.DB.Transaction(func(tx *gorm.DB) error {
+		var task database.PickingTask
+		if err := tx.First(&task, "id = ?", id).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				handledResp = &responses.InternalResponse{
+					Message: "Tarea no encontrada", Handled: true, StatusCode: responses.StatusNotFound,
+				}
+				return fmt.Errorf("not found")
+			}
+			return err
 		}
-		return &responses.InternalResponse{Error: err, Message: "Error al obtener la tarea de picking"}
-	}
 
-	protected := map[string]bool{
-		"id":         true,
-		"task_id":    true,
-		"created_at": true,
-	}
-
-	whitelist := map[string]bool{
-		"assigned_to":  true,
-		"priority":     true,
-		"status":       true,
-		"notes":        true,
-		"items":        true,
-		"order_number": true,
-		"updated_at":   true,
-		"completed_at": true,
-	}
-
-	clean := make(map[string]interface{}, len(data)+2)
-	for k, v := range data {
-		key := strings.ToLower(k)
-		key = strings.ReplaceAll(key, "assignedto", "assigned_to")
-		key = strings.ReplaceAll(key, "ordernumber", "order_number")
-		key = strings.ReplaceAll(key, "outboundnumber", "order_number")
-		key = strings.ReplaceAll(key, "completedat", "completed_at")
-		key = strings.ReplaceAll(key, "updatedat", "updated_at")
-
-		if protected[key] {
-			continue
+		// Only open|assigned → in_progress is a valid start transition.
+		if task.Status != "open" && task.Status != "assigned" {
+			handledResp = &responses.InternalResponse{
+				Message:    fmt.Sprintf("No se puede iniciar una tarea en estado '%s'", task.Status),
+				Handled:    true,
+				StatusCode: responses.StatusBadRequest,
+			}
+			return fmt.Errorf("invalid transition")
 		}
-		if !whitelist[key] {
-			continue
+
+		items, err := parsePickingItemsWithLegacyFallback(task.Items)
+		if err != nil {
+			return fmt.Errorf("parse items: %w", err)
 		}
-		clean[key] = v
+
+		// Validate no expired lots before reserving (B4).
+		if resp := r.validateNoExpiredLots(items); resp != nil {
+			handledResp = resp
+			return fmt.Errorf("expired lot")
+		}
+
+		// Apply lazy reservations.
+		if resp := r.applyReservations(tx, items); resp != nil {
+			handledResp = resp
+			return fmt.Errorf("reservation failed")
+		}
+
+		if err := tx.Exec(
+			`UPDATE picking_tasks SET status = 'in_progress', updated_at = NOW() WHERE id = ?`, id,
+		).Error; err != nil {
+			return fmt.Errorf("update status: %w", err)
+		}
+
+		return nil
+	})
+
+	if txErr != nil {
+		if handledResp != nil {
+			return handledResp
+		}
+		return &responses.InternalResponse{Error: txErr, Message: "Error al iniciar picking"}
 	}
 
-	clean["updated_at"] = tools.GetCurrentTime()
+	if r.AuditService != nil {
+		r.AuditService.Log(ctx, &userId, tools.ActionExecute, "picking_task", id, nil, nil, "", "")
+	}
+	return nil
+}
 
-	var nextStatus string
-	currentStatus := strings.ToLower(strings.TrimSpace(task.Status))
+// ─────────────────────────────────────────────────────────────────────────────
+// B3b/B3c — UpdatePickingTask: full rewrite with reserve recalc
+// ─────────────────────────────────────────────────────────────────────────────
 
-	if raw, ok := clean["status"]; ok {
-		if s, ok := raw.(string); ok {
-			sLower := strings.ToLower(strings.TrimSpace(s))
-			// Enforce allowed status transitions
-			if !isValidPickingStatusTransition(currentStatus, sLower) {
-				return &responses.InternalResponse{
-					Message:    fmt.Sprintf("Transición de estado no permitida: %s → %s", currentStatus, sLower),
+func (r *PickingTaskRepository) UpdatePickingTask(ctx context.Context, id string, data map[string]interface{}, userId string) *responses.InternalResponse {
+	var handledResp *responses.InternalResponse
+
+	txErr := r.DB.Transaction(func(tx *gorm.DB) error {
+		var task database.PickingTask
+		if err := tx.First(&task, "id = ?", id).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				handledResp = &responses.InternalResponse{
+					Message: "Tarea no encontrada", Handled: true, StatusCode: responses.StatusNotFound,
+				}
+				return fmt.Errorf("not found")
+			}
+			return err
+		}
+
+		clean := sanitizePickingUpdatePayload(data)
+		clean["updated_at"] = tools.GetCurrentTime()
+
+		// Validate and apply status transition if status changed.
+		nextStatus, _ := clean["status"].(string)
+		if nextStatus != "" {
+			currentStatus := strings.ToLower(strings.TrimSpace(task.Status))
+			nextStatus = strings.ToLower(strings.TrimSpace(nextStatus))
+			clean["status"] = nextStatus
+
+			if !isValidPickingTransition(currentStatus, nextStatus) {
+				handledResp = &responses.InternalResponse{
+					Message:    fmt.Sprintf("Transición inválida: %s → %s", currentStatus, nextStatus),
 					Handled:    true,
 					StatusCode: responses.StatusConflict,
 				}
+				return fmt.Errorf("invalid transition")
 			}
-			nextStatus = sLower
-			switch sLower {
-			case "closed":
+
+			// B3c — cancel from in_progress releases reservations.
+			if nextStatus == "cancelled" && currentStatus == "in_progress" {
+				oldItems, err := parsePickingItemsWithLegacyFallback(task.Items)
+				if err != nil {
+					return fmt.Errorf("parse old items for cancel: %w", err)
+				}
+				if resp := r.releaseReservations(tx, oldItems); resp != nil {
+					handledResp = resp
+					return fmt.Errorf("release failed")
+				}
+			}
+
+			// Set completed_at based on terminal status.
+			switch nextStatus {
+			case "completed", "completed_with_differences", "cancelled", "abandoned", "closed":
 				clean["completed_at"] = tools.GetCurrentTime()
 			default:
 				clean["completed_at"] = gorm.Expr("NULL")
 			}
-			clean["status"] = sLower
 		}
-	}
 
-	if items, ok := clean["items"]; ok {
-		switch it := items.(type) {
-		case map[string]interface{}, []interface{}:
-			b, err := json.Marshal(it)
+		// B3b — if items changed while task is in_progress, recalculate reservations.
+		if rawItems, itemsChanged := clean["items"]; itemsChanged && task.Status == "in_progress" {
+			// Release old reservations first.
+			oldItems, err := parsePickingItemsWithLegacyFallback(task.Items)
 			if err != nil {
-				return &responses.InternalResponse{Error: err, Message: "Formato de items inválido", Handled: true}
+				return fmt.Errorf("parse old items: %w", err)
 			}
-			clean["items"] = b
+			if resp := r.releaseReservations(tx, oldItems); resp != nil {
+				handledResp = resp
+				return fmt.Errorf("release old failed")
+			}
+
+			// Convert clean["items"] ([]interface{} from JSON decode) → typed slice
+			// via re-marshal to avoid unsafe type assertions.
+			newItemsBytes, err := json.Marshal(rawItems)
+			if err != nil {
+				return fmt.Errorf("marshal new items: %w", err)
+			}
+			var newItems []requests.PickingTaskItemRequest
+			if err := json.Unmarshal(newItemsBytes, &newItems); err != nil {
+				return fmt.Errorf("parse new items: %w", err)
+			}
+
+			if resp := r.validateNoExpiredLots(newItems); resp != nil {
+				handledResp = resp
+				return fmt.Errorf("expired lot in update")
+			}
+
+			if resp := r.applyReservations(tx, newItems); resp != nil {
+				handledResp = resp
+				return fmt.Errorf("apply new reservations failed")
+			}
+
+			// Store the serialised items.
+			clean["items"] = json.RawMessage(newItemsBytes)
+		} else if rawItems, itemsChanged := clean["items"]; itemsChanged {
+			// Not in_progress — just marshal correctly.
+			newItemsBytes, err := json.Marshal(rawItems)
+			if err != nil {
+				return fmt.Errorf("marshal items: %w", err)
+			}
+			clean["items"] = json.RawMessage(newItemsBytes)
 		}
+
+		if err := tx.Model(&task).Updates(clean).Error; err != nil {
+			return fmt.Errorf("update task: %w", err)
+		}
+
+		return nil
+	})
+
+	if txErr != nil {
+		if handledResp != nil {
+			return handledResp
+		}
+		return &responses.InternalResponse{Error: txErr, Message: "Error al actualizar tarea"}
 	}
 
-	// Optimistic locking: ensure we only update when status has not changed.
-	query := r.DB.Model(&task).Where("id = ?", id)
-	if nextStatus != "" {
-		query = query.Where("status = ?", currentStatus)
+	if r.AuditService != nil {
+		r.AuditService.Log(ctx, &userId, tools.ActionUpdate, "picking_task", id, nil, nil, "", "")
 	}
-
-	if err := query.Updates(clean).Error; err != nil {
-		return &responses.InternalResponse{Error: err, Message: "Error al actualizar la tarea de picking"}
-	}
-
 	return nil
 }
 
-// isValidPickingStatusTransition returns true when a status change is allowed.
-// Allowed paths:
-// - open -> in_progress
-// - in_progress -> completed
-// - open|in_progress -> cancelled
-// - same -> same (idempotent)
-func isValidPickingStatusTransition(current, next string) bool {
-	if current == next || next == "" {
-		return true
+// ─────────────────────────────────────────────────────────────────────────────
+// B3d — CompletePickingLine: consumes reservations per allocation
+// ─────────────────────────────────────────────────────────────────────────────
+
+func (r *PickingTaskRepository) CompletePickingLine(ctx context.Context, id, userId string, item requests.PickingTaskItemRequest) *responses.InternalResponse {
+	var handledResp *responses.InternalResponse
+
+	txErr := r.DB.Transaction(func(tx *gorm.DB) error {
+		var task database.PickingTask
+		if err := tx.First(&task, "id = ?", id).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				handledResp = &responses.InternalResponse{Message: "Tarea de picking no encontrada", Handled: true, StatusCode: responses.StatusNotFound}
+				return fmt.Errorf("not found")
+			}
+			return err
+		}
+
+		existingItems, err := parsePickingItemsWithLegacyFallback(task.Items)
+		if err != nil {
+			return fmt.Errorf("parse task items: %w", err)
+		}
+
+		// Validate lots before touching inventory.
+		if resp := r.validateNoExpiredLots([]requests.PickingTaskItemRequest{item}); resp != nil {
+			handledResp = resp
+			return fmt.Errorf("expired lot in complete line")
+		}
+
+		// Find the matching item by SKU.
+		foundIdx := -1
+		for i := range existingItems {
+			if existingItems[i].SKU == item.SKU {
+				foundIdx = i
+				break
+			}
+		}
+		if foundIdx == -1 {
+			handledResp = &responses.InternalResponse{Message: "Item no encontrado en la tarea de picking", Handled: true}
+			return fmt.Errorf("item not found")
+		}
+
+		// Decrement inventory, reserved_qty, and lot quantities per allocation.
+		for _, alloc := range item.Allocations {
+			pickedQty := alloc.Quantity
+			if alloc.PickedQty != nil {
+				pickedQty = *alloc.PickedQty
+			}
+
+			if err := tx.Exec(`
+				UPDATE inventory
+				   SET quantity     = quantity - ?,
+				       reserved_qty = GREATEST(0, reserved_qty - ?),
+				       updated_at   = NOW()
+				 WHERE sku = ? AND location = ?
+			`, pickedQty, alloc.Quantity, item.SKU, alloc.Location).Error; err != nil {
+				return fmt.Errorf("decrementar inventario %s @ %s: %w", item.SKU, alloc.Location, err)
+			}
+
+			if alloc.LotNumber != nil && *alloc.LotNumber != "" {
+				// Decrement inventory_lots (per-location lot quantity).
+				tx.Exec(`
+					UPDATE inventory_lots
+					   SET quantity = GREATEST(0, quantity - ?)
+					 WHERE inventory_id = (SELECT id FROM inventory WHERE sku = ? AND location = ? LIMIT 1)
+					   AND lot_id      = (SELECT id FROM lots         WHERE sku = ? AND lot_number = ? LIMIT 1)
+				`, pickedQty, item.SKU, alloc.Location, item.SKU, *alloc.LotNumber)
+
+				// Decrement lots global quantity.
+				tx.Exec(`
+					UPDATE lots SET quantity = GREATEST(0, quantity - ?), updated_at = NOW()
+					 WHERE sku = ? AND lot_number = ?
+				`, pickedQty, item.SKU, *alloc.LotNumber)
+			}
+		}
+
+		// Update item status in the task's JSONB.
+		totalPicked := 0.0
+		for _, alloc := range item.Allocations {
+			if alloc.PickedQty != nil {
+				totalPicked += *alloc.PickedQty
+			} else {
+				totalPicked += alloc.Quantity
+			}
+		}
+		if totalPicked >= existingItems[foundIdx].ExpectedQuantity {
+			existingItems[foundIdx].Status = tools.StrPtr("completed")
+		} else {
+			existingItems[foundIdx].Status = tools.StrPtr("partial")
+		}
+		// Store updated allocations from the incoming item.
+		existingItems[foundIdx].Allocations = item.Allocations
+
+		updatedItems, err := json.Marshal(existingItems)
+		if err != nil {
+			return fmt.Errorf("marshal updated items: %w", err)
+		}
+
+		if err := tx.Exec(
+			`UPDATE picking_tasks SET items = ?, updated_at = NOW() WHERE id = ?`,
+			json.RawMessage(updatedItems), id,
+		).Error; err != nil {
+			return fmt.Errorf("update task items: %w", err)
+		}
+
+		return nil
+	})
+
+	if txErr != nil {
+		if handledResp != nil {
+			return handledResp
+		}
+		return &responses.InternalResponse{Error: txErr, Message: "Error al completar línea de picking"}
 	}
 
-	switch current {
-	case "open":
-		return next == "in_progress" || next == "cancelled"
-	case "in_progress":
-		return next == "completed" || next == "cancelled"
-	default:
-		// completed / closed / cancelled are terminal in this simple model
-		return false
+	if r.AuditService != nil {
+		r.AuditService.Log(ctx, &userId, tools.ActionUpdate, "picking_task", id, nil, nil, "", "")
 	}
+	return nil
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// H5 — CompletePickingTask: full task, allocation-aware
+// ─────────────────────────────────────────────────────────────────────────────
+
+func (r *PickingTaskRepository) CompletePickingTask(ctx context.Context, id, userId string) *responses.InternalResponse {
+	var handledResp *responses.InternalResponse
+
+	txErr := r.DB.Transaction(func(tx *gorm.DB) error {
+		var task database.PickingTask
+		if err := tx.First(&task, "id = ?", id).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				handledResp = &responses.InternalResponse{Message: "Tarea no encontrada", Handled: true, StatusCode: responses.StatusNotFound}
+				return fmt.Errorf("not found")
+			}
+			return err
+		}
+
+		if task.Status != "in_progress" {
+			handledResp = &responses.InternalResponse{
+				Message:    fmt.Sprintf("No se puede completar una tarea en estado '%s'", task.Status),
+				Handled:    true,
+				StatusCode: responses.StatusBadRequest,
+			}
+			return fmt.Errorf("invalid transition")
+		}
+
+		items, err := parsePickingItemsWithLegacyFallback(task.Items)
+		if err != nil {
+			return fmt.Errorf("parse items: %w", err)
+		}
+
+		hasDifferences := false
+		for _, item := range items {
+			for _, alloc := range item.Allocations {
+				pickedQty := alloc.Quantity
+				if alloc.PickedQty != nil {
+					pickedQty = *alloc.PickedQty
+				}
+				if pickedQty != alloc.Quantity {
+					hasDifferences = true
+				}
+
+				// Decrement inventory quantity + release reservation.
+				if err := tx.Exec(`
+					UPDATE inventory
+					   SET quantity     = quantity - ?,
+					       reserved_qty = GREATEST(0, reserved_qty - ?),
+					       updated_at   = NOW()
+					 WHERE sku = ? AND location = ?
+				`, pickedQty, alloc.Quantity, item.SKU, alloc.Location).Error; err != nil {
+					return fmt.Errorf("decrementar %s @ %s: %w", item.SKU, alloc.Location, err)
+				}
+
+				// Decrement lot-level quantities when a specific lot was picked.
+				if alloc.LotNumber != nil && *alloc.LotNumber != "" {
+					tx.Exec(`
+						UPDATE inventory_lots
+						   SET quantity = GREATEST(0, quantity - ?)
+						 WHERE inventory_id = (SELECT id FROM inventory WHERE sku = ? AND location = ? LIMIT 1)
+						   AND lot_id      = (SELECT id FROM lots         WHERE sku = ? AND lot_number = ? LIMIT 1)
+					`, pickedQty, item.SKU, alloc.Location, item.SKU, *alloc.LotNumber)
+
+					tx.Exec(`
+						UPDATE lots SET quantity = GREATEST(0, quantity - ?), updated_at = NOW()
+						 WHERE sku = ? AND lot_number = ?
+					`, pickedQty, item.SKU, *alloc.LotNumber)
+				}
+			}
+		}
+
+		finalStatus := "completed"
+		if hasDifferences {
+			finalStatus = "completed_with_differences"
+		}
+
+		if err := tx.Exec(
+			`UPDATE picking_tasks SET status = ?, completed_at = NOW(), updated_at = NOW() WHERE id = ?`,
+			finalStatus, id,
+		).Error; err != nil {
+			return fmt.Errorf("update status: %w", err)
+		}
+
+		return nil
+	})
+
+	if txErr != nil {
+		if handledResp != nil {
+			return handledResp
+		}
+		return &responses.InternalResponse{Error: txErr, Message: "Error al completar picking"}
+	}
+
+	if r.AuditService != nil {
+		r.AuditService.Log(ctx, &userId, tools.ActionExecute, "picking_task", id, nil, nil, "", "")
+	}
+	return nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Excel Import / Export
+// ─────────────────────────────────────────────────────────────────────────────
 
 func (r *PickingTaskRepository) ImportPickingTaskFromExcel(userID string, fileBytes []byte) *responses.InternalResponse {
 	f, err := excelize.OpenReader(bytes.NewReader(fileBytes))
@@ -396,11 +873,9 @@ func (r *PickingTaskRepository) ImportPickingTaskFromExcel(userID string, fileBy
 	notes := getOneOf("Notes")
 
 	var assignedId string
-
 	if assignedTo != nil && strings.TrimSpace(*assignedTo) != "" {
 		var user database.User
-
-		if err := r.DB.Where("email = ?", strings.TrimSpace(*assignedTo), strings.TrimSpace(*assignedTo)).First(&user).Error; err != nil {
+		if err := r.DB.Where("email = ?", strings.TrimSpace(*assignedTo)).First(&user).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return &responses.InternalResponse{Error: fmt.Errorf("user %s not found", *assignedTo), Message: "Usuario asignado no encontrado", Handled: true}
 			}
@@ -418,8 +893,6 @@ func (r *PickingTaskRepository) ImportPickingTaskFromExcel(userID string, fileBy
 			priorityNorm = "low"
 		case "high", "alta":
 			priorityNorm = "high"
-		default:
-			priorityNorm = "normal"
 		}
 	}
 
@@ -469,7 +942,7 @@ func (r *PickingTaskRepository) ImportPickingTaskFromExcel(userID string, fileBy
 		}
 	}
 
-	var items []database.PickingTaskItem
+	var items []requests.PickingTaskItemRequest
 
 	for i := headerRowIdx + 1; i < len(rows); i++ {
 		row := rows[i]
@@ -484,22 +957,53 @@ func (r *PickingTaskRepository) ImportPickingTaskFromExcel(userID string, fileBy
 		lotsStr := get(row, colIndex["lot_numbers"])
 		serialsStr := get(row, colIndex["serial_numbers"])
 
-		qty := 0
-		if n, err := strconv.Atoi(strings.TrimSpace(qtyStr)); err == nil {
+		qty := 0.0
+		if n, err := strconv.ParseFloat(strings.TrimSpace(qtyStr), 64); err == nil {
 			qty = n
 		}
 
-		lots := splitCSV(lotsStr)
-		serials := splitCSV(serialsStr)
+		// Build a single allocation from the Excel location column (legacy-style).
+		allocations := []database.LocationAllocation{}
+		if loc := strings.TrimSpace(location); loc != "" && qty > 0 {
+			allocations = append(allocations, database.LocationAllocation{
+				Location: loc,
+				Quantity: qty,
+			})
+		}
 
-		// TODO B3: Location → Allocations, LotNumbers/SerialNumbers need new types (LotEntry/Serial).
-		// Excel import will be re-wired in B3. Variables consumed to silence unused-var errors.
-		_, _, _ = location, lots, serials
-		items = append(items, database.PickingTaskItem{
+		// Parse lot numbers from comma-separated string.
+		var lotEntries []database.LotEntry
+		for _, ln := range splitCSV(lotsStr) {
+			if ln != "" {
+				lotEntries = append(lotEntries, database.LotEntry{LotNumber: ln, SKU: sku, Quantity: qty})
+			}
+		}
+
+		// Serial numbers — stored in SerialNumbers field.
+		var serials []database.Serial
+		for _, sn := range splitCSV(serialsStr) {
+			if sn != "" {
+				serials = append(serials, database.Serial{SerialNumber: sn, SKU: sku})
+			}
+		}
+
+		item := requests.PickingTaskItemRequest{
 			SKU:              strings.TrimSpace(sku),
-			ExpectedQuantity: float64(qty),
-		})
+			ExpectedQuantity: qty,
+			Allocations:      allocations,
+		}
+		if len(lotEntries) > 0 {
+			item.LotNumbers = lotEntries
+		}
+		if len(serials) > 0 {
+			item.SerialNumbers = serials
+		}
+
+		if qty > 0 {
+			items = append(items, item)
+		}
 	}
+
 	if len(items) == 0 {
 		return &responses.InternalResponse{Error: fmt.Errorf("no items"), Message: "No se encontraron items para importar", Handled: true}
 	}
@@ -534,20 +1038,9 @@ func (r *PickingTaskRepository) ExportPickingTasksToExcel() ([]byte, *responses.
 	f.SetSheetName("Sheet1", sheet)
 
 	headers := []string{
-		"ID",
-		"Task ID",
-		"Order Number",
-		"Created By",
-		"Assigned To",
-		"Status",
-		"Priority",
-		"Notes",
-		"Items",
-		"Created At",
-		"Updated At",
-		"Completed At",
+		"ID", "Task ID", "Order Number", "Created By", "Assigned To",
+		"Status", "Priority", "Notes", "Items", "Created At", "Updated At", "Completed At",
 	}
-
 	for i, h := range headers {
 		cell, _ := excelize.CoordinatesToCellName(i+1, 1)
 		f.SetCellValue(sheet, cell, h)
@@ -556,18 +1049,9 @@ func (r *PickingTaskRepository) ExportPickingTasksToExcel() ([]byte, *responses.
 	for i, task := range tasks {
 		rowNum := i + 2
 		row := []interface{}{
-			task.ID,
-			task.TaskID,
-			task.OrderNumber,
-			task.CreatedBy,
-			task.AssignedTo,
-			task.Status,
-			task.Priority,
-			task.Notes,
-			string(task.Items),
-			task.CreatedAt.Format(time.RFC3339),
-			nil,
-			nil,
+			task.ID, task.TaskID, task.OrderNumber, task.CreatedBy, task.AssignedTo,
+			task.Status, task.Priority, task.Notes, string(task.Items),
+			task.CreatedAt.Format(time.RFC3339), nil, nil,
 		}
 		if !task.UpdatedAt.IsZero() {
 			row[10] = task.UpdatedAt.Format(time.RFC3339)
@@ -575,7 +1059,6 @@ func (r *PickingTaskRepository) ExportPickingTasksToExcel() ([]byte, *responses.
 		if !task.CompletedAt.IsZero() {
 			row[11] = task.CompletedAt.Format(time.RFC3339)
 		}
-
 		for j, val := range row {
 			cell, _ := excelize.CoordinatesToCellName(j+1, rowNum)
 			f.SetCellValue(sheet, cell, val)
@@ -584,576 +1067,40 @@ func (r *PickingTaskRepository) ExportPickingTasksToExcel() ([]byte, *responses.
 
 	var buf bytes.Buffer
 	if err := f.Write(&buf); err != nil {
-		return nil, &responses.InternalResponse{
-			Error:   err,
-			Message: "Error al generar el archivo de Excel",
-			Handled: false,
-		}
+		return nil, &responses.InternalResponse{Error: err, Message: "Error al generar el archivo de Excel"}
 	}
-
 	return buf.Bytes(), nil
-}
-
-func (r *PickingTaskRepository) CompletePickingTask(id string, location, userId string) *responses.InternalResponse {
-	handledResp := &responses.InternalResponse{}
-
-	err := r.DB.Transaction(func(tx *gorm.DB) error {
-		// Get the task
-		var task database.PickingTask
-		if err := tx.First(&task, "id = ?", id).Error; err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				*handledResp = responses.InternalResponse{Message: "Tarea de picking no encontrada", Handled: true}
-				return nil
-			}
-			return fmt.Errorf("retrieve picking task: %w", err)
-		}
-
-		if task.Status == "completed" || task.Status == "closed" {
-			*handledResp = responses.InternalResponse{Message: "Tarea de picking ya completada o cerrada", Handled: true}
-
-			return nil
-		}
-
-		var items []requests.PickingTaskItemRequest
-
-		if err := json.Unmarshal(task.Items, &items); err != nil {
-			*handledResp = responses.InternalResponse{Error: err, Message: "Formato de items inválido", Handled: true}
-			return nil
-		}
-
-		for i := 0; i < len(items); i++ {
-			if items[i].Status != nil && (*items[i].Status == "completed" || *items[i].Status == "partial") {
-				continue
-			}
-
-			sku := items[i].SKU
-
-			items[i].Status = tools.StrPtr("completed")
-			items[i].DeliveredQuantity = tools.IntToPtr(int(items[i].ExpectedQuantity))
-
-			var article database.Article
-
-			if err := tx.Where("sku = ?", sku).First(&article).Error; err != nil {
-				if err == gorm.ErrRecordNotFound {
-					continue
-				}
-				return fmt.Errorf("find article %s: %w", sku, err)
-			}
-
-			var inventory database.Inventory
-
-			// Check if there is enough stock in the specified location
-			if err := tx.Where("sku = ? AND location = ?", sku, location).First(&inventory).Error; err != nil {
-				if err == gorm.ErrRecordNotFound {
-					*handledResp = responses.InternalResponse{Message: fmt.Sprintf("No hay suficiente stock para el SKU %s en la ubicación %s", sku, location), Handled: true}
-
-					return nil
-				}
-				return fmt.Errorf("find inventory %s in %s: %w", sku, location, err)
-			}
-
-			if inventory.Quantity < float64(items[i].ExpectedQuantity) {
-				*handledResp = responses.InternalResponse{Message: fmt.Sprintf("No hay suficiente stock para el SKU %s en la ubicación %s", sku, location), Handled: true}
-
-				return nil
-			}
-
-			// Deduct the stock
-			newQty := inventory.Quantity - float64(items[i].ExpectedQuantity)
-
-			if err := tx.Model(&database.Inventory{}).Where("id = ?", inventory.ID).
-				Update("quantity", newQty).Error; err != nil {
-				return fmt.Errorf("update inventory %s in %s: %w", sku, location, err)
-			}
-
-			// Create inventory movement record
-			movement := database.InventoryMovement{
-				SKU:            sku,
-				Location:       location,
-				MovementType:   "picking",
-				Quantity:       float64(items[i].ExpectedQuantity),
-				RemainingStock: newQty,
-				Reason:         tools.StrPtr(fmt.Sprintf("Picking Task %s", task.TaskID)),
-				CreatedBy:      task.CreatedBy,
-				CreatedAt:      tools.GetCurrentTime(),
-			}
-
-			if err := tx.Create(&movement).Error; err != nil {
-				return fmt.Errorf("error al crear movimiento de inventario %s en %s: %w", sku, location, err)
-			}
-
-			if article.TrackBySerial && items[i].SerialNumbers != nil {
-				// Check if given serials count matches expected quantity
-				if len(items[i].SerialNumbers) != items[i].ExpectedQuantity {
-					// If not, then this task can't be completed fully
-					*handledResp = responses.InternalResponse{Message: fmt.Sprintf("La cantidad de números de serie (%d) no coincide con la cantidad esperada (%d) para el SKU %s", len(items[i].SerialNumbers), items[i].ExpectedQuantity, sku), Handled: true}
-					return nil
-				}
-
-				for k := 0; k < len(items[i].SerialNumbers); k++ {
-					serial := items[i].SerialNumbers[k]
-
-					// Check if serial was created before
-					var serialItem database.Serial
-
-					// Check if serial exists and is in stock and its available
-					if err := tx.Where("serial_number = ? AND sku = ? AND status = 'available'", serial.SerialNumber, sku).First(&serialItem).Error; err != nil {
-						if err == gorm.ErrRecordNotFound {
-							*handledResp = responses.InternalResponse{Message: fmt.Sprintf("El número de serie %s para el SKU %s no se encontró en el inventario", serial.SerialNumber, sku), Handled: true}
-							return nil
-						}
-						return fmt.Errorf("find serial %s for SKU %s: %w", serial.SerialNumber, sku, err)
-					}
-
-					// Mark serial as picked
-					serialItem.Status = "picked"
-					serialItem.UpdatedAt = tools.GetCurrentTime()
-
-					if err := tx.Save(&serialItem).Error; err != nil {
-						return fmt.Errorf("update serial %s for SKU %s: %w", serial.SerialNumber, sku, err)
-					}
-
-					// Mark serial as completed in the task
-					items[i].SerialNumbers[k].Status = "completed"
-					items[i].SerialNumbers[k].ID = serialItem.ID
-				}
-
-				// Mark item as completed
-				items[i].Status = tools.StrPtr("completed")
-			}
-
-			if article.TrackByLot && items[i].LotNumbers != nil {
-				// Check if given lots sum matches expected quantity
-				var totalLotQty float64
-
-				for _, lot := range items[i].LotNumbers {
-					totalLotQty += lot.Quantity
-				}
-
-				if int(totalLotQty) != items[i].ExpectedQuantity {
-					*handledResp = responses.InternalResponse{Message: fmt.Sprintf("La cantidad total de lotes (%.2f) no coincide con la cantidad esperada (%d) para el SKU %s", totalLotQty, items[i].ExpectedQuantity, sku), Handled: true}
-
-					return nil
-				}
-
-				for j := 0; j < len(items[i].LotNumbers); j++ {
-					lotNum := items[i].LotNumbers[j]
-
-					var lot database.Lot
-
-					// Check if lot exists for this SKU
-					if err := tx.Where("lot_number = ? AND sku = ?", lotNum.LotNumber, sku).First(&lot).Error; err != nil {
-						if err == gorm.ErrRecordNotFound {
-							*handledResp = responses.InternalResponse{Message: fmt.Sprintf("El número de lote %s para el SKU %s no se encontró en el inventario", lotNum.LotNumber, sku), Handled: true}
-							return nil
-						}
-						return fmt.Errorf("find lot %s for SKU %s: %w", lotNum.LotNumber, sku, err)
-					}
-
-					// Check if lot has enough quantity
-					if lot.Quantity < lotNum.Quantity {
-						*handledResp = responses.InternalResponse{Message: fmt.Sprintf("No hay suficiente cantidad en el número de lote %s para el SKU %s (disponible: %.2f, requerido: %.2f)", lotNum.LotNumber, sku, lot.Quantity, lotNum.Quantity), Handled: true}
-						return nil
-					}
-
-					// Deduct lot quantity
-					lot.Quantity -= lotNum.Quantity
-					lot.UpdatedAt = tools.GetCurrentTime()
-
-					if err := tx.Save(&lot).Error; err != nil {
-						return fmt.Errorf("update lot %s for SKU %s: %w", lotNum.LotNumber, sku, err)
-					}
-
-					// Mark lot as completed in the task and deliverd quantity
-					items[i].LotNumbers[j].Status = tools.StrPtr("completed")
-					items[i].LotNumbers[j].ReceivedQuantity = &lotNum.Quantity
-				}
-
-				// Mark item as completed
-				items[i].Status = tools.StrPtr("completed")
-			}
-		}
-
-		updatedItems, err := json.Marshal(items)
-		if err != nil {
-			return fmt.Errorf("marshal updated items: %w", err)
-		}
-
-		task.Items = updatedItems
-
-		clean := map[string]interface{}{
-			"status":       "closed",
-			"items":        updatedItems,
-			"completed_at": tools.GetCurrentTime(),
-			"updated_at":   tools.GetCurrentTime(),
-		}
-
-		if err := tx.Model(&task).Updates(clean).Error; err != nil {
-			return fmt.Errorf("update picking task: %w", err)
-		}
-
-		return nil
-	})
-
-	if err != nil {
-		return &responses.InternalResponse{Error: err, Message: "Transacción fallida"}
-	}
-
-	if handledResp.Error != nil || handledResp.Handled {
-		return handledResp
-	}
-
-	return nil
-}
-
-func (r *PickingTaskRepository) CompletePickingLine(id string, location, userId string, item requests.PickingTaskItemRequest) *responses.InternalResponse {
-	handledResp := &responses.InternalResponse{}
-
-	err := r.DB.Transaction(func(tx *gorm.DB) error {
-		var task database.PickingTask
-
-		if err := r.DB.First(&task, "id = ?", id).Error; err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				*handledResp = responses.InternalResponse{Message: "Tarea de picking no encontrada", Handled: true}
-				return nil
-			}
-			*handledResp = responses.InternalResponse{Error: err, Message: "Error al obtener la tarea de picking"}
-			return nil
-		}
-
-		var items []requests.PickingTaskItemRequest
-		var foundItem *requests.PickingTaskItemRequest
-
-		if err := json.Unmarshal(task.Items, &items); err != nil {
-			*handledResp = responses.InternalResponse{Error: err, Message: "Formato de items inválido", Handled: true}
-			return nil
-		}
-
-		found := false
-
-		for i := 0; i < len(items); i++ {
-			if items[i].SKU == item.SKU && items[i].Location == item.Location {
-				foundItem = &items[i]
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			*handledResp = responses.InternalResponse{Message: "Item no encontrado en la tarea de picking", Handled: true}
-			return nil
-		}
-
-		var article database.Article
-
-		if err := tx.Where("sku = ?", foundItem.SKU).First(&article).Error; err != nil {
-			if err == gorm.ErrRecordNotFound {
-				*handledResp = responses.InternalResponse{Message: "Artículo no encontrado para el SKU " + foundItem.SKU, Handled: true}
-				return nil
-			}
-			return fmt.Errorf("find article %s: %w", foundItem.SKU, err)
-		}
-
-		if foundItem.Status != nil && (*foundItem.Status == "completed" || *foundItem.Status == "closed" || *foundItem.Status == "partial") {
-			*handledResp = responses.InternalResponse{Message: "Artículo ya procesado", Handled: true}
-			return nil
-		}
-
-		var qty float64
-		if article.TrackByLot && item.LotNumbers != nil {
-			for _, lot := range item.LotNumbers {
-				qty += lot.Quantity
-			}
-		} else if article.TrackBySerial && item.SerialNumbers != nil {
-			qty = float64(len(item.SerialNumbers))
-		} else {
-			qty = tools.IntToFloat64(item.ExpectedQuantity)
-		}
-
-		if qty <= 0 || qty < float64(foundItem.ExpectedQuantity) {
-			// Update items status to partial for this SKU
-			for i := 0; i < len(items); i++ {
-				if items[i].SKU == item.SKU {
-					items[i].Status = tools.StrPtr("partial")
-					items[i].DeliveredQuantity = tools.IntToPtr(int(qty))
-					break
-				}
-			}
-
-			updatedItems, err := json.Marshal(items)
-			if err != nil {
-				return fmt.Errorf("marshal updated items: %w", err)
-			}
-
-			task.Items = updatedItems
-
-			clean := map[string]interface{}{
-				"items":      updatedItems,
-				"updated_at": tools.GetCurrentTime(),
-			}
-
-			if err := tx.Model(&task).Updates(clean).Error; err != nil {
-				*handledResp = responses.InternalResponse{Error: err, Message: "Error al actualizar la tarea de picking"}
-				return nil
-			}
-		} else {
-			// If given quantity meets or exceeds expected, mark item as completed
-			for i := 0; i < len(items); i++ {
-				if items[i].SKU == item.SKU {
-					items[i].Status = tools.StrPtr("completed")
-					items[i].DeliveredQuantity = tools.IntToPtr(int(qty))
-					break
-				}
-			}
-		}
-
-		var inventory database.Inventory
-
-		// Check if there is enough stock in the specified location
-		if err := tx.Where("sku = ? AND location = ?", item.SKU, location).First(&inventory).Error; err != nil {
-			if err == gorm.ErrRecordNotFound {
-				return fmt.Errorf("no hay suficiente stock para SKU %s en location %s", item.SKU, location)
-			}
-			return fmt.Errorf("find inventory %s in %s: %w", item.SKU, location, err)
-		}
-
-		if inventory.Quantity < qty {
-			*handledResp = responses.InternalResponse{Message: fmt.Sprintf("No hay suficiente stock para SKU %s en location %s", item.SKU, location), Handled: true}
-
-			return nil
-		}
-
-		// Deduct the stock
-		newQty := inventory.Quantity - qty
-
-		if err := tx.Model(&database.Inventory{}).Where("id = ?", inventory.ID).
-			Update("quantity", newQty).Error; err != nil {
-			return fmt.Errorf("update inventory %s in %s: %w", item.SKU, location, err)
-		}
-
-		// Create inventory movement record
-		movement := database.InventoryMovement{
-			SKU:            item.SKU,
-			Location:       location,
-			MovementType:   "picking",
-			Quantity:       qty,
-			RemainingStock: newQty,
-			Reason:         tools.StrPtr(fmt.Sprintf("Picking Task %s", task.TaskID)),
-			CreatedBy:      task.CreatedBy,
-			CreatedAt:      tools.GetCurrentTime(),
-		}
-
-		if err := tx.Create(&movement).Error; err != nil {
-			return fmt.Errorf("error al crear movimiento de inventario para %s en %s: %w", item.SKU, location, err)
-		}
-
-		if article.TrackBySerial && item.SerialNumbers != nil {
-			for k := 0; k < len(item.SerialNumbers); k++ {
-				serial := item.SerialNumbers[k]
-
-				// Check if serial is in stock and available
-				var serialItem database.Serial
-				if err := tx.Where("serial_number = ? AND sku = ? AND status = 'available'", serial.SerialNumber, item.SKU).First(&serialItem).Error; err != nil {
-					if err == gorm.ErrRecordNotFound {
-						*handledResp = responses.InternalResponse{Message: fmt.Sprintf("Número de serie %s para SKU %s no encontrado en inventario", serial.SerialNumber, item.SKU), Handled: true}
-						return nil
-					}
-					return fmt.Errorf("find serial %s for SKU %s: %w", serial.SerialNumber, item.SKU, err)
-				}
-
-				// Mark serial as picked
-				serialItem.Status = "picked"
-				serialItem.UpdatedAt = tools.GetCurrentTime()
-
-				// Iterate over items for this SKU and then itereate over serials to check if already in task
-				alreadyInTask := false
-				for i := 0; i < len(items); i++ {
-					if items[i].SKU == item.SKU {
-						for j := 0; j < len(items[i].SerialNumbers); j++ {
-							if items[i].SerialNumbers[j].SerialNumber == serial.SerialNumber {
-								alreadyInTask = true
-								break
-							}
-						}
-						break
-					}
-				}
-
-				// If not, append it
-				if !alreadyInTask {
-					for i := 0; i < len(items); i++ {
-						if items[i].SKU == item.SKU {
-							items[i].SerialNumbers = append(items[i].SerialNumbers, database.Serial{
-								ID:           serialItem.ID,
-								SerialNumber: serial.SerialNumber,
-								SKU:          item.SKU,
-								Status:       "completed",
-								CreatedAt:    serialItem.CreatedAt,
-								UpdatedAt:    serialItem.UpdatedAt,
-							})
-							break
-						}
-					}
-				}
-
-				if err := tx.Save(&serialItem).Error; err != nil {
-					return fmt.Errorf("update serial %s for SKU %s: %w", serial.SerialNumber, item.SKU, err)
-				}
-
-				// Mark items serial as completed
-				for i := 0; i < len(items); i++ {
-					if items[i].SKU == item.SKU {
-						for j := 0; j < len(items[i].SerialNumbers); j++ {
-							if items[i].SerialNumbers[j].SerialNumber == serial.SerialNumber {
-								items[i].SerialNumbers[j].Status = "completed"
-								items[i].SerialNumbers[j].ID = serialItem.ID
-								break
-							}
-						}
-						break
-					}
-				}
-			}
-
-			if len(item.SerialNumbers) == foundItem.ExpectedQuantity {
-				item.Status = tools.StrPtr("completed")
-			} else {
-				item.Status = tools.StrPtr("partial")
-			}
-		}
-
-		if article.TrackByLot && item.LotNumbers != nil {
-			for j := 0; j < len(item.LotNumbers); j++ {
-				lotNum := item.LotNumbers[j]
-
-				var lot database.Lot
-
-				// Check if lot exists for this SKU
-				if err := tx.Where("lot_number = ? AND sku = ?", lotNum.LotNumber, item.SKU).First(&lot).Error; err != nil {
-					if err == gorm.ErrRecordNotFound {
-						*handledResp = responses.InternalResponse{Message: fmt.Sprintf("Número de lote %s para SKU %s no encontrado en inventario", lotNum.LotNumber, item.SKU), Handled: true}
-						return nil
-					}
-					return fmt.Errorf("find lot %s for SKU %s: %w", lotNum.LotNumber, item.SKU, err)
-				}
-
-				// Check if lot has enough quantity
-				if lot.Quantity < lotNum.Quantity {
-					*handledResp = responses.InternalResponse{Message: fmt.Sprintf("No hay suficiente cantidad en el número de lote %s para SKU %s (disponible: %.2f, requerido: %.2f)", lotNum.LotNumber, item.SKU, lot.Quantity, lotNum.Quantity), Handled: true}
-					return nil
-				}
-
-				// Deduct lot quantity
-				lot.Quantity -= lotNum.Quantity
-				lot.UpdatedAt = tools.GetCurrentTime()
-
-				if err := tx.Save(&lot).Error; err != nil {
-					return fmt.Errorf("update lot %s for SKU %s: %w", lotNum.LotNumber, item.SKU, err)
-				}
-
-				if lot.Quantity != item.LotNumbers[j].Quantity {
-					for i := 0; i < len(items); i++ {
-						if items[i].SKU == item.SKU {
-							for k := 0; k < len(items[i].LotNumbers); k++ {
-								if items[i].LotNumbers[k].LotNumber == lot.LotNumber {
-									items[i].LotNumbers[k].Status = tools.StrPtr("partial")
-									items[i].LotNumbers[k].ReceivedQuantity = &lotNum.Quantity
-									break
-								}
-							}
-							items[i].Status = tools.StrPtr("partial")
-							break
-						}
-					}
-				}
-
-				// Mark lot as completed in the task and deliverd quantity
-				for i := 0; i < len(items); i++ {
-					if items[i].SKU == item.SKU {
-						alreadyInTask := false
-						for k := 0; k < len(items[i].LotNumbers); k++ {
-							if items[i].LotNumbers[k].LotNumber == lotNum.LotNumber {
-								items[i].LotNumbers[k].Status = tools.StrPtr("completed")
-								items[i].LotNumbers[k].ReceivedQuantity = &lotNum.Quantity
-								alreadyInTask = true
-								break
-							}
-						}
-
-						if !alreadyInTask {
-							items[i].LotNumbers = append(items[i].LotNumbers, requests.CreateLotRequest{
-								LotNumber:        lotNum.LotNumber,
-								SKU:              item.SKU,
-								Quantity:         lotNum.Quantity,
-								ReceivedQuantity: &lotNum.Quantity,
-								Status:           tools.StrPtr("completed"),
-							})
-						}
-
-						break
-					}
-				}
-			}
-
-			// If total lot quantity meets expected, mark item as completed
-			for i := 0; i < len(items); i++ {
-				if items[i].SKU == item.SKU {
-					if qty >= float64(foundItem.ExpectedQuantity) {
-						items[i].Status = tools.StrPtr("completed")
-					} else {
-						items[i].Status = tools.StrPtr("partial")
-					}
-					break
-				}
-			}
-		}
-
-		updatedItems, err := json.Marshal(items)
-		if err != nil {
-			return fmt.Errorf("marshal updated items: %w", err)
-		}
-
-		task.Items = updatedItems
-
-		clean := map[string]interface{}{
-			"items":        updatedItems,
-			"completed_at": tools.GetCurrentTime(),
-			"updated_at":   tools.GetCurrentTime(),
-		}
-
-		if err := tx.Model(&task).Updates(clean).Error; err != nil {
-			return fmt.Errorf("update picking task: %w", err)
-		}
-
-		return nil
-	})
-
-	if err != nil {
-		return &responses.InternalResponse{Error: err, Message: "Error en la transacción"}
-	}
-
-	if handledResp.Error != nil || handledResp.Handled {
-		return handledResp
-	}
-
-	return nil
 }
 
 func (r *PickingTaskRepository) GenerateImportTemplate(language string) ([]byte, error) {
 	isEs := language != "en"
 	l2 := getLang(language)
 	_, _ = l2["yes"], l2["no"]
-	title := "Importar Tareas de Picking"; subtitle := "Plantilla de importación — eSTOCK"
-	instrTitle := "📋 Instrucciones"; instrContent := "1. Complete desde la fila 9  •  2. SKU, Cantidad Solicitada, Ubicación y Asignado A son obligatorios (*)  •  3. Lotes y seriales: separe con comas"
+	title := "Importar Tareas de Picking"
+	subtitle := "Plantilla de importación — eSTOCK"
+	instrTitle := "📋 Instrucciones"
+	instrContent := "1. Complete desde la fila 9  •  2. SKU, Cantidad Solicitada, Ubicación y Asignado A son obligatorios (*)  •  3. Lotes y seriales: separe con comas"
 	if !isEs {
-		title = "Import Picking Tasks"; subtitle = "Picking task import template — eSTOCK"
-		instrTitle = "📋 Instructions"; instrContent = "1. Fill in data from row 9  •  2. SKU, Requested Quantity, Location and Assigned To are required (*)  •  3. Lots and serials: separate with commas"
+		title = "Import Picking Tasks"
+		subtitle = "Picking task import template — eSTOCK"
+		instrTitle = "📋 Instructions"
+		instrContent = "1. Fill in data from row 9  •  2. SKU, Requested Quantity, Location and Assigned To are required (*)  •  3. Lots and serials: separate with commas"
 	}
 	prios := []string{"normal", "low", "high"}
 
 	cfg := ModuleTemplateConfig{
-		DataSheetName: func() string { if isEs { return "Picking" }; return "PickingTasks" }(),
-		OptSheetName:  func() string { if isEs { return "Opciones" }; return "Options" }(),
+		DataSheetName: func() string {
+			if isEs {
+				return "Picking"
+			}
+			return "PickingTasks"
+		}(),
+		OptSheetName: func() string {
+			if isEs {
+				return "Opciones"
+			}
+			return "Options"
+		}(),
 		Title: title, Subtitle: subtitle, InstrTitle: instrTitle, InstrContent: instrContent,
 		Columns: func() []ColumnDef {
 			if isEs {
@@ -1184,10 +1131,18 @@ func (r *PickingTaskRepository) GenerateImportTemplate(language string) ([]byte,
 		ExampleRow: []string{"SKU-0001", "25", "LOC-001", "", "", "ORD-001", "operator@company.com", "normal", ""},
 		ApplyValidations: func(f *excelize.File, dataSheet, optSheet string, start, end int) error {
 			f.NewSheet(optSheet)
-			for i, v := range prios { cell, _ := excelize.CoordinatesToCellName(1, i+1); f.SetCellValue(optSheet, cell, v) }
+			for i, v := range prios {
+				cell, _ := excelize.CoordinatesToCellName(1, i+1)
+				f.SetCellValue(optSheet, cell, v)
+			}
 			f.SetSheetVisible(optSheet, false)
 			prioRef := "'" + optSheet + "'!$A$1:$A$3"
-			errPrio := func() string { if isEs { return "Prioridad inválida" }; return "Invalid priority" }()
+			errPrio := func() string {
+				if isEs {
+					return "Prioridad inválida"
+				}
+				return "Invalid priority"
+			}()
 			return addDropListValidation(f, dataSheet, "H9:H2000", prioRef, errPrio, errPrio)
 		},
 	}

--- a/routes/picking_task_routes.go
+++ b/routes/picking_task_routes.go
@@ -27,10 +27,9 @@ func RegisterPickingTasksRoutes(router *gin.RouterGroup, db *gorm.DB, config con
 		route.PATCH("/:id/start", pickingTasksController.StartPickingTask)
 		route.PATCH("/:id/cancel", pickingTasksController.CancelPickingTask)
 		route.PATCH("/:id/complete", pickingTasksController.CompletePickingTask)
+		route.PATCH("/:id/complete-line", pickingTasksController.CompletePickingLine)
 		route.GET("/import/template", pickingTasksController.DownloadImportTemplate)
 		route.POST("/import", pickingTasksController.ImportPickingTaskFromExcel)
 		route.GET("/export", pickingTasksController.ExportPickingTasksToExcel)
-		route.PATCH("/complete-full-task/:id/:location", pickingTasksController.CompletePickingTask)
-		route.PATCH("/complete-picking-line/:id/:location", pickingTasksController.CompletePickingLine)
 	}
 }

--- a/services/picking_task_service.go
+++ b/services/picking_task_service.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"context"
+
 	"github.com/eflowcr/eSTOCK_backend/models/database"
 	"github.com/eflowcr/eSTOCK_backend/models/requests"
 	"github.com/eflowcr/eSTOCK_backend/models/responses"
@@ -12,9 +14,7 @@ type PickingTaskService struct {
 }
 
 func NewPickingTaskService(repo ports.PickingTaskRepository) *PickingTaskService {
-	return &PickingTaskService{
-		Repository: repo,
-	}
+	return &PickingTaskService{Repository: repo}
 }
 
 func (s *PickingTaskService) GetAllPickingTasks() ([]responses.PickingTaskView, *responses.InternalResponse) {
@@ -29,8 +29,12 @@ func (s *PickingTaskService) CreatePickingTask(userId string, task *requests.Cre
 	return s.Repository.CreatePickingTask(userId, task)
 }
 
-func (s *PickingTaskService) UpdatePickingTask(id string, data map[string]interface{}) *responses.InternalResponse {
-	return s.Repository.UpdatePickingTask(id, data)
+func (s *PickingTaskService) StartPickingTask(ctx context.Context, id, userId string) *responses.InternalResponse {
+	return s.Repository.StartPickingTask(ctx, id, userId)
+}
+
+func (s *PickingTaskService) UpdatePickingTask(ctx context.Context, id string, data map[string]interface{}, userId string) *responses.InternalResponse {
+	return s.Repository.UpdatePickingTask(ctx, id, data, userId)
 }
 
 func (s *PickingTaskService) ImportPickingTaskFromExcel(userID string, fileBytes []byte) *responses.InternalResponse {
@@ -41,12 +45,12 @@ func (s *PickingTaskService) ExportPickingTasksToExcel() ([]byte, *responses.Int
 	return s.Repository.ExportPickingTasksToExcel()
 }
 
-func (s *PickingTaskService) CompletePickingTask(id string, location, userId string) *responses.InternalResponse {
-	return s.Repository.CompletePickingTask(id, location, userId)
+func (s *PickingTaskService) CompletePickingTask(ctx context.Context, id, userId string) *responses.InternalResponse {
+	return s.Repository.CompletePickingTask(ctx, id, userId)
 }
 
-func (s *PickingTaskService) CompletePickingLine(id string, location, userId string, item requests.PickingTaskItemRequest) *responses.InternalResponse {
-	return s.Repository.CompletePickingLine(id, location, userId, item)
+func (s *PickingTaskService) CompletePickingLine(ctx context.Context, id, userId string, item requests.PickingTaskItemRequest) *responses.InternalResponse {
+	return s.Repository.CompletePickingLine(ctx, id, userId, item)
 }
 
 func (s *PickingTaskService) GenerateImportTemplate(language string) ([]byte, error) {

--- a/services/picking_task_service_test.go
+++ b/services/picking_task_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -13,19 +14,20 @@ import (
 
 // mockPickingTaskRepo is an in-memory fake for unit testing PickingTaskService.
 type mockPickingTaskRepo struct {
-	allTasks          []responses.PickingTaskView
-	allTasksErr       *responses.InternalResponse
-	byID              map[string]*database.PickingTask
-	byIDErr           *responses.InternalResponse
-	createErr         *responses.InternalResponse
-	updateErr         *responses.InternalResponse
-	importErr         *responses.InternalResponse
-	exportBytes       []byte
-	exportErr         *responses.InternalResponse
-	completeTaskErr   *responses.InternalResponse
-	completeLineErr   *responses.InternalResponse
-	templateBytes     []byte
-	templateErr       error
+	allTasks        []responses.PickingTaskView
+	allTasksErr     *responses.InternalResponse
+	byID            map[string]*database.PickingTask
+	byIDErr         *responses.InternalResponse
+	createErr       *responses.InternalResponse
+	startErr        *responses.InternalResponse
+	updateErr       *responses.InternalResponse
+	importErr       *responses.InternalResponse
+	exportBytes     []byte
+	exportErr       *responses.InternalResponse
+	completeTaskErr *responses.InternalResponse
+	completeLineErr *responses.InternalResponse
+	templateBytes   []byte
+	templateErr     error
 }
 
 func (m *mockPickingTaskRepo) GetAllPickingTasks() ([]responses.PickingTaskView, *responses.InternalResponse) {
@@ -52,7 +54,11 @@ func (m *mockPickingTaskRepo) CreatePickingTask(userId string, task *requests.Cr
 	return m.createErr
 }
 
-func (m *mockPickingTaskRepo) UpdatePickingTask(id string, data map[string]interface{}) *responses.InternalResponse {
+func (m *mockPickingTaskRepo) StartPickingTask(_ context.Context, id, userId string) *responses.InternalResponse {
+	return m.startErr
+}
+
+func (m *mockPickingTaskRepo) UpdatePickingTask(_ context.Context, id string, data map[string]interface{}, userId string) *responses.InternalResponse {
 	return m.updateErr
 }
 
@@ -64,11 +70,11 @@ func (m *mockPickingTaskRepo) ExportPickingTasksToExcel() ([]byte, *responses.In
 	return m.exportBytes, m.exportErr
 }
 
-func (m *mockPickingTaskRepo) CompletePickingTask(id string, location, userId string) *responses.InternalResponse {
+func (m *mockPickingTaskRepo) CompletePickingTask(_ context.Context, id, userId string) *responses.InternalResponse {
 	return m.completeTaskErr
 }
 
-func (m *mockPickingTaskRepo) CompletePickingLine(id string, location, userId string, item requests.PickingTaskItemRequest) *responses.InternalResponse {
+func (m *mockPickingTaskRepo) CompletePickingLine(_ context.Context, id, userId string, item requests.PickingTaskItemRequest) *responses.InternalResponse {
 	return m.completeLineErr
 }
 
@@ -158,10 +164,31 @@ func TestPickingTaskService_CreatePickingTask_Error(t *testing.T) {
 	assert.Equal(t, responses.StatusConflict, errResp.StatusCode)
 }
 
+func TestPickingTaskService_StartPickingTask_Success(t *testing.T) {
+	repo := &mockPickingTaskRepo{}
+	svc := NewPickingTaskService(repo)
+	errResp := svc.StartPickingTask(context.Background(), "1", "user-1")
+	require.Nil(t, errResp)
+}
+
+func TestPickingTaskService_StartPickingTask_Error(t *testing.T) {
+	repo := &mockPickingTaskRepo{
+		startErr: &responses.InternalResponse{
+			Message:    "insufficient stock",
+			Handled:    true,
+			StatusCode: responses.StatusBadRequest,
+		},
+	}
+	svc := NewPickingTaskService(repo)
+	errResp := svc.StartPickingTask(context.Background(), "1", "user-1")
+	require.NotNil(t, errResp)
+	assert.Equal(t, responses.StatusBadRequest, errResp.StatusCode)
+}
+
 func TestPickingTaskService_UpdatePickingTask_Success(t *testing.T) {
 	repo := &mockPickingTaskRepo{}
 	svc := NewPickingTaskService(repo)
-	errResp := svc.UpdatePickingTask("1", map[string]interface{}{"status": "in_progress"})
+	errResp := svc.UpdatePickingTask(context.Background(), "1", map[string]interface{}{"status": "in_progress"}, "user-1")
 	require.Nil(t, errResp)
 }
 
@@ -174,7 +201,7 @@ func TestPickingTaskService_UpdatePickingTask_Error(t *testing.T) {
 		},
 	}
 	svc := NewPickingTaskService(repo)
-	errResp := svc.UpdatePickingTask("99", map[string]interface{}{"status": "in_progress"})
+	errResp := svc.UpdatePickingTask(context.Background(), "99", map[string]interface{}{"status": "in_progress"}, "user-1")
 	require.NotNil(t, errResp)
 	assert.Equal(t, responses.StatusNotFound, errResp.StatusCode)
 }
@@ -201,9 +228,7 @@ func TestPickingTaskService_ImportPickingTaskFromExcel_Error(t *testing.T) {
 }
 
 func TestPickingTaskService_ExportPickingTasksToExcel_Success(t *testing.T) {
-	repo := &mockPickingTaskRepo{
-		exportBytes: []byte("excel-data"),
-	}
+	repo := &mockPickingTaskRepo{exportBytes: []byte("excel-data")}
 	svc := NewPickingTaskService(repo)
 	data, errResp := svc.ExportPickingTasksToExcel()
 	require.Nil(t, errResp)
@@ -227,7 +252,7 @@ func TestPickingTaskService_ExportPickingTasksToExcel_Error(t *testing.T) {
 func TestPickingTaskService_CompletePickingTask_Success(t *testing.T) {
 	repo := &mockPickingTaskRepo{}
 	svc := NewPickingTaskService(repo)
-	errResp := svc.CompletePickingTask("1", "LOC-A", "user-1")
+	errResp := svc.CompletePickingTask(context.Background(), "1", "user-1")
 	require.Nil(t, errResp)
 }
 
@@ -240,7 +265,7 @@ func TestPickingTaskService_CompletePickingTask_Error(t *testing.T) {
 		},
 	}
 	svc := NewPickingTaskService(repo)
-	errResp := svc.CompletePickingTask("1", "LOC-A", "user-1")
+	errResp := svc.CompletePickingTask(context.Background(), "1", "user-1")
 	require.NotNil(t, errResp)
 	assert.Equal(t, responses.StatusBadRequest, errResp.StatusCode)
 }
@@ -251,9 +276,11 @@ func TestPickingTaskService_CompletePickingLine_Success(t *testing.T) {
 	item := requests.PickingTaskItemRequest{
 		SKU:              "SKU-001",
 		ExpectedQuantity: 10,
-		Location:         "LOC-A",
+		Allocations: []database.LocationAllocation{
+			{Location: "LOC-A", Quantity: 10},
+		},
 	}
-	errResp := svc.CompletePickingLine("1", "LOC-A", "user-1", item)
+	errResp := svc.CompletePickingLine(context.Background(), "1", "user-1", item)
 	require.Nil(t, errResp)
 }
 
@@ -266,16 +293,19 @@ func TestPickingTaskService_CompletePickingLine_Error(t *testing.T) {
 		},
 	}
 	svc := NewPickingTaskService(repo)
-	item := requests.PickingTaskItemRequest{SKU: "SKU-001", Location: "LOC-A"}
-	errResp := svc.CompletePickingLine("99", "LOC-A", "user-1", item)
+	item := requests.PickingTaskItemRequest{
+		SKU: "SKU-001",
+		Allocations: []database.LocationAllocation{
+			{Location: "LOC-A", Quantity: 5},
+		},
+	}
+	errResp := svc.CompletePickingLine(context.Background(), "99", "user-1", item)
 	require.NotNil(t, errResp)
 	assert.Equal(t, responses.StatusNotFound, errResp.StatusCode)
 }
 
 func TestPickingTaskService_GenerateImportTemplate_Success(t *testing.T) {
-	repo := &mockPickingTaskRepo{
-		templateBytes: []byte("template-data"),
-	}
+	repo := &mockPickingTaskRepo{templateBytes: []byte("template-data")}
 	svc := NewPickingTaskService(repo)
 	data, err := svc.GenerateImportTemplate("es")
 	require.NoError(t, err)
@@ -283,9 +313,7 @@ func TestPickingTaskService_GenerateImportTemplate_Success(t *testing.T) {
 }
 
 func TestPickingTaskService_GenerateImportTemplate_Error(t *testing.T) {
-	repo := &mockPickingTaskRepo{
-		templateErr: errors.New("unsupported language"),
-	}
+	repo := &mockPickingTaskRepo{templateErr: errors.New("unsupported language")}
 	svc := NewPickingTaskService(repo)
 	data, err := svc.GenerateImportTemplate("xx")
 	require.Error(t, err)

--- a/services/stock_transfers_service.go
+++ b/services/stock_transfers_service.go
@@ -150,11 +150,24 @@ func (s *StockTransfersService) ExecuteTransfer(transferID, userID string) (*dat
 			qty := line.Quantity
 
 			var fromInv database.Inventory
-			if err := tx.Where("sku = ? AND location = ?", sku, fromCode).First(&fromInv).Error; err != nil {
-				if errors.Is(err, gorm.ErrRecordNotFound) {
-					return fmt.Errorf("insufficient stock: SKU %s not found at source location %s", sku, fromCode)
-				}
+			// Lock the inventory row to prevent race conditions during concurrent transfers
+			// or simultaneous picking operations (B3e A5).
+			if err := tx.Raw(
+				`SELECT id, sku, location, quantity, reserved_qty FROM inventory WHERE sku = ? AND location = ? FOR UPDATE`,
+				sku, fromCode,
+			).Scan(&fromInv).Error; err != nil {
 				return fmt.Errorf("find inventory %s at %s: %w", sku, fromCode, err)
+			}
+			if fromInv.ID == "" {
+				return fmt.Errorf("insufficient stock: SKU %s not found at source location %s", sku, fromCode)
+			}
+			// B3e (A5): check available (non-reserved) stock.
+			available := fromInv.Quantity - fromInv.ReservedQty
+			if qty > available {
+				return fmt.Errorf(
+					"no puede transferir %.2f de %s en %s — hay %.2f reservadas en pickings activos (disponible: %.2f)",
+					qty, sku, fromCode, fromInv.ReservedQty, available,
+				)
 			}
 			if fromInv.Quantity < qty {
 				return fmt.Errorf("insufficient stock: SKU %s at %s has %.3f, need %.3f", sku, fromCode, fromInv.Quantity, qty)

--- a/wire/wire.go
+++ b/wire/wire.go
@@ -168,8 +168,13 @@ func NewLots(db *gorm.DB, pool *pgxpool.Pool) (ports.LotsRepository, *services.L
 	return r, services.NewLotsService(r, articlesRepo)
 }
 
-func NewPickingTask(db *gorm.DB) (ports.PickingTaskRepository, *services.PickingTaskService) {
+// NewPickingTask builds PickingTaskRepository (with optional AuditService) and PickingTaskService.
+// When pool is non-nil, audit logging is enabled; otherwise AuditService is nil (graceful no-op).
+func NewPickingTask(db *gorm.DB, auditSvc ...*services.AuditService) (ports.PickingTaskRepository, *services.PickingTaskService) {
 	r := &repositories.PickingTaskRepository{DB: db}
+	if len(auditSvc) > 0 {
+		r.AuditService = auditSvc[0]
+	}
 	return r, services.NewPickingTaskService(r)
 }
 


### PR DESCRIPTION
## Summary

- **H1** — `PickingTaskItemRequest` updated: `Allocations []LocationAllocation` replaces `Location string`, `ExpectedQuantity float64`, `PickedQty *float64`, `ValidateAllocationSum()` method.
- **H2** — `parsePickingItemsWithLegacyFallback`: accepts old single-location items and synthesizes a single allocation transparently.
- **B3a** — `StartPickingTask` (new method): transitions `open|assigned → in_progress`, applies lazy reservations via conditional `UPDATE … WHERE (quantity - reserved_qty) >= ?`.
- **B3b** — `UpdatePickingTask` full rewrite: recalculates reservations when items change while `in_progress` (release old → validate → apply new).
- **B3c** — Cancel from `in_progress` releases all reservations via `GREATEST(0, reserved_qty - ?)`.
- **B3d** — `CompletePickingLine`: iterates allocations; decrements `inventory.quantity` + `reserved_qty` + `inventory_lots.quantity` + `lots.quantity`.
- **B3e** — `AdjustmentsRepository.CreateAdjustment` blocks if `new_qty < reserved_qty`. `StockTransfersService.ExecuteTransfer` locks row `FOR UPDATE` and blocks if `transfer_qty > available`.
- **H5** — `CompletePickingTask` removes `location` param; iterates all item allocations; detects differences → `completed_with_differences`.
- **Excel import** — TODO B3 resolved: Location column → single allocation, lot/serial numbers hydrated.
- **Tests**: 16 unit tests (state machine + H1/H2/sanitize) + 15 integration stubs (B3a-e + H5) + updated mocks in service/controller tests.

## Decisions

- `lot status = 'active'` confirmed (no `'available'` consumers found).
- `CompleteFullTask` old lot path (`Count + First + Save`) was replaced with allocation-aware decrement.
- Old `isValidPickingStatusTransition` removed; all code uses `isValidPickingTransition` (H4).
- `wire.NewPickingTask` accepts optional `AuditService` via variadic arg for backward compatibility.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -count=1 -short` — all PASS (integration tests skip without Docker)
- [ ] Integration tests (`-run TestPickingB3`) require Docker/testcontainers — run in CI