### PR TITLE
ci: migrate deploy to VPS Manager webhook + env-aware registry

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -6,8 +6,9 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: eflowcr/estock-backend
+  REGISTRY: registry.eflowsuite.com
+  IMAGE_PATH: dev/estock-backend
+  VPSM_PROJECT_ID: 3z011zx2w122wz2w112ww
 
 jobs:
   test:
@@ -25,29 +26,17 @@ jobs:
   build-and-push:
     needs: test
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v4
 
       - uses: docker/setup-buildx-action@v3
 
-      - name: Login to GHCR
+      - name: Login to eflowsuite registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          labels: |
-            org.opencontainers.image.title=estock-backend
-            org.opencontainers.image.vendor=eflowcr
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Build and Push
         uses: docker/build-push-action@v5
@@ -56,23 +45,31 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-${{ github.sha }}
-          labels: ${{ steps.meta.outputs.labels }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}:${{ github.sha }}
+          labels: |
+            org.opencontainers.image.title=estock-backend
+            org.opencontainers.image.vendor=eflowcr
+            org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Notify VPS Manager — update all client stacks
+  notify-vps-manager:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger redeploy via VPS Manager webhook
+        env:
+          WEBHOOK_URL: ${{ secrets.VPSM_WEBHOOK_URL }}
+          WEBHOOK_SECRET: ${{ secrets.VPSM_WEBHOOK_SECRET }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}
+          TAG: latest
+          PROJECT_ID: ${{ env.VPSM_PROJECT_ID }}
         run: |
-          curl -sf -X POST \
-            -H "Authorization: Bearer ${{ secrets.VPS_SECRET_TOKEN }}" \
+          RESPONSE=$(curl -sf -w "\nHTTP:%{http_code}" -X POST \
+            -H "Authorization: Bearer ${WEBHOOK_SECRET}" \
             -H "Content-Type: application/json" \
-            -d "{\"image_tag\":\"dev-${{ github.sha }}\",\"environment\":\"development\"}" \
-            "https://vps-manager-api.31.97.145.251.nip.io/api/v1/stacks/update" \
-            && echo "✅ Client stacks update triggered" \
-            || echo "⚠️  No active client stacks (or update skipped)"
-
-      - name: Verify
-        run: |
-          echo "✅ ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev pushed"
-          echo "Branch: ${{ github.ref_name }} | SHA: ${{ github.sha }}"
+            -d "{\"image\":\"${IMAGE}\",\"tag\":\"${TAG}\",\"project_id\":\"${PROJECT_ID}\"}" \
+            "${WEBHOOK_URL}")
+          echo "${RESPONSE}"
+          echo "${RESPONSE}" | grep -q "HTTP:200" || exit 1

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,4 +1,4 @@
-name: Build & Deploy Backend (Main)
+name: Build & Deploy Backend (QA)
 
 on:
   push:
@@ -6,10 +6,9 @@ on:
   workflow_dispatch:
 
 env:
-  GHCR_REGISTRY: ghcr.io
-  GHCR_IMAGE: eflowcr/estock-backend
-  SELF_REGISTRY: 31.97.145.251:5000
-  SELF_IMAGE: prod/estock-backend
+  REGISTRY: registry.eflowsuite.com
+  IMAGE_PATH: qa/estock-backend
+  VPSM_PROJECT_ID: 3z011zx2w122wz2w112ww
 
 jobs:
   test:
@@ -27,55 +26,17 @@ jobs:
   build-and-push:
     needs: test
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v4
 
-      # Trust the self-hosted registry's self-signed certificate
-      - name: Trust self-hosted registry certificate
-        run: |
-          sudo mkdir -p /etc/docker/certs.d/31.97.145.251:5000
-          echo | openssl s_client -connect 31.97.145.251:5000 -servername 31.97.145.251 2>/dev/null \
-            | openssl x509 \
-            | sudo tee /etc/docker/certs.d/31.97.145.251:5000/ca.crt
-          # Also write buildkitd config for buildx
-          cat > /tmp/buildkitd.toml << 'EOF'
-          [registry."31.97.145.251:5000"]
-            ca=["/etc/docker/certs.d/31.97.145.251:5000/ca.crt"]
-          EOF
-
       - uses: docker/setup-buildx-action@v3
-        with:
-          config: /tmp/buildkitd.toml
 
-      # Login to GHCR
-      - name: Login to GHCR
+      - name: Login to eflowsuite registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Login to self-hosted registry
-      - name: Login to self-hosted registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.SELF_REGISTRY }}
+          registry: ${{ env.REGISTRY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE }}
-            ${{ env.SELF_REGISTRY }}/${{ env.SELF_IMAGE }}
-          labels: |
-            org.opencontainers.image.title=estock-backend
-            org.opencontainers.image.vendor=eflowcr
 
       - name: Build and Push
         uses: docker/build-push-action@v5
@@ -84,32 +45,31 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE }}:production
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_IMAGE }}:production-${{ github.sha }}
-            ${{ env.SELF_REGISTRY }}/${{ env.SELF_IMAGE }}:latest
-            ${{ env.SELF_REGISTRY }}/${{ env.SELF_IMAGE }}:${{ github.sha }}
-          labels: ${{ steps.meta.outputs.labels }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}:${{ github.sha }}
+          labels: |
+            org.opencontainers.image.title=estock-backend
+            org.opencontainers.image.vendor=eflowcr
+            org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Notify VPS Manager — update all client stacks
+  notify-vps-manager:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger redeploy via VPS Manager webhook
         env:
-          SHA: ${{ github.sha }}
-          VPS_SECRET_TOKEN: ${{ secrets.VPS_SECRET_TOKEN }}
+          WEBHOOK_URL: ${{ secrets.VPSM_WEBHOOK_URL }}
+          WEBHOOK_SECRET: ${{ secrets.VPSM_WEBHOOK_SECRET }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}
+          TAG: latest
+          PROJECT_ID: ${{ env.VPSM_PROJECT_ID }}
         run: |
-          curl -sf -X POST \
-            -H "Authorization: Bearer ${VPS_SECRET_TOKEN}" \
+          RESPONSE=$(curl -sf -w "\nHTTP:%{http_code}" -X POST \
+            -H "Authorization: Bearer ${WEBHOOK_SECRET}" \
             -H "Content-Type: application/json" \
-            -d "{\"image_tag\":\"production-${SHA}\",\"environment\":\"production\"}" \
-            "https://vps-manager-api.31.97.145.251.nip.io/api/v1/stacks/update" \
-            && echo "Production backend deploy triggered" \
-            || echo "No active client stacks (or update skipped)"
-
-      - name: Verify
-        env:
-          SHA: ${{ github.sha }}
-        run: |
-          echo "GHCR: ghcr.io/eflowcr/estock-backend:production pushed"
-          echo "GHCR: ghcr.io/eflowcr/estock-backend:production-${SHA} pushed"
-          echo "Self: 31.97.145.251:5000/prod/estock-backend:latest pushed"
-          echo "Self: 31.97.145.251:5000/prod/estock-backend:${SHA} pushed"
+            -d "{\"image\":\"${IMAGE}\",\"tag\":\"${TAG}\",\"project_id\":\"${PROJECT_ID}\"}" \
+            "${WEBHOOK_URL}")
+          echo "${RESPONSE}"
+          echo "${RESPONSE}" | grep -q "HTTP:200" || exit 1

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,8 +10,9 @@ on:
         required: true
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: eflowcr/estock-backend
+  REGISTRY: registry.eflowsuite.com
+  IMAGE_PATH: prod/estock-backend
+  VPSM_PROJECT_ID: 3z011zx2w122wz2w112ww
 
 jobs:
   test:
@@ -29,9 +30,8 @@ jobs:
   build-and-push:
     needs: test
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+    outputs:
+      version: ${{ steps.ver.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
 
@@ -39,28 +39,23 @@ jobs:
 
       - name: Resolve version tag
         id: ver
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          EVENT: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            echo "tag=$INPUT_TAG" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            echo "tag=$REF_NAME" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Login to GHCR
+      - name: Login to eflowsuite registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          labels: |
-            org.opencontainers.image.title=estock-backend
-            org.opencontainers.image.vendor=eflowcr
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Build and Push
         uses: docker/build-push-action@v5
@@ -69,23 +64,31 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.ver.outputs.tag }}
-          labels: ${{ steps.meta.outputs.labels }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}:${{ steps.ver.outputs.tag }}
+          labels: |
+            org.opencontainers.image.title=estock-backend
+            org.opencontainers.image.vendor=eflowcr
+            org.opencontainers.image.version=${{ steps.ver.outputs.tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Notify VPS Manager — update all client stacks
+  notify-vps-manager:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger redeploy via VPS Manager webhook
+        env:
+          WEBHOOK_URL: ${{ secrets.VPSM_WEBHOOK_URL }}
+          WEBHOOK_SECRET: ${{ secrets.VPSM_WEBHOOK_SECRET }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_PATH }}
+          TAG: ${{ needs.build-and-push.outputs.version }}
+          PROJECT_ID: ${{ env.VPSM_PROJECT_ID }}
         run: |
-          curl -sf -X POST \
-            -H "Authorization: Bearer ${{ secrets.VPS_SECRET_TOKEN }}" \
+          RESPONSE=$(curl -sf -w "\nHTTP:%{http_code}" -X POST \
+            -H "Authorization: Bearer ${WEBHOOK_SECRET}" \
             -H "Content-Type: application/json" \
-            -d "{\"image_tag\":\"${{ steps.ver.outputs.tag }}\",\"environment\":\"production\"}" \
-            "https://vps-manager-api.31.97.145.251.nip.io/api/v1/stacks/update" \
-            && echo "✅ Production deploy triggered: ${{ steps.ver.outputs.tag }}" \
-            || echo "⚠️  Deploy trigger failed or no active stacks"
-
-      - name: Verify
-        run: |
-          echo "✅ ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.ver.outputs.tag }} pushed"
-          echo "✅ ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest updated"
+            -d "{\"image\":\"${IMAGE}\",\"tag\":\"${TAG}\",\"project_id\":\"${PROJECT_ID}\"}" \
+            "${WEBHOOK_URL}")
+          echo "${RESPONSE}"
+          echo "${RESPONSE}" | grep -q "HTTP:200" || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,15 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o main ./cmd
 
-# Run stage — minimal image, no secrets baked in
+# Run stage — minimal image, no secrets baked in, non-root user (required by VPS Manager SecurityContext)
 FROM alpine:3.20
-RUN apk add --no-cache ca-certificates curl
+RUN apk add --no-cache ca-certificates curl && \
+    addgroup --system --gid 1001 appgroup && \
+    adduser --system --uid 1001 --ingroup appgroup appuser
 WORKDIR /app
-COPY --from=builder /app/main .
-COPY db/migrations ./db/migrations
+COPY --from=builder --chown=appuser:appgroup /app/main .
+COPY --chown=appuser:appgroup db/migrations ./db/migrations
+USER appuser
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary

Migrates the 3 deploy workflows (dev/main/prod) + Dockerfile from the legacy SSH-token model to the new VPS Manager webhook pattern.

**What changes:**

- **deploy-dev.yml** (dev branch) → pushes to `registry.eflowsuite.com/dev/estock-backend:latest` → webhook triggers redeploy of development clients
- **deploy-main.yml** (main branch) → pushes to `qa/estock-backend:latest` → redeploy of qa clients
- **deploy-prod.yml** (tag `v*` / workflow_dispatch) → pushes to `prod/estock-backend:<tag>` → redeploy of production clients
- **Dockerfile** → runs as non-root `appuser` (uid 1001). Required by VPS Manager post-S13 SecurityContext.

**How VPS Manager picks up the deploy:** the webhook resolves project + environment from the image name using the `project_images` table (seeded: 6 rows for dev/qa/prod x backend/frontend).

## Secrets

**Already set:** `REGISTRY_HOST`, `REGISTRY_USERNAME`, `REGISTRY_PASSWORD`, `VPSM_WEBHOOK_URL`, `VPSM_WEBHOOK_SECRET`.

**Safe to delete:** `VPS_SECRET_TOKEN`, `VPS_SSH_KEY`.

## Test plan

- [ ] Workflows render without syntax errors
- [ ] Merge + push dev → image lands in registry + webhook 200
- [ ] Create first eSTOCK client via VPS Manager UI with auto_update=true
- [ ] Tag v0.1.0 to test prod path