### PR TITLE
feat(s3.5-w2b): tenant_id isolation on lots + stock_alerts

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -84,13 +84,15 @@ func main() {
 	go func() {
 		time.Sleep(30 * time.Second)
 
-		analyzer := func() error {
+		// S3.5 W2-B: analyzer runs once per active tenant; tools.RunStockAlertAnalysis
+		// iterates the tenants table and invokes this callback for each tenant UUID.
+		analyzer := func(tenantID string) error {
 			repo := &repositories.StockAlertsRepository{DB: db, Redis: redisClient}
 			svc := services.NewStockAlertsService(repo)
-			if _, resp := svc.Analyze(); resp != nil && resp.Error != nil {
+			if _, resp := svc.Analyze(tenantID); resp != nil && resp.Error != nil {
 				return resp.Error
 			}
-			if _, resp := svc.LotExpiration(); resp != nil && resp.Error != nil {
+			if _, resp := svc.LotExpiration(tenantID); resp != nil && resp.Error != nil {
 				return resp.Error
 			}
 			return nil

--- a/controllers/admin_cron_controller.go
+++ b/controllers/admin_cron_controller.go
@@ -21,13 +21,15 @@ func NewAdminCronController(db *gorm.DB) *AdminCronController {
 func (c *AdminCronController) Trigger(ctx *gin.Context) {
 	job := ctx.DefaultQuery("job", "all")
 
-	analyzer := func() error {
+	// S3.5 W2-B: analyzer is invoked once per active tenant by RunStockAlertAnalysis;
+	// see tools/cron.go for the iteration over the tenants table.
+	analyzer := func(tenantID string) error {
 		repo := &repositories.StockAlertsRepository{DB: c.DB}
 		svc := services.NewStockAlertsService(repo)
-		if _, resp := svc.Analyze(); resp != nil && resp.Error != nil {
+		if _, resp := svc.Analyze(tenantID); resp != nil && resp.Error != nil {
 			return resp.Error
 		}
-		if _, resp := svc.LotExpiration(); resp != nil && resp.Error != nil {
+		if _, resp := svc.LotExpiration(tenantID); resp != nil && resp.Error != nil {
 			return resp.Error
 		}
 		return nil

--- a/controllers/lots_controller.go
+++ b/controllers/lots_controller.go
@@ -7,18 +7,20 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// LotsController exposes lots HTTP endpoints. S3.5 W2-B: TenantID is injected at
+// construction time (from configuration.Config or middleware) and forwarded to every
+// service call so the data layer cannot be invoked tenant-less.
 type LotsController struct {
-	Service services.LotsService
+	Service  services.LotsService
+	TenantID string
 }
 
-func NewLotsController(service services.LotsService) *LotsController {
-	return &LotsController{
-		Service: service,
-	}
+func NewLotsController(service services.LotsService, tenantID string) *LotsController {
+	return &LotsController{Service: service, TenantID: tenantID}
 }
 
 func (c *LotsController) GetAllLots(ctx *gin.Context) {
-	lots, response := c.Service.GetAllLots()
+	lots, response := c.Service.GetAllLots(c.TenantID)
 
 	if response != nil {
 		writeErrorResponse(ctx, "GetAllLots", "get_all_lots", response)
@@ -35,7 +37,7 @@ func (c *LotsController) GetAllLots(ctx *gin.Context) {
 
 func (c *LotsController) GetLotsBySKU(ctx *gin.Context) {
 	sku := ctx.Param("id")
-	lots, response := c.Service.GetLotsBySKU(&sku)
+	lots, response := c.Service.GetLotsBySKU(c.TenantID, &sku)
 
 	if response != nil {
 		writeErrorResponse(ctx, "GetLotsBySKU", "get_lots_by_sku", response)
@@ -61,7 +63,7 @@ func (c *LotsController) CreateLot(ctx *gin.Context) {
 		return
 	}
 
-	lotResponse := c.Service.Create(&request)
+	lotResponse := c.Service.Create(c.TenantID, &request)
 	if lotResponse != nil {
 		writeErrorResponse(ctx, "CreateLot", "create_lot", lotResponse)
 		return
@@ -82,7 +84,7 @@ func (c *LotsController) UpdateLot(ctx *gin.Context) {
 		return
 	}
 
-	response := c.Service.UpdateUpdateLot(id, data)
+	response := c.Service.UpdateUpdateLot(c.TenantID, id, data)
 	if response != nil {
 		writeErrorResponse(ctx, "UpdateLot", "update_lot", response)
 		return
@@ -97,7 +99,7 @@ func (c *LotsController) DeleteLot(ctx *gin.Context) {
 		return
 	}
 
-	response := c.Service.DeleteLot(id)
+	response := c.Service.DeleteLot(c.TenantID, id)
 	if response != nil {
 		writeErrorResponse(ctx, "DeleteLot", "delete_lot", response)
 		return
@@ -113,7 +115,7 @@ func (c *LotsController) GetLotTrace(ctx *gin.Context) {
 		return
 	}
 
-	trace, resp := c.Service.GetTrace(id)
+	trace, resp := c.Service.GetTrace(c.TenantID, id)
 	if resp != nil {
 		writeErrorResponse(ctx, "GetLotTrace", "get_lot_trace", resp)
 		return

--- a/controllers/lots_controller_test.go
+++ b/controllers/lots_controller_test.go
@@ -22,11 +22,14 @@ type mockLotsRepoCtrl struct {
 	deleteErr *responses.InternalResponse
 }
 
-func (m *mockLotsRepoCtrl) GetAllLots() ([]database.Lot, *responses.InternalResponse) {
+// S3.5 W2-B: every method takes a tenantID; tests use the const below.
+const ctrlTestTenantID = "00000000-0000-0000-0000-000000000001"
+
+func (m *mockLotsRepoCtrl) GetAllLots(_ string) ([]database.Lot, *responses.InternalResponse) {
 	return m.lots, nil
 }
 
-func (m *mockLotsRepoCtrl) GetLotsBySKU(sku *string) ([]database.Lot, *responses.InternalResponse) {
+func (m *mockLotsRepoCtrl) GetLotsBySKU(_ string, sku *string) ([]database.Lot, *responses.InternalResponse) {
 	if sku == nil || *sku == "" {
 		return nil, nil
 	}
@@ -38,15 +41,15 @@ func (m *mockLotsRepoCtrl) GetLotsBySKU(sku *string) ([]database.Lot, *responses
 	return []database.Lot{}, nil
 }
 
-func (m *mockLotsRepoCtrl) CreateLot(data *requests.CreateLotRequest) *responses.InternalResponse {
+func (m *mockLotsRepoCtrl) CreateLot(_ string, data *requests.CreateLotRequest) *responses.InternalResponse {
 	return m.createErr
 }
 
-func (m *mockLotsRepoCtrl) UpdateLot(id string, data map[string]interface{}) *responses.InternalResponse {
+func (m *mockLotsRepoCtrl) UpdateLot(_ string, id string, data map[string]interface{}) *responses.InternalResponse {
 	return m.updateErr
 }
 
-func (m *mockLotsRepoCtrl) DeleteLot(id string) *responses.InternalResponse {
+func (m *mockLotsRepoCtrl) DeleteLot(_ string, id string) *responses.InternalResponse {
 	return m.deleteErr
 }
 
@@ -59,7 +62,11 @@ func (m *mockLotsRepoCtrl) GetLotByID(id string) (*database.Lot, *responses.Inte
 	return nil, &responses.InternalResponse{Message: "not found", Handled: true, StatusCode: responses.StatusNotFound}
 }
 
-func (m *mockLotsRepoCtrl) GetLotTrace(_ string) (*responses.LotTraceResponse, *responses.InternalResponse) {
+func (m *mockLotsRepoCtrl) GetLotByIDForTenant(id, _ string) (*database.Lot, *responses.InternalResponse) {
+	return m.GetLotByID(id)
+}
+
+func (m *mockLotsRepoCtrl) GetLotTrace(_, _ string) (*responses.LotTraceResponse, *responses.InternalResponse) {
 	return nil, nil
 }
 
@@ -67,7 +74,7 @@ func (m *mockLotsRepoCtrl) GetLotTrace(_ string) (*responses.LotTraceResponse, *
 
 func newLotsController(repo *mockLotsRepoCtrl) *LotsController {
 	svc := services.NewLotsService(repo, nil)
-	return NewLotsController(*svc)
+	return NewLotsController(*svc, ctrlTestTenantID)
 }
 
 // ─── tests ───────────────────────────────────────────────────────────────────

--- a/controllers/stock_alerts_controller.go
+++ b/controllers/stock_alerts_controller.go
@@ -6,19 +6,21 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// StockAlertsController exposes stock-alert endpoints. S3.5 W2-B: TenantID is injected
+// at construction time and propagated through every service call so multi-tenant
+// deployments cannot leak alerts or mix Analyze() inputs across tenants.
 type StockAlertsController struct {
-	Service services.StockAlertsService
+	Service  services.StockAlertsService
+	TenantID string
 }
 
-func NewStockAlertsController(service services.StockAlertsService) *StockAlertsController {
-	return &StockAlertsController{
-		Service: service,
-	}
+func NewStockAlertsController(service services.StockAlertsService, tenantID string) *StockAlertsController {
+	return &StockAlertsController{Service: service, TenantID: tenantID}
 }
 
 func (c *StockAlertsController) GetAllStockAlerts(ctx *gin.Context) {
 	resolved := ctx.Param("resolved") == "true"
-	stockAlerts, response := c.Service.GetAllStockAlerts(resolved)
+	stockAlerts, response := c.Service.GetAllStockAlerts(c.TenantID, resolved)
 
 	if response != nil {
 		writeErrorResponse(ctx, "GetAllStockAlerts", "get_all_stock_alerts", response)
@@ -34,7 +36,7 @@ func (c *StockAlertsController) GetAllStockAlerts(ctx *gin.Context) {
 }
 
 func (c *StockAlertsController) Analyze(ctx *gin.Context) {
-	responseData, response := c.Service.Analyze()
+	responseData, response := c.Service.Analyze(c.TenantID)
 
 	if response != nil {
 		writeErrorResponse(ctx, "Analyze", "analyze_stock_alerts", response)
@@ -45,7 +47,7 @@ func (c *StockAlertsController) Analyze(ctx *gin.Context) {
 }
 
 func (c *StockAlertsController) LotExpiration(ctx *gin.Context) {
-	response, errResponse := c.Service.LotExpiration()
+	response, errResponse := c.Service.LotExpiration(c.TenantID)
 	if errResponse != nil {
 		writeErrorResponse(ctx, "LotExpiration", "lot_expiration", errResponse)
 		return
@@ -60,7 +62,7 @@ func (c *StockAlertsController) ResolveAlert(ctx *gin.Context) {
 		return
 	}
 
-	response := c.Service.ResolveAlert(alertID)
+	response := c.Service.ResolveAlert(c.TenantID, alertID)
 
 	if response != nil {
 		writeErrorResponse(ctx, "ResolveAlert", "resolve_stock_alert", response)
@@ -71,7 +73,7 @@ func (c *StockAlertsController) ResolveAlert(ctx *gin.Context) {
 }
 
 func (c *StockAlertsController) ExportAlertsToExcel(ctx *gin.Context) {
-	data, response := c.Service.ExportAlertsToExcel()
+	data, response := c.Service.ExportAlertsToExcel(c.TenantID)
 
 	if response != nil {
 		writeErrorResponse(ctx, "ExportAlertsToExcel", "export_stock_alerts_to_excel", response)

--- a/controllers/stock_alerts_controller_test.go
+++ b/controllers/stock_alerts_controller_test.go
@@ -25,23 +25,25 @@ type mockStockAlertsRepoCtrl struct {
 	exportErr       *responses.InternalResponse
 }
 
-func (m *mockStockAlertsRepoCtrl) GetAllStockAlerts(resolved bool) ([]database.StockAlert, *responses.InternalResponse) {
+// S3.5 W2-B: tenantID is now part of every repo method; tests pass it through but
+// the mock ignores it (we only verify the controller-side wiring works).
+func (m *mockStockAlertsRepoCtrl) GetAllStockAlerts(_ string, resolved bool) ([]database.StockAlert, *responses.InternalResponse) {
 	return m.alerts, m.alertsErr
 }
 
-func (m *mockStockAlertsRepoCtrl) Analyze() (*responses.StockAlertResponse, *responses.InternalResponse) {
+func (m *mockStockAlertsRepoCtrl) Analyze(_ string) (*responses.StockAlertResponse, *responses.InternalResponse) {
 	return m.analyzeResp, m.analyzeErr
 }
 
-func (m *mockStockAlertsRepoCtrl) LotExpiration() (*responses.StockAlertResponse, *responses.InternalResponse) {
+func (m *mockStockAlertsRepoCtrl) LotExpiration(_ string) (*responses.StockAlertResponse, *responses.InternalResponse) {
 	return m.lotExpResp, m.lotExpErr
 }
 
-func (m *mockStockAlertsRepoCtrl) ResolveAlert(alertID string) *responses.InternalResponse {
+func (m *mockStockAlertsRepoCtrl) ResolveAlert(_, alertID string) *responses.InternalResponse {
 	return m.resolveErr
 }
 
-func (m *mockStockAlertsRepoCtrl) ExportAlertsToExcel() ([]byte, *responses.InternalResponse) {
+func (m *mockStockAlertsRepoCtrl) ExportAlertsToExcel(_ string) ([]byte, *responses.InternalResponse) {
 	return m.exportData, m.exportErr
 }
 
@@ -49,7 +51,7 @@ func (m *mockStockAlertsRepoCtrl) ExportAlertsToExcel() ([]byte, *responses.Inte
 
 func newStockAlertsController(repo *mockStockAlertsRepoCtrl) *StockAlertsController {
 	svc := services.NewStockAlertsService(repo)
-	return NewStockAlertsController(*svc)
+	return NewStockAlertsController(*svc, ctrlTestTenantID)
 }
 
 // ─── tests ───────────────────────────────────────────────────────────────────

--- a/db/migrations/000030_lots_tenant_isolation.down.sql
+++ b/db/migrations/000030_lots_tenant_isolation.down.sql
@@ -1,0 +1,14 @@
+-- 000030_lots_tenant_isolation.down.sql
+-- Reverses 000030_lots_tenant_isolation.up.sql.
+--
+-- WARNING: dropping tenant_id collapses isolation. Safe only on single-tenant
+-- prod (G2 as of S3.5). If multiple tenants share data and this is rolled back,
+-- the unique (sku, lot_number) constraint that previously existed implicitly
+-- via application logic will no longer be enforced — lot lookups may return
+-- rows from other tenants.
+
+DROP INDEX IF EXISTS uq_lots_tenant_sku_lot_number;
+DROP INDEX IF EXISTS idx_lots_tenant_sku;
+DROP INDEX IF EXISTS idx_lots_tenant_created_at;
+
+ALTER TABLE lots DROP COLUMN IF EXISTS tenant_id;

--- a/db/migrations/000030_lots_tenant_isolation.up.sql
+++ b/db/migrations/000030_lots_tenant_isolation.up.sql
@@ -1,0 +1,28 @@
+-- 000030_lots_tenant_isolation.up.sql
+-- S3.5 W2-B: Add tenant_id to lots table to close multi-tenant master-data gap.
+--
+-- Background: lots had no tenant_id, so two tenants with the same lot_number on the
+-- same SKU would collide and queries would return cross-tenant rows. Articles and
+-- inventory tables already (or will, in S3.5 W1/W2-A) carry tenant_id; lots was the
+-- last operational dependency missing isolation for the receiving/picking flows.
+--
+-- Backfill strategy: existing lots belong to the single live tenant (G2). Default
+-- to the global default tenant UUID, then DROP DEFAULT so future inserts must set
+-- tenant_id explicitly (matches pattern from 000019).
+
+ALTER TABLE lots
+  ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001'::uuid;
+
+-- Composite index: tenant filter + most common sort key (created_at DESC for ListLots).
+CREATE INDEX IF NOT EXISTS idx_lots_tenant_created_at ON lots(tenant_id, created_at DESC);
+
+-- Composite index for the SKU lookup pattern (rotation/picking).
+CREATE INDEX IF NOT EXISTS idx_lots_tenant_sku ON lots(tenant_id, sku);
+
+-- Per-tenant uniqueness on (lot_number, sku). Two tenants may legitimately use the
+-- same lot_number/SKU pair, but within one tenant lot_number must be unique per SKU
+-- so receiving/picking can resolve a lot deterministically.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_lots_tenant_sku_lot_number
+  ON lots(tenant_id, sku, lot_number);
+
+ALTER TABLE lots ALTER COLUMN tenant_id DROP DEFAULT;

--- a/db/migrations/000031_stock_alerts_tenant_isolation.down.sql
+++ b/db/migrations/000031_stock_alerts_tenant_isolation.down.sql
@@ -1,0 +1,6 @@
+-- 000031_stock_alerts_tenant_isolation.down.sql
+-- Reverses 000031_stock_alerts_tenant_isolation.up.sql.
+
+DROP INDEX IF EXISTS idx_stock_alerts_tenant_resolved_created_at;
+
+ALTER TABLE stock_alerts DROP COLUMN IF EXISTS tenant_id;

--- a/db/migrations/000031_stock_alerts_tenant_isolation.up.sql
+++ b/db/migrations/000031_stock_alerts_tenant_isolation.up.sql
@@ -1,0 +1,21 @@
+-- 000031_stock_alerts_tenant_isolation.up.sql
+-- S3.5 W2-B: Add tenant_id to stock_alerts table.
+--
+-- Background: stock_alerts.Analyze() recomputed alerts globally (TRUNCATE +
+-- recompute over all inventory rows). With S2.5 inventory now tenant-scoped,
+-- Analyze() must run per tenant and the resulting alert rows must carry
+-- tenant_id so the dashboard, exports and notifications stay isolated.
+--
+-- Backfill: existing rows belong to the single live tenant (G2). Default to the
+-- global default tenant UUID, then DROP DEFAULT so future inserts must set
+-- tenant_id explicitly.
+
+ALTER TABLE stock_alerts
+  ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001'::uuid;
+
+-- Composite index: tenant filter + the GetAllStockAlerts/Summary filter (is_resolved)
+-- and sort key (created_at). Covers both list endpoints in one index.
+CREATE INDEX IF NOT EXISTS idx_stock_alerts_tenant_resolved_created_at
+  ON stock_alerts(tenant_id, is_resolved, created_at);
+
+ALTER TABLE stock_alerts ALTER COLUMN tenant_id DROP DEFAULT;

--- a/db/query/articles/articles.sql
+++ b/db/query/articles/articles.sql
@@ -153,8 +153,15 @@ DELETE FROM articles WHERE id = $1 AND tenant_id = $2;
 -- Lots by SKU (for UpdateArticle warnings) — internal, no tenant filter (lots table
 -- not yet tenant-scoped; tracked in S3.5 W2).
 -- name: ListLotsBySku :many
+-- NOTE (S3.5 W2-B): SELECT column list mirrors db/sqlc/models.go::Lot (tenant_id was
+-- added at the end by migration 000030); without it sqlc would emit a per-query Row
+-- struct and break sqlcLotToDatabase consumers. This query is intentionally global
+-- (no tenant filter) because it powers the article-update warning that surfaces
+-- "lot rows still exist" feedback when an admin disables track_by_lot. ArticlesService
+-- runs in a tenant-scoped controller already; revisiting this for strict tenant scoping
+-- is tracked as an articles-domain follow-up (W1 owns articles.sql).
 SELECT id, lot_number, sku, quantity, expiration_date, created_at, updated_at, status,
-       lot_notes, manufactured_at, best_before_date
+       lot_notes, manufactured_at, best_before_date, tenant_id
 FROM lots
 WHERE sku = $1;
 

--- a/db/query/lots/lots.sql
+++ b/db/query/lots/lots.sql
@@ -1,41 +1,69 @@
 -- Lots CRUD for sqlc
--- Schema: db/migrations (lots table)
+-- Schema: db/migrations (lots table; tenant_id added in 000030)
+-- S3.5 W2-B: every public query is tenant-scoped. Internal helpers (GetLotByID) keep
+-- the un-scoped variant for cross-domain joins (lot trace, picking task validation)
+-- where the caller already proved tenancy via the parent record.
+--
+-- Column order in SELECT/RETURNING must match db/sqlc/models.go::Lot (Postgres appends
+-- tenant_id at the end after the 000030 migration), otherwise sqlc generates per-query
+-- Row structs instead of returning the shared Lot model.
 
 -- name: ListLots :many
+-- Returns all lots for a tenant, sorted by created_at DESC.
 SELECT id, lot_number, sku, quantity, expiration_date, created_at, updated_at, status,
-       lot_notes, manufactured_at, best_before_date
+       lot_notes, manufactured_at, best_before_date, tenant_id
 FROM lots
+WHERE tenant_id = $1
+ORDER BY created_at DESC;
+
+-- name: ListLotsBySkuForTenant :many
+-- Tenant-scoped lookup by SKU; replaces the un-scoped ListLotsBySku for HTTP callers.
+SELECT id, lot_number, sku, quantity, expiration_date, created_at, updated_at, status,
+       lot_notes, manufactured_at, best_before_date, tenant_id
+FROM lots
+WHERE tenant_id = $1 AND sku = $2
 ORDER BY created_at DESC;
 
 -- name: GetLotByID :one
+-- Internal use only: no tenant filter. Use GetLotByIDForTenant for HTTP callers.
 SELECT id, lot_number, sku, quantity, expiration_date, created_at, updated_at, status,
-       lot_notes, manufactured_at, best_before_date
+       lot_notes, manufactured_at, best_before_date, tenant_id
 FROM lots
 WHERE id = $1
 LIMIT 1;
 
+-- name: GetLotByIDForTenant :one
+-- Tenant guard prevents cross-tenant lot enumeration via HTTP (S3.5 W2-B).
+SELECT id, lot_number, sku, quantity, expiration_date, created_at, updated_at, status,
+       lot_notes, manufactured_at, best_before_date, tenant_id
+FROM lots
+WHERE id = $1 AND tenant_id = $2
+LIMIT 1;
+
 -- name: CreateLot :one
 INSERT INTO lots (lot_number, sku, quantity, expiration_date, status,
-                 lot_notes, manufactured_at, best_before_date)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                 lot_notes, manufactured_at, best_before_date, tenant_id)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 RETURNING id, lot_number, sku, quantity, expiration_date, created_at, updated_at, status,
-          lot_notes, manufactured_at, best_before_date;
+          lot_notes, manufactured_at, best_before_date, tenant_id;
 
 -- name: UpdateLot :one
+-- Tenant guard prevents cross-tenant updates (S3.5 W2-B).
 UPDATE lots
 SET
-    lot_number = $2,
-    sku = $3,
-    quantity = $4,
-    expiration_date = $5,
-    status = $6,
-    lot_notes = $7,
-    manufactured_at = $8,
-    best_before_date = $9,
+    lot_number = $3,
+    sku = $4,
+    quantity = $5,
+    expiration_date = $6,
+    status = $7,
+    lot_notes = $8,
+    manufactured_at = $9,
+    best_before_date = $10,
     updated_at = CURRENT_TIMESTAMP
-WHERE id = $1
+WHERE id = $1 AND tenant_id = $2
 RETURNING id, lot_number, sku, quantity, expiration_date, created_at, updated_at, status,
-          lot_notes, manufactured_at, best_before_date;
+          lot_notes, manufactured_at, best_before_date, tenant_id;
 
 -- name: DeleteLot :exec
-DELETE FROM lots WHERE id = $1;
+-- Tenant guard prevents cross-tenant deletes (S3.5 W2-B).
+DELETE FROM lots WHERE id = $1 AND tenant_id = $2;

--- a/db/sqlc/articles.sql.go
+++ b/db/sqlc/articles.sql.go
@@ -693,13 +693,20 @@ func (q *Queries) ListArticlesForTenant(ctx context.Context, tenantID pgtype.UUI
 
 const listLotsBySku = `-- name: ListLotsBySku :many
 SELECT id, lot_number, sku, quantity, expiration_date, created_at, updated_at, status,
-       lot_notes, manufactured_at, best_before_date
+       lot_notes, manufactured_at, best_before_date, tenant_id
 FROM lots
 WHERE sku = $1
 `
 
 // Lots by SKU (for UpdateArticle warnings) — internal, no tenant filter (lots table
 // not yet tenant-scoped; tracked in S3.5 W2).
+// NOTE (S3.5 W2-B): SELECT column list mirrors db/sqlc/models.go::Lot (tenant_id was
+// added at the end by migration 000030); without it sqlc would emit a per-query Row
+// struct and break sqlcLotToDatabase consumers. This query is intentionally global
+// (no tenant filter) because it powers the article-update warning that surfaces
+// "lot rows still exist" feedback when an admin disables track_by_lot. ArticlesService
+// runs in a tenant-scoped controller already; revisiting this for strict tenant scoping
+// is tracked as an articles-domain follow-up (W1 owns articles.sql).
 func (q *Queries) ListLotsBySku(ctx context.Context, sku string) ([]Lot, error) {
 	rows, err := q.db.Query(ctx, listLotsBySku, sku)
 	if err != nil {
@@ -721,6 +728,7 @@ func (q *Queries) ListLotsBySku(ctx context.Context, sku string) ([]Lot, error) 
 			&i.LotNotes,
 			&i.ManufacturedAt,
 			&i.BestBeforeDate,
+			&i.TenantID,
 		); err != nil {
 			return nil, err
 		}

--- a/db/sqlc/lots.sql.go
+++ b/db/sqlc/lots.sql.go
@@ -13,10 +13,10 @@ import (
 
 const createLot = `-- name: CreateLot :one
 INSERT INTO lots (lot_number, sku, quantity, expiration_date, status,
-                 lot_notes, manufactured_at, best_before_date)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                 lot_notes, manufactured_at, best_before_date, tenant_id)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 RETURNING id, lot_number, sku, quantity, expiration_date, created_at, updated_at, status,
-          lot_notes, manufactured_at, best_before_date
+          lot_notes, manufactured_at, best_before_date, tenant_id
 `
 
 type CreateLotParams struct {
@@ -28,6 +28,7 @@ type CreateLotParams struct {
 	LotNotes       pgtype.Text      `json:"lot_notes"`
 	ManufacturedAt pgtype.Date      `json:"manufactured_at"`
 	BestBeforeDate pgtype.Date      `json:"best_before_date"`
+	TenantID       pgtype.UUID      `json:"tenant_id"`
 }
 
 func (q *Queries) CreateLot(ctx context.Context, arg CreateLotParams) (Lot, error) {
@@ -40,6 +41,7 @@ func (q *Queries) CreateLot(ctx context.Context, arg CreateLotParams) (Lot, erro
 		arg.LotNotes,
 		arg.ManufacturedAt,
 		arg.BestBeforeDate,
+		arg.TenantID,
 	)
 	var i Lot
 	err := row.Scan(
@@ -54,27 +56,35 @@ func (q *Queries) CreateLot(ctx context.Context, arg CreateLotParams) (Lot, erro
 		&i.LotNotes,
 		&i.ManufacturedAt,
 		&i.BestBeforeDate,
+		&i.TenantID,
 	)
 	return i, err
 }
 
 const deleteLot = `-- name: DeleteLot :exec
-DELETE FROM lots WHERE id = $1
+DELETE FROM lots WHERE id = $1 AND tenant_id = $2
 `
 
-func (q *Queries) DeleteLot(ctx context.Context, id string) error {
-	_, err := q.db.Exec(ctx, deleteLot, id)
+type DeleteLotParams struct {
+	ID       string      `json:"id"`
+	TenantID pgtype.UUID `json:"tenant_id"`
+}
+
+// Tenant guard prevents cross-tenant deletes (S3.5 W2-B).
+func (q *Queries) DeleteLot(ctx context.Context, arg DeleteLotParams) error {
+	_, err := q.db.Exec(ctx, deleteLot, arg.ID, arg.TenantID)
 	return err
 }
 
 const getLotByID = `-- name: GetLotByID :one
 SELECT id, lot_number, sku, quantity, expiration_date, created_at, updated_at, status,
-       lot_notes, manufactured_at, best_before_date
+       lot_notes, manufactured_at, best_before_date, tenant_id
 FROM lots
 WHERE id = $1
 LIMIT 1
 `
 
+// Internal use only: no tenant filter. Use GetLotByIDForTenant for HTTP callers.
 func (q *Queries) GetLotByID(ctx context.Context, id string) (Lot, error) {
 	row := q.db.QueryRow(ctx, getLotByID, id)
 	var i Lot
@@ -90,6 +100,41 @@ func (q *Queries) GetLotByID(ctx context.Context, id string) (Lot, error) {
 		&i.LotNotes,
 		&i.ManufacturedAt,
 		&i.BestBeforeDate,
+		&i.TenantID,
+	)
+	return i, err
+}
+
+const getLotByIDForTenant = `-- name: GetLotByIDForTenant :one
+SELECT id, lot_number, sku, quantity, expiration_date, created_at, updated_at, status,
+       lot_notes, manufactured_at, best_before_date, tenant_id
+FROM lots
+WHERE id = $1 AND tenant_id = $2
+LIMIT 1
+`
+
+type GetLotByIDForTenantParams struct {
+	ID       string      `json:"id"`
+	TenantID pgtype.UUID `json:"tenant_id"`
+}
+
+// Tenant guard prevents cross-tenant lot enumeration via HTTP (S3.5 W2-B).
+func (q *Queries) GetLotByIDForTenant(ctx context.Context, arg GetLotByIDForTenantParams) (Lot, error) {
+	row := q.db.QueryRow(ctx, getLotByIDForTenant, arg.ID, arg.TenantID)
+	var i Lot
+	err := row.Scan(
+		&i.ID,
+		&i.LotNumber,
+		&i.Sku,
+		&i.Quantity,
+		&i.ExpirationDate,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Status,
+		&i.LotNotes,
+		&i.ManufacturedAt,
+		&i.BestBeforeDate,
+		&i.TenantID,
 	)
 	return i, err
 }
@@ -97,15 +142,24 @@ func (q *Queries) GetLotByID(ctx context.Context, id string) (Lot, error) {
 const listLots = `-- name: ListLots :many
 
 SELECT id, lot_number, sku, quantity, expiration_date, created_at, updated_at, status,
-       lot_notes, manufactured_at, best_before_date
+       lot_notes, manufactured_at, best_before_date, tenant_id
 FROM lots
+WHERE tenant_id = $1
 ORDER BY created_at DESC
 `
 
 // Lots CRUD for sqlc
-// Schema: db/migrations (lots table)
-func (q *Queries) ListLots(ctx context.Context) ([]Lot, error) {
-	rows, err := q.db.Query(ctx, listLots)
+// Schema: db/migrations (lots table; tenant_id added in 000030)
+// S3.5 W2-B: every public query is tenant-scoped. Internal helpers (GetLotByID) keep
+// the un-scoped variant for cross-domain joins (lot trace, picking task validation)
+// where the caller already proved tenancy via the parent record.
+//
+// Column order in SELECT/RETURNING must match db/sqlc/models.go::Lot (Postgres appends
+// tenant_id at the end after the 000030 migration), otherwise sqlc generates per-query
+// Row structs instead of returning the shared Lot model.
+// Returns all lots for a tenant, sorted by created_at DESC.
+func (q *Queries) ListLots(ctx context.Context, tenantID pgtype.UUID) ([]Lot, error) {
+	rows, err := q.db.Query(ctx, listLots, tenantID)
 	if err != nil {
 		return nil, err
 	}
@@ -125,6 +179,54 @@ func (q *Queries) ListLots(ctx context.Context) ([]Lot, error) {
 			&i.LotNotes,
 			&i.ManufacturedAt,
 			&i.BestBeforeDate,
+			&i.TenantID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listLotsBySkuForTenant = `-- name: ListLotsBySkuForTenant :many
+SELECT id, lot_number, sku, quantity, expiration_date, created_at, updated_at, status,
+       lot_notes, manufactured_at, best_before_date, tenant_id
+FROM lots
+WHERE tenant_id = $1 AND sku = $2
+ORDER BY created_at DESC
+`
+
+type ListLotsBySkuForTenantParams struct {
+	TenantID pgtype.UUID `json:"tenant_id"`
+	Sku      string      `json:"sku"`
+}
+
+// Tenant-scoped lookup by SKU; replaces the un-scoped ListLotsBySku for HTTP callers.
+func (q *Queries) ListLotsBySkuForTenant(ctx context.Context, arg ListLotsBySkuForTenantParams) ([]Lot, error) {
+	rows, err := q.db.Query(ctx, listLotsBySkuForTenant, arg.TenantID, arg.Sku)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Lot{}
+	for rows.Next() {
+		var i Lot
+		if err := rows.Scan(
+			&i.ID,
+			&i.LotNumber,
+			&i.Sku,
+			&i.Quantity,
+			&i.ExpirationDate,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.Status,
+			&i.LotNotes,
+			&i.ManufacturedAt,
+			&i.BestBeforeDate,
+			&i.TenantID,
 		); err != nil {
 			return nil, err
 		}
@@ -139,22 +241,23 @@ func (q *Queries) ListLots(ctx context.Context) ([]Lot, error) {
 const updateLot = `-- name: UpdateLot :one
 UPDATE lots
 SET
-    lot_number = $2,
-    sku = $3,
-    quantity = $4,
-    expiration_date = $5,
-    status = $6,
-    lot_notes = $7,
-    manufactured_at = $8,
-    best_before_date = $9,
+    lot_number = $3,
+    sku = $4,
+    quantity = $5,
+    expiration_date = $6,
+    status = $7,
+    lot_notes = $8,
+    manufactured_at = $9,
+    best_before_date = $10,
     updated_at = CURRENT_TIMESTAMP
-WHERE id = $1
+WHERE id = $1 AND tenant_id = $2
 RETURNING id, lot_number, sku, quantity, expiration_date, created_at, updated_at, status,
-          lot_notes, manufactured_at, best_before_date
+          lot_notes, manufactured_at, best_before_date, tenant_id
 `
 
 type UpdateLotParams struct {
 	ID             string           `json:"id"`
+	TenantID       pgtype.UUID      `json:"tenant_id"`
 	LotNumber      string           `json:"lot_number"`
 	Sku            string           `json:"sku"`
 	Quantity       pgtype.Numeric   `json:"quantity"`
@@ -165,9 +268,11 @@ type UpdateLotParams struct {
 	BestBeforeDate pgtype.Date      `json:"best_before_date"`
 }
 
+// Tenant guard prevents cross-tenant updates (S3.5 W2-B).
 func (q *Queries) UpdateLot(ctx context.Context, arg UpdateLotParams) (Lot, error) {
 	row := q.db.QueryRow(ctx, updateLot,
 		arg.ID,
+		arg.TenantID,
 		arg.LotNumber,
 		arg.Sku,
 		arg.Quantity,
@@ -190,6 +295,7 @@ func (q *Queries) UpdateLot(ctx context.Context, arg UpdateLotParams) (Lot, erro
 		&i.LotNotes,
 		&i.ManufacturedAt,
 		&i.BestBeforeDate,
+		&i.TenantID,
 	)
 	return i, err
 }

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -525,6 +525,7 @@ type StockAlert struct {
 	DaysToExpiration      pgtype.Int4      `json:"days_to_expiration"`
 	CreatedAt             pgtype.Timestamp `json:"created_at"`
 	ResolvedAt            pgtype.Timestamp `json:"resolved_at"`
+	TenantID              pgtype.UUID      `json:"tenant_id"`
 }
 
 type StockSetting struct {

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -271,6 +271,7 @@ type Lot struct {
 	LotNotes       pgtype.Text      `json:"lot_notes"`
 	ManufacturedAt pgtype.Date      `json:"manufactured_at"`
 	BestBeforeDate pgtype.Date      `json:"best_before_date"`
+	TenantID       pgtype.UUID      `json:"tenant_id"`
 }
 
 type Notification struct {

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -42,7 +42,8 @@ type Querier interface {
 	DeleteArticle(ctx context.Context, arg DeleteArticleParams) error
 	DeleteLocation(ctx context.Context, id string) error
 	DeleteLocationType(ctx context.Context, id string) error
-	DeleteLot(ctx context.Context, id string) error
+	// Tenant guard prevents cross-tenant deletes (S3.5 W2-B).
+	DeleteLot(ctx context.Context, arg DeleteLotParams) error
 	DeletePresentation(ctx context.Context, presentationID string) error
 	DeletePresentationConversion(ctx context.Context, id string) error
 	DeletePresentationType(ctx context.Context, id string) error
@@ -70,7 +71,10 @@ type Querier interface {
 	GetLocationByLocationCode(ctx context.Context, locationCode string) (GetLocationByLocationCodeRow, error)
 	GetLocationTypeByCode(ctx context.Context, code string) (LocationType, error)
 	GetLocationTypeByID(ctx context.Context, id string) (LocationType, error)
+	// Internal use only: no tenant filter. Use GetLotByIDForTenant for HTTP callers.
 	GetLotByID(ctx context.Context, id string) (Lot, error)
+	// Tenant guard prevents cross-tenant lot enumeration via HTTP (S3.5 W2-B).
+	GetLotByIDForTenant(ctx context.Context, arg GetLotByIDForTenantParams) (Lot, error)
 	GetOrCreateUserPreferences(ctx context.Context, userID string) (UserPreference, error)
 	GetPresentationByID(ctx context.Context, presentationID string) (Presentation, error)
 	GetPresentationConversionByFromAndTo(ctx context.Context, arg GetPresentationConversionByFromAndToParams) (PresentationConversion, error)
@@ -122,11 +126,28 @@ type Querier interface {
 	// Schema: db/migrations (locations table)
 	ListLocations(ctx context.Context) ([]ListLocationsRow, error)
 	// Lots CRUD for sqlc
-	// Schema: db/migrations (lots table)
-	ListLots(ctx context.Context) ([]Lot, error)
+	// Schema: db/migrations (lots table; tenant_id added in 000030)
+	// S3.5 W2-B: every public query is tenant-scoped. Internal helpers (GetLotByID) keep
+	// the un-scoped variant for cross-domain joins (lot trace, picking task validation)
+	// where the caller already proved tenancy via the parent record.
+	//
+	// Column order in SELECT/RETURNING must match db/sqlc/models.go::Lot (Postgres appends
+	// tenant_id at the end after the 000030 migration), otherwise sqlc generates per-query
+	// Row structs instead of returning the shared Lot model.
+	// Returns all lots for a tenant, sorted by created_at DESC.
+	ListLots(ctx context.Context, tenantID pgtype.UUID) ([]Lot, error)
 	// Lots by SKU (for UpdateArticle warnings) — internal, no tenant filter (lots table
 	// not yet tenant-scoped; tracked in S3.5 W2).
+	// NOTE (S3.5 W2-B): SELECT column list mirrors db/sqlc/models.go::Lot (tenant_id was
+	// added at the end by migration 000030); without it sqlc would emit a per-query Row
+	// struct and break sqlcLotToDatabase consumers. This query is intentionally global
+	// (no tenant filter) because it powers the article-update warning that surfaces
+	// "lot rows still exist" feedback when an admin disables track_by_lot. ArticlesService
+	// runs in a tenant-scoped controller already; revisiting this for strict tenant scoping
+	// is tracked as an articles-domain follow-up (W1 owns articles.sql).
 	ListLotsBySku(ctx context.Context, sku string) ([]Lot, error)
+	// Tenant-scoped lookup by SKU; replaces the un-scoped ListLotsBySku for HTTP callers.
+	ListLotsBySkuForTenant(ctx context.Context, arg ListLotsBySkuForTenantParams) ([]Lot, error)
 	// Presentation conversions CRUD. Schema: db/migrations (presentation_conversions table)
 	ListPresentationConversions(ctx context.Context) ([]PresentationConversion, error)
 	ListPresentationConversionsAdmin(ctx context.Context) ([]PresentationConversion, error)
@@ -159,6 +180,7 @@ type Querier interface {
 	UpdateClient(ctx context.Context, arg UpdateClientParams) (Client, error)
 	UpdateLocation(ctx context.Context, arg UpdateLocationParams) (UpdateLocationRow, error)
 	UpdateLocationType(ctx context.Context, arg UpdateLocationTypeParams) (LocationType, error)
+	// Tenant guard prevents cross-tenant updates (S3.5 W2-B).
 	UpdateLot(ctx context.Context, arg UpdateLotParams) (Lot, error)
 	UpdatePresentation(ctx context.Context, arg UpdatePresentationParams) (Presentation, error)
 	UpdatePresentationConversion(ctx context.Context, arg UpdatePresentationConversionParams) (PresentationConversion, error)

--- a/models/database/lot.go
+++ b/models/database/lot.go
@@ -4,6 +4,9 @@ import "time"
 
 type Lot struct {
 	ID             string     `gorm:"column:id;primaryKey" json:"id"`
+	// TenantID isolates lots per tenant (S3.5 W2-B). Hidden from JSON because clients
+	// resolve tenancy via JWT/Config, never via response payloads.
+	TenantID       string     `gorm:"column:tenant_id;type:uuid;not null;index" json:"-"`
 	LotNumber      string     `gorm:"column:lot_number" json:"lot_number"`
 	SKU            string     `gorm:"column:sku" json:"sku"`
 	Quantity       float64    `gorm:"column:quantity" json:"quantity"`

--- a/models/database/stock_alert.go
+++ b/models/database/stock_alert.go
@@ -2,8 +2,15 @@ package database
 
 import "time"
 
+// StockAlert represents a stock-level or expiration alert for a SKU/lot owned by a tenant.
+//
+// S3.5 W2-B: TenantID is required so Analyze() can recompute alerts per tenant without
+// mixing inventory/movement data across tenants. JSON tag is "-" because the HTTP layer
+// resolves tenant scope from the JWT/Config — payload-side tenant_id would be redundant
+// and a potential leak vector.
 type StockAlert struct {
 	ID                    string     `gorm:"column:id;primaryKey" json:"id"`
+	TenantID              string     `gorm:"column:tenant_id;type:uuid;not null;index" json:"-"`
 	SKU                   string     `gorm:"column:sku" json:"sku"`
 	AlertType             string     `gorm:"column:alert_type" json:"alert_type"`
 	CurrentStock          int        `gorm:"column:current_stock" json:"current_stock"`

--- a/ports/lots.go
+++ b/ports/lots.go
@@ -7,12 +7,18 @@ import (
 )
 
 // LotsRepository defines persistence operations for lots.
+//
+// S3.5 W2-B: every public method takes a tenantID so multi-tenant deployments cannot
+// cross-leak lot data via SKU lookup or list/trace endpoints. Internal lookups that
+// already validated tenancy via a parent record (e.g. picking task → lot via
+// inventory_movements) keep using GetLotByID without a tenant filter.
 type LotsRepository interface {
-	GetAllLots() ([]database.Lot, *responses.InternalResponse)
-	GetLotsBySKU(sku *string) ([]database.Lot, *responses.InternalResponse)
+	GetAllLots(tenantID string) ([]database.Lot, *responses.InternalResponse)
+	GetLotsBySKU(tenantID string, sku *string) ([]database.Lot, *responses.InternalResponse)
 	GetLotByID(id string) (*database.Lot, *responses.InternalResponse)
-	CreateLot(data *requests.CreateLotRequest) *responses.InternalResponse
-	UpdateLot(id string, data map[string]interface{}) *responses.InternalResponse
-	DeleteLot(id string) *responses.InternalResponse
-	GetLotTrace(lotID string) (*responses.LotTraceResponse, *responses.InternalResponse)
+	GetLotByIDForTenant(id, tenantID string) (*database.Lot, *responses.InternalResponse)
+	CreateLot(tenantID string, data *requests.CreateLotRequest) *responses.InternalResponse
+	UpdateLot(tenantID, id string, data map[string]interface{}) *responses.InternalResponse
+	DeleteLot(tenantID, id string) *responses.InternalResponse
+	GetLotTrace(tenantID, lotID string) (*responses.LotTraceResponse, *responses.InternalResponse)
 }

--- a/ports/stock_alerts.go
+++ b/ports/stock_alerts.go
@@ -6,10 +6,15 @@ import (
 )
 
 // StockAlertsRepository defines persistence operations for stock alerts.
+//
+// S3.5 W2-B: every method is tenant-scoped. Analyze() reads inventory and lots, both of
+// which are tenant-scoped (S2.5 + S3.5 W2-B); without a tenantID parameter the
+// truncate/recompute would mix data across tenants and overwrite each tenant's alerts
+// every time another tenant ran the analyzer.
 type StockAlertsRepository interface {
-	GetAllStockAlerts(resolved bool) ([]database.StockAlert, *responses.InternalResponse)
-	Analyze() (*responses.StockAlertResponse, *responses.InternalResponse)
-	LotExpiration() (*responses.StockAlertResponse, *responses.InternalResponse)
-	ResolveAlert(alertID string) *responses.InternalResponse
-	ExportAlertsToExcel() ([]byte, *responses.InternalResponse)
+	GetAllStockAlerts(tenantID string, resolved bool) ([]database.StockAlert, *responses.InternalResponse)
+	Analyze(tenantID string) (*responses.StockAlertResponse, *responses.InternalResponse)
+	LotExpiration(tenantID string) (*responses.StockAlertResponse, *responses.InternalResponse)
+	ResolveAlert(tenantID, alertID string) *responses.InternalResponse
+	ExportAlertsToExcel(tenantID string) ([]byte, *responses.InternalResponse)
 }

--- a/repositories/articles_repository_sqlc.go
+++ b/repositories/articles_repository_sqlc.go
@@ -716,6 +716,7 @@ func sqlcLotToDatabase(l sqlc.Lot) database.Lot {
 	st := l.Status
 	return database.Lot{
 		ID:             l.ID,
+		TenantID:       pgUUIDToString(l.TenantID),
 		LotNumber:      l.LotNumber,
 		SKU:            l.Sku,
 		Quantity:       pgNumericToFloat(l.Quantity),

--- a/repositories/lots_repository.go
+++ b/repositories/lots_repository.go
@@ -15,10 +15,15 @@ type LotsRepository struct {
 	DB *gorm.DB
 }
 
-func (r *LotsRepository) GetAllLots() ([]database.Lot, *responses.InternalResponse) {
+// GetAllLots returns lots for a single tenant ordered by creation date (newest first).
+// S3.5 W2-B: tenant filter is mandatory; an empty tenantID yields zero rows by design.
+func (r *LotsRepository) GetAllLots(tenantID string) ([]database.Lot, *responses.InternalResponse) {
 	var lots []database.Lot
 
-	err := r.DB.Table(database.Lot{}.TableName()).Order("created_at DESC").Find(&lots).Error
+	err := r.DB.Table(database.Lot{}.TableName()).
+		Where("tenant_id = ?", tenantID).
+		Order("created_at DESC").
+		Find(&lots).Error
 	if err != nil {
 		return nil, &responses.InternalResponse{
 			Error:   err,
@@ -30,10 +35,12 @@ func (r *LotsRepository) GetAllLots() ([]database.Lot, *responses.InternalRespon
 	return lots, nil
 }
 
-func (r *LotsRepository) GetLotsBySKU(sku *string) ([]database.Lot, *responses.InternalResponse) {
+// GetLotsBySKU returns the tenant's lots, optionally filtered by SKU.
+// S3.5 W2-B: tenant filter is always applied; SKU is an additional narrowing filter.
+func (r *LotsRepository) GetLotsBySKU(tenantID string, sku *string) ([]database.Lot, *responses.InternalResponse) {
 	var lots []database.Lot
 
-	query := r.DB.Table(database.Lot{}.TableName())
+	query := r.DB.Table(database.Lot{}.TableName()).Where("tenant_id = ?", tenantID)
 
 	if sku != nil && *sku != "" {
 		query = query.Where("sku = ?", *sku)
@@ -53,7 +60,8 @@ func (r *LotsRepository) GetLotsBySKU(sku *string) ([]database.Lot, *responses.I
 	return lots, nil
 }
 
-func (r *LotsRepository) CreateLot(data *requests.CreateLotRequest) *responses.InternalResponse {
+// CreateLot inserts a new lot owned by tenantID. S3.5 W2-B.
+func (r *LotsRepository) CreateLot(tenantID string, data *requests.CreateLotRequest) *responses.InternalResponse {
 	now := tools.GetCurrentTime()
 
 	// Parse string to time.Time
@@ -74,6 +82,7 @@ func (r *LotsRepository) CreateLot(data *requests.CreateLotRequest) *responses.I
 
 	lot := &database.Lot{
 		ID:             lotID,
+		TenantID:       tenantID,
 		LotNumber:      data.LotNumber,
 		SKU:            data.SKU,
 		Quantity:       data.Quantity,
@@ -94,10 +103,12 @@ func (r *LotsRepository) CreateLot(data *requests.CreateLotRequest) *responses.I
 	return nil
 }
 
-func (r *LotsRepository) UpdateLot(id string, data map[string]interface{}) *responses.InternalResponse {
+// UpdateLot mutates a lot scoped to the calling tenant. S3.5 W2-B: cross-tenant updates
+// return NotFound to avoid leaking the existence of a row owned by another tenant.
+func (r *LotsRepository) UpdateLot(tenantID, id string, data map[string]interface{}) *responses.InternalResponse {
 	var lot database.Lot
 
-	err := r.DB.First(&lot, "id = ?", id).Error
+	err := r.DB.Where("id = ? AND tenant_id = ?", id, tenantID).First(&lot).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return &responses.InternalResponse{
 			Message:    "Lot not found",
@@ -115,6 +126,7 @@ func (r *LotsRepository) UpdateLot(id string, data map[string]interface{}) *resp
 
 	protectedFields := map[string]bool{
 		"id":         true,
+		"tenant_id":  true,
 		"created_at": true,
 	}
 
@@ -125,7 +137,7 @@ func (r *LotsRepository) UpdateLot(id string, data map[string]interface{}) *resp
 	data["updated_at"] = tools.GetCurrentTime()
 
 	if err := r.DB.Table(database.Lot{}.TableName()).Where(
-		"id = ?", id,
+		"id = ? AND tenant_id = ?", id, tenantID,
 	).Updates(data).Error; err != nil {
 		return &responses.InternalResponse{
 			Error:   err,
@@ -137,8 +149,9 @@ func (r *LotsRepository) UpdateLot(id string, data map[string]interface{}) *resp
 	return nil
 }
 
-func (r *LotsRepository) DeleteLot(id string) *responses.InternalResponse {
-	result := r.DB.Delete(&database.Lot{}, id)
+// DeleteLot removes a lot scoped to the calling tenant. S3.5 W2-B.
+func (r *LotsRepository) DeleteLot(tenantID, id string) *responses.InternalResponse {
+	result := r.DB.Where("id = ? AND tenant_id = ?", id, tenantID).Delete(&database.Lot{})
 	if result.Error != nil {
 		return &responses.InternalResponse{
 			Error:   result.Error,
@@ -158,6 +171,9 @@ func (r *LotsRepository) DeleteLot(id string) *responses.InternalResponse {
 	return nil
 }
 
+// GetLotByID is the internal-use lookup (no tenant filter). Used by GetLotTrace itself
+// after the tenant guard has already run, and by intra-domain joins where the parent
+// row has already been tenant-checked.
 func (r *LotsRepository) GetLotByID(id string) (*database.Lot, *responses.InternalResponse) {
 	var lot database.Lot
 	err := r.DB.First(&lot, "id = ?", id).Error
@@ -174,9 +190,30 @@ func (r *LotsRepository) GetLotByID(id string) (*database.Lot, *responses.Intern
 	return &lot, nil
 }
 
-func (r *LotsRepository) GetLotTrace(lotID string) (*responses.LotTraceResponse, *responses.InternalResponse) {
-	// 1. Lot data
-	lot, resp := r.GetLotByID(lotID)
+// GetLotByIDForTenant scopes the lookup to tenantID. S3.5 W2-B: HTTP callers must use
+// this variant so cross-tenant lot enumeration is impossible.
+func (r *LotsRepository) GetLotByIDForTenant(id, tenantID string) (*database.Lot, *responses.InternalResponse) {
+	var lot database.Lot
+	err := r.DB.Where("id = ? AND tenant_id = ?", id, tenantID).First(&lot).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, &responses.InternalResponse{
+			Message:    "Lot not found",
+			Handled:    true,
+			StatusCode: responses.StatusNotFound,
+		}
+	}
+	if err != nil {
+		return nil, &responses.InternalResponse{Error: err, Message: "Failed to retrieve lot", Handled: false}
+	}
+	return &lot, nil
+}
+
+// GetLotTrace returns the full provenance trace for a lot owned by tenantID.
+// S3.5 W2-B: lot lookup is tenant-scoped; downstream joins inherit isolation
+// via inventory_movements/inventory_lots which were tenant-scoped in S2.5.
+func (r *LotsRepository) GetLotTrace(tenantID, lotID string) (*responses.LotTraceResponse, *responses.InternalResponse) {
+	// 1. Lot data (tenant-scoped — guards trace endpoint from cross-tenant enumeration).
+	lot, resp := r.GetLotByIDForTenant(lotID, tenantID)
 	if resp != nil {
 		return nil, resp
 	}

--- a/repositories/lots_repository_sqlc.go
+++ b/repositories/lots_repository_sqlc.go
@@ -34,9 +34,23 @@ func NewLotsRepositorySQLCWithGORM(queries *sqlc.Queries, db *gorm.DB) *LotsRepo
 
 var _ ports.LotsRepository = (*LotsRepositorySQLC)(nil)
 
-func (r *LotsRepositorySQLC) GetAllLots() ([]database.Lot, *responses.InternalResponse) {
+// tenantBadRequest converts a tenant_id parse error into a 400 response.
+func tenantBadRequest(err error) *responses.InternalResponse {
+	return &responses.InternalResponse{
+		Error:      err,
+		Message:    "tenant_id inválido",
+		Handled:    true,
+		StatusCode: responses.StatusBadRequest,
+	}
+}
+
+func (r *LotsRepositorySQLC) GetAllLots(tenantID string) ([]database.Lot, *responses.InternalResponse) {
 	ctx := context.Background()
-	list, err := r.queries.ListLots(ctx)
+	tid, err := stringToPgUUID(tenantID)
+	if err != nil {
+		return nil, tenantBadRequest(err)
+	}
+	list, err := r.queries.ListLots(ctx, tid)
 	if err != nil {
 		return nil, &responses.InternalResponse{Error: err, Message: "Failed to fetch lots", Handled: false}
 	}
@@ -47,14 +61,17 @@ func (r *LotsRepositorySQLC) GetAllLots() ([]database.Lot, *responses.InternalRe
 	return out, nil
 }
 
-func (r *LotsRepositorySQLC) GetLotsBySKU(sku *string) ([]database.Lot, *responses.InternalResponse) {
+func (r *LotsRepositorySQLC) GetLotsBySKU(tenantID string, sku *string) ([]database.Lot, *responses.InternalResponse) {
 	ctx := context.Background()
+	tid, err := stringToPgUUID(tenantID)
+	if err != nil {
+		return nil, tenantBadRequest(err)
+	}
 	var list []sqlc.Lot
-	var err error
 	if sku != nil && *sku != "" {
-		list, err = r.queries.ListLotsBySku(ctx, *sku)
+		list, err = r.queries.ListLotsBySkuForTenant(ctx, sqlc.ListLotsBySkuForTenantParams{TenantID: tid, Sku: *sku})
 	} else {
-		list, err = r.queries.ListLots(ctx)
+		list, err = r.queries.ListLots(ctx, tid)
 	}
 	if err != nil {
 		return nil, &responses.InternalResponse{Error: err, Message: "Failed to fetch lots", Handled: false}
@@ -66,8 +83,12 @@ func (r *LotsRepositorySQLC) GetLotsBySKU(sku *string) ([]database.Lot, *respons
 	return out, nil
 }
 
-func (r *LotsRepositorySQLC) CreateLot(data *requests.CreateLotRequest) *responses.InternalResponse {
+func (r *LotsRepositorySQLC) CreateLot(tenantID string, data *requests.CreateLotRequest) *responses.InternalResponse {
 	ctx := context.Background()
+	tid, err := stringToPgUUID(tenantID)
+	if err != nil {
+		return tenantBadRequest(err)
+	}
 	var expPg pgtype.Timestamp
 	if data.ExpirationDate != nil && *data.ExpirationDate != "" {
 		if t, err := time.Parse("2006-01-02", *data.ExpirationDate); err == nil {
@@ -81,6 +102,7 @@ func (r *LotsRepositorySQLC) CreateLot(data *requests.CreateLotRequest) *respons
 	qty := pgtype.Numeric{}
 	_ = qty.Scan(data.Quantity)
 	arg := sqlc.CreateLotParams{
+		TenantID:       tid,
 		LotNumber:      data.LotNumber,
 		Sku:            data.SKU,
 		Quantity:       qty,
@@ -90,16 +112,21 @@ func (r *LotsRepositorySQLC) CreateLot(data *requests.CreateLotRequest) *respons
 		ManufacturedAt: ptrStringToPgDate(data.ManufacturedAt),
 		BestBeforeDate: ptrStringToPgDate(data.BestBeforeDate),
 	}
-	_, err := r.queries.CreateLot(ctx, arg)
+	_, err = r.queries.CreateLot(ctx, arg)
 	if err != nil {
 		return &responses.InternalResponse{Error: err, Message: "Failed to create lot", Handled: false}
 	}
 	return nil
 }
 
-func (r *LotsRepositorySQLC) UpdateLot(id string, data map[string]interface{}) *responses.InternalResponse {
+func (r *LotsRepositorySQLC) UpdateLot(tenantID, id string, data map[string]interface{}) *responses.InternalResponse {
 	ctx := context.Background()
-	lot, err := r.queries.GetLotByID(ctx, id)
+	tid, err := stringToPgUUID(tenantID)
+	if err != nil {
+		return tenantBadRequest(err)
+	}
+	// Tenant-scoped fetch — cross-tenant lookup returns NotFound, never the actual row.
+	lot, err := r.queries.GetLotByIDForTenant(ctx, sqlc.GetLotByIDForTenantParams{ID: id, TenantID: tid})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return &responses.InternalResponse{
@@ -129,6 +156,7 @@ func (r *LotsRepositorySQLC) UpdateLot(id string, data map[string]interface{}) *
 	}
 	arg := sqlc.UpdateLotParams{
 		ID:             lot.ID,
+		TenantID:       tid,
 		LotNumber:      lot.LotNumber,
 		Sku:            lot.Sku,
 		Quantity:       lot.Quantity,
@@ -145,10 +173,14 @@ func (r *LotsRepositorySQLC) UpdateLot(id string, data map[string]interface{}) *
 	return nil
 }
 
-func (r *LotsRepositorySQLC) DeleteLot(id string) *responses.InternalResponse {
+func (r *LotsRepositorySQLC) DeleteLot(tenantID, id string) *responses.InternalResponse {
 	ctx := context.Background()
-	_, err := r.queries.GetLotByID(ctx, id)
+	tid, err := stringToPgUUID(tenantID)
 	if err != nil {
+		return tenantBadRequest(err)
+	}
+	// Tenant-scoped existence check — guarantees Delete cannot affect another tenant's row.
+	if _, err := r.queries.GetLotByIDForTenant(ctx, sqlc.GetLotByIDForTenantParams{ID: id, TenantID: tid}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return &responses.InternalResponse{
 				Message:    "Lot not found",
@@ -158,12 +190,14 @@ func (r *LotsRepositorySQLC) DeleteLot(id string) *responses.InternalResponse {
 		}
 		return &responses.InternalResponse{Error: err, Message: "Failed to retrieve lot", Handled: false}
 	}
-	if err := r.queries.DeleteLot(ctx, id); err != nil {
+	if err := r.queries.DeleteLot(ctx, sqlc.DeleteLotParams{ID: id, TenantID: tid}); err != nil {
 		return &responses.InternalResponse{Error: err, Message: "Failed to delete lot", Handled: false}
 	}
 	return nil
 }
 
+// GetLotByID is the internal-use lookup (no tenant filter). HTTP callers must use
+// GetLotByIDForTenant instead.
 func (r *LotsRepositorySQLC) GetLotByID(id string) (*database.Lot, *responses.InternalResponse) {
 	ctx := context.Background()
 	l, err := r.queries.GetLotByID(ctx, id)
@@ -181,8 +215,31 @@ func (r *LotsRepositorySQLC) GetLotByID(id string) (*database.Lot, *responses.In
 	return &lot, nil
 }
 
+// GetLotByIDForTenant scopes the lookup to tenantID. S3.5 W2-B.
+func (r *LotsRepositorySQLC) GetLotByIDForTenant(id, tenantID string) (*database.Lot, *responses.InternalResponse) {
+	ctx := context.Background()
+	tid, err := stringToPgUUID(tenantID)
+	if err != nil {
+		return nil, tenantBadRequest(err)
+	}
+	l, err := r.queries.GetLotByIDForTenant(ctx, sqlc.GetLotByIDForTenantParams{ID: id, TenantID: tid})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, &responses.InternalResponse{
+				Message:    "Lot not found",
+				Handled:    true,
+				StatusCode: responses.StatusNotFound,
+			}
+		}
+		return nil, &responses.InternalResponse{Error: err, Message: "Failed to retrieve lot", Handled: false}
+	}
+	lot := sqlcLotToDatabase(l)
+	return &lot, nil
+}
+
 // GetLotTrace delegates to the GORM-based LotsRepository when DB is available.
-func (r *LotsRepositorySQLC) GetLotTrace(lotID string) (*responses.LotTraceResponse, *responses.InternalResponse) {
+// S3.5 W2-B: tenantID propagates so the lot lookup itself is tenant-scoped.
+func (r *LotsRepositorySQLC) GetLotTrace(tenantID, lotID string) (*responses.LotTraceResponse, *responses.InternalResponse) {
 	if r.DB == nil {
 		return nil, &responses.InternalResponse{
 			Message:    "GetLotTrace requiere conexión GORM — configure DB en el repositorio SQLC",
@@ -191,5 +248,5 @@ func (r *LotsRepositorySQLC) GetLotTrace(lotID string) (*responses.LotTraceRespo
 		}
 	}
 	gormRepo := &LotsRepository{DB: r.DB}
-	return gormRepo.GetLotTrace(lotID)
+	return gormRepo.GetLotTrace(tenantID, lotID)
 }

--- a/repositories/stock_alerts_repository.go
+++ b/repositories/stock_alerts_repository.go
@@ -40,27 +40,38 @@ const (
 const analyzeCacheTTL = 60 * time.Second
 
 type analyzeCache struct {
-	result    *responses.StockAlertResponse
-	cachedAt  time.Time
+	result   *responses.StockAlertResponse
+	cachedAt time.Time
 }
 
-const redisAnalyzeKey = "stock_alerts:analyze"
+// redisAnalyzeKeyPrefix is namespaced per tenant so the cached payload from one tenant
+// can never be served to another (S3.5 W2-B).
+const redisAnalyzeKeyPrefix = "stock_alerts:analyze:"
+
+func redisAnalyzeKey(tenantID string) string {
+	return redisAnalyzeKeyPrefix + tenantID
+}
 
 type StockAlertsRepository struct {
 	DB    *gorm.DB
 	Redis *redis.Client // nil → in-memory fallback
 
 	// analyzeMu serializes concurrent Analyze() calls so only one runs at a time.
-	analyzeMu    sync.Mutex
-	analyzeCache analyzeCache // in-memory fallback when Redis is nil
+	// Locking is global (not per-tenant) because TRUNCATE locks the entire stock_alerts
+	// table. Per-tenant DELETE in the new tenant-scoped flow could be parallelised, but
+	// the simple mutex keeps semantics aligned with the previous implementation.
+	analyzeMu sync.Mutex
+	// analyzeCache: in-memory fallback when Redis is nil. Map keyed by tenantID so the
+	// fallback is also tenant-scoped (otherwise tenant A would receive tenant B's cache).
+	analyzeCache map[string]analyzeCache
 }
 
-func (r *StockAlertsRepository) GetAllStockAlerts(resolved bool) ([]database.StockAlert, *responses.InternalResponse) {
+func (r *StockAlertsRepository) GetAllStockAlerts(tenantID string, resolved bool) ([]database.StockAlert, *responses.InternalResponse) {
 	var stockAlerts []database.StockAlert
 
 	err := r.DB.
 		Table(database.StockAlert{}.TableName()).
-		Where("is_resolved = ?", resolved).
+		Where("tenant_id = ? AND is_resolved = ?", tenantID, resolved).
 		Order("created_at ASC").
 		Find(&stockAlerts).Error
 
@@ -75,23 +86,43 @@ func (r *StockAlertsRepository) GetAllStockAlerts(resolved bool) ([]database.Sto
 	return stockAlerts, nil
 }
 
-func (r *StockAlertsRepository) Analyze() (*responses.StockAlertResponse, *responses.InternalResponse) {
-	// Serialize concurrent calls: only one Analyze() runs at a time.
+// Analyze recomputes stock alerts for a single tenant. The previous implementation
+// TRUNCATEd the entire stock_alerts table and re-derived alerts from globally-scanned
+// inventory/movements; in a multi-tenant deployment that would erase tenant B's alerts
+// every time tenant A's user opened the dashboard.
+//
+// S3.5 W2-B refactor:
+//   - DELETE only this tenant's rows instead of TRUNCATE.
+//   - All inventory/movement/lot reads carry WHERE tenant_id = ?.
+//   - The Redis/in-memory cache key is tenant-scoped.
+//
+// Cron callers must invoke Analyze() per tenant; see tools/cron.go.
+func (r *StockAlertsRepository) Analyze(tenantID string) (*responses.StockAlertResponse, *responses.InternalResponse) {
+	if tenantID == "" {
+		return nil, &responses.InternalResponse{
+			Message:    "tenant_id es requerido para analizar alertas de stock",
+			Handled:    true,
+			StatusCode: responses.StatusBadRequest,
+		}
+	}
+
+	// Serialize concurrent calls: only one Analyze() runs at a time across all tenants.
 	r.analyzeMu.Lock()
 	defer r.analyzeMu.Unlock()
 
-	// --- Cache read ---
+	// --- Cache read (per-tenant) ---
+	cacheKey := redisAnalyzeKey(tenantID)
 	if r.Redis != nil {
-		// Try Redis first (survives restarts, shared across instances).
-		if cached, err := r.Redis.Get(context.Background(), redisAnalyzeKey).Bytes(); err == nil {
+		if cached, err := r.Redis.Get(context.Background(), cacheKey).Bytes(); err == nil {
 			var resp responses.StockAlertResponse
 			if json.Unmarshal(cached, &resp) == nil {
 				return &resp, nil
 			}
 		}
-	} else if r.analyzeCache.result != nil && time.Since(r.analyzeCache.cachedAt) < analyzeCacheTTL {
-		// Fall back to in-memory cache.
-		return r.analyzeCache.result, nil
+	} else if r.analyzeCache != nil {
+		if entry, ok := r.analyzeCache[tenantID]; ok && entry.result != nil && time.Since(entry.cachedAt) < analyzeCacheTTL {
+			return entry.result, nil
+		}
 	}
 
 	// Begin transaction
@@ -104,9 +135,12 @@ func (r *StockAlertsRepository) Analyze() (*responses.StockAlertResponse, *respo
 		}
 	}
 
-	// TRUNCATE is ~10× faster than DELETE for full-table clears (no row-level logging).
-	err := tx.Exec("TRUNCATE TABLE " + database.StockAlert{}.TableName()).Error
+	// Per-tenant clear (replaces global TRUNCATE). Slower than TRUNCATE but isolation-safe.
+	err := tx.
+		Exec("DELETE FROM "+database.StockAlert{}.TableName()+" WHERE tenant_id = ?", tenantID).
+		Error
 	if err != nil {
+		tx.Rollback()
 		return nil, &responses.InternalResponse{
 			Error:   err,
 			Message: "Error al limpiar alertas de stock existentes",
@@ -114,10 +148,11 @@ func (r *StockAlertsRepository) Analyze() (*responses.StockAlertResponse, *respo
 		}
 	}
 
-	// Get all inventory
+	// Get inventory for this tenant only.
 	var inventory []database.Inventory
 	err = tx.
 		Table(database.Inventory{}.TableName()).
+		Where("tenant_id = ?", tenantID).
 		Find(&inventory).Error
 
 	if err != nil {
@@ -129,14 +164,14 @@ func (r *StockAlertsRepository) Analyze() (*responses.StockAlertResponse, *respo
 		}
 	}
 
-	// Fix 1: Batch-fetch all outbound movements in the last 30 days — one query instead of N.
+	// Batch-fetch all outbound movements in the last 30 days for this tenant — one query.
 	const movementLookbackDays = 30
 	lookbackCutoff := time.Now().AddDate(0, 0, -movementLookbackDays)
 
 	var allMovements []database.InventoryMovement
 	err = tx.
 		Table(database.InventoryMovement{}.TableName()).
-		Where("movement_type = ? AND created_at >= ?", "outbound", lookbackCutoff).
+		Where("tenant_id = ? AND movement_type = ? AND created_at >= ?", tenantID, "outbound", lookbackCutoff).
 		Find(&allMovements).Error
 
 	if err != nil {
@@ -158,8 +193,6 @@ func (r *StockAlertsRepository) Analyze() (*responses.StockAlertResponse, *respo
 	var alerts []database.StockAlert
 
 	for i := 0; i < len(inventory); i++ {
-		// Look up pre-fetched movements — empty slice if none in last 30 days.
-		// analyzeInventoryItem handles empty slices by classifying on stock level alone.
 		movements := movementMap[inventory[i].SKU+"|"+inventory[i].Location]
 
 		analysis, errResponse := analyzeInventoryItem(inventory[i], movements)
@@ -169,9 +202,9 @@ func (r *StockAlertsRepository) Analyze() (*responses.StockAlertResponse, *respo
 		}
 
 		if analysis != nil && analysis.AlertLevel != "" {
-			// Use Go-generated UUID — no DB round-trip per alert.
 			alert := database.StockAlert{
 				ID:               uuid.NewString(),
+				TenantID:         tenantID,
 				SKU:              analysis.SKU,
 				AlertType:        analysis.AlertType,
 				CurrentStock:     analysis.CurrentStock,
@@ -182,7 +215,6 @@ func (r *StockAlertsRepository) Analyze() (*responses.StockAlertResponse, *respo
 				CreatedAt:        time.Now(),
 			}
 
-			// Fix 2 (tail): sentinel MaxInt32 means "infinite" — store nil in DB.
 			if analysis.PredictedStockOutDays < math.MaxInt32 {
 				days := analysis.PredictedStockOutDays
 				alert.PredictedStockOutDays = &days
@@ -194,8 +226,8 @@ func (r *StockAlertsRepository) Analyze() (*responses.StockAlertResponse, *respo
 		}
 	}
 
-	// Build lot expiration alerts in memory (no individual inserts).
-	lotAlerts, err := r.buildLotExpirationAlerts(tx)
+	// Build lot expiration alerts for this tenant only.
+	lotAlerts, err := r.buildLotExpirationAlerts(tx, tenantID)
 	if err != nil {
 		tx.Rollback()
 		return nil, &responses.InternalResponse{
@@ -206,7 +238,6 @@ func (r *StockAlertsRepository) Analyze() (*responses.StockAlertResponse, *respo
 	}
 	alerts = append(alerts, lotAlerts...)
 
-	// Batch-insert all alerts in a single statement.
 	if len(alerts) > 0 {
 		err = tx.Create(&alerts).Error
 		if err != nil {
@@ -219,7 +250,6 @@ func (r *StockAlertsRepository) Analyze() (*responses.StockAlertResponse, *respo
 		}
 	}
 
-	// Commit transaction
 	err = tx.Commit().Error
 	if err != nil {
 		tx.Rollback()
@@ -230,12 +260,10 @@ func (r *StockAlertsRepository) Analyze() (*responses.StockAlertResponse, *respo
 		}
 	}
 
-	// If no alerts were generated
 	if len(alerts) == 0 {
 		return nil, nil
 	}
 
-	// Fix 4: compute summary counts and use them (were hardcoded to 0 before).
 	criticalCount := 0
 	highCount := 0
 	mediumCount := 0
@@ -268,13 +296,16 @@ func (r *StockAlertsRepository) Analyze() (*responses.StockAlertResponse, *respo
 		},
 	}
 
-	// --- Cache write ---
+	// --- Cache write (per-tenant) ---
 	if r.Redis != nil {
 		if b, err := json.Marshal(response); err == nil {
-			r.Redis.Set(context.Background(), redisAnalyzeKey, b, analyzeCacheTTL)
+			r.Redis.Set(context.Background(), cacheKey, b, analyzeCacheTTL)
 		}
 	} else {
-		r.analyzeCache = analyzeCache{result: response, cachedAt: time.Now()}
+		if r.analyzeCache == nil {
+			r.analyzeCache = make(map[string]analyzeCache)
+		}
+		r.analyzeCache[tenantID] = analyzeCache{result: response, cachedAt: time.Now()}
 	}
 
 	return response, nil
@@ -288,7 +319,6 @@ func analyzeInventoryItem(item database.Inventory, movements []database.Inventor
 		return nil, errResponse
 	}
 
-	// Fix 2: Cap before int conversion to prevent +Inf → MaxInt64 overflow.
 	predictedFloat := consumptionTrend.PredictedStockOutDays
 	var predictedInt int
 	switch {
@@ -302,14 +332,12 @@ func analyzeInventoryItem(item database.Inventory, movements []database.Inventor
 
 	alertLevel := classifyAlertLevel(int(quantity), predictedInt)
 
-	// If null, no alert is needed
 	if alertLevel == nil {
 		return nil, nil
 	}
 
 	recommendedStock := calculateRecommendedStock(quantity, consumptionTrend.AverageDailyConsumption, *alertLevel)
 
-	// Determine alert type
 	alertType := classifyAlertType(int(quantity))
 
 	message := GenerateAlertMessage(
@@ -512,9 +540,9 @@ func GenerateAlertMessage(
 	return fmt.Sprintf("Alerta para SKU %s: Stock actual %d, se recomienda un nuevo pedido de %d unidades.", sku, currentStock, recommendedStock)
 }
 
-// buildLotExpirationAlerts fetches lots and builds alert structs in memory — no DB inserts.
-// Used by Analyze() which batch-inserts everything at the end.
-func (r *StockAlertsRepository) buildLotExpirationAlerts(tx *gorm.DB) ([]database.StockAlert, error) {
+// buildLotExpirationAlerts fetches lots for the given tenant and builds alert structs in
+// memory — no DB inserts. Used by Analyze() which batch-inserts everything at the end.
+func (r *StockAlertsRepository) buildLotExpirationAlerts(tx *gorm.DB, tenantID string) ([]database.StockAlert, error) {
 	var alerts []database.StockAlert
 	date := tools.GetCurrentTime()
 
@@ -522,7 +550,7 @@ func (r *StockAlertsRepository) buildLotExpirationAlerts(tx *gorm.DB) ([]databas
 	err := tx.
 		Table("lots").
 		Select("id, lot_number, sku, quantity, expiration_date").
-		Where("expiration_date IS NOT NULL AND expiration_date > ?", date).
+		Where("tenant_id = ? AND expiration_date IS NOT NULL AND expiration_date > ?", tenantID, date).
 		Order("expiration_date ASC").
 		Find(&lots).Error
 
@@ -552,6 +580,7 @@ func (r *StockAlertsRepository) buildLotExpirationAlerts(tx *gorm.DB) ([]databas
 		daysToExpireCopy := daysToExpire
 		alerts = append(alerts, database.StockAlert{
 			ID:               uuid.NewString(),
+			TenantID:         tenantID,
 			SKU:              lots[i].SKU,
 			AlertType:        "lot_expiration",
 			CurrentStock:     int(lots[i].Quantity),
@@ -574,8 +603,8 @@ func (r *StockAlertsRepository) buildLotExpirationAlerts(tx *gorm.DB) ([]databas
 
 // generateLotExpirationAlertsInTransaction builds and immediately inserts lot expiration alerts.
 // Used by LotExpiration() only.
-func (r *StockAlertsRepository) generateLotExpirationAlertsInTransaction(tx *gorm.DB) ([]database.StockAlert, error) {
-	alerts, err := r.buildLotExpirationAlerts(tx)
+func (r *StockAlertsRepository) generateLotExpirationAlertsInTransaction(tx *gorm.DB, tenantID string) ([]database.StockAlert, error) {
+	alerts, err := r.buildLotExpirationAlerts(tx, tenantID)
 	if err != nil {
 		return nil, err
 	}
@@ -587,16 +616,23 @@ func (r *StockAlertsRepository) generateLotExpirationAlertsInTransaction(tx *gor
 	return alerts, nil
 }
 
-func (r *StockAlertsRepository) LotExpiration() (*responses.StockAlertResponse, *responses.InternalResponse) {
-	// Begin transaction
+func (r *StockAlertsRepository) LotExpiration(tenantID string) (*responses.StockAlertResponse, *responses.InternalResponse) {
+	if tenantID == "" {
+		return nil, &responses.InternalResponse{
+			Message:    "tenant_id es requerido para generar alertas de expiración de lotes",
+			Handled:    true,
+			StatusCode: responses.StatusBadRequest,
+		}
+	}
+
 	tx := r.DB.Begin()
 	defer func() {
-		if r := recover(); r != nil {
+		if rec := recover(); rec != nil {
 			tx.Rollback()
 		}
 	}()
 
-	alerts, err := r.generateLotExpirationAlertsInTransaction(tx)
+	alerts, err := r.generateLotExpirationAlertsInTransaction(tx, tenantID)
 	if err != nil {
 		return nil, &responses.InternalResponse{
 			Error:   err,
@@ -626,9 +662,11 @@ func (r *StockAlertsRepository) LotExpiration() (*responses.StockAlertResponse, 
 	return response, nil
 }
 
-func (r *StockAlertsRepository) ResolveAlert(alertID string) *responses.InternalResponse {
+// ResolveAlert flips is_resolved=true for an alert owned by tenantID. Cross-tenant
+// resolves return NotFound so the existence of another tenant's alert is not leaked.
+func (r *StockAlertsRepository) ResolveAlert(tenantID, alertID string) *responses.InternalResponse {
 	var alert database.StockAlert
-	err := r.DB.Where("id = ?", alertID).First(&alert).Error
+	err := r.DB.Where("id = ? AND tenant_id = ?", alertID, tenantID).First(&alert).Error
 	if err != nil {
 		return &responses.InternalResponse{
 			Error:   err,
@@ -661,12 +699,12 @@ func (r *StockAlertsRepository) ResolveAlert(alertID string) *responses.Internal
 	return nil
 }
 
-func (r *StockAlertsRepository) Summary() (*responses.StockAlertResponse, *responses.InternalResponse) {
+func (r *StockAlertsRepository) Summary(tenantID string) (*responses.StockAlertResponse, *responses.InternalResponse) {
 	var alerts []database.StockAlert
 
 	err := r.DB.
 		Table(database.StockAlert{}.TableName()).
-		Where("is_resolved = ?", false).
+		Where("tenant_id = ? AND is_resolved = ?", tenantID, false).
 		Order("created_at ASC").
 		Find(&alerts).Error
 
@@ -725,8 +763,8 @@ func sumarizeAlerts(alerts []database.StockAlert) responses.StockAlertSumary {
 	}
 }
 
-func (r *StockAlertsRepository) ExportAlertsToExcel() ([]byte, *responses.InternalResponse) {
-	alerts, errResp := r.GetAllStockAlerts(false)
+func (r *StockAlertsRepository) ExportAlertsToExcel(tenantID string) ([]byte, *responses.InternalResponse) {
+	alerts, errResp := r.GetAllStockAlerts(tenantID, false)
 	if errResp != nil {
 		return nil, errResp
 	}

--- a/routes/lots_routes.go
+++ b/routes/lots_routes.go
@@ -17,7 +17,9 @@ var _ ports.LotsRepository = (*repositories.LotsRepositorySQLC)(nil)
 
 func RegisterLotsRoutes(router *gin.RouterGroup, db *gorm.DB, pool *pgxpool.Pool, config configuration.Config, rolesRepo ports.RolesRepository) {
 	_, lotsService := wire.NewLots(db, pool)
-	lotsController := controllers.NewLotsController(*lotsService)
+	// S3.5 W2-B: TenantID flows from configuration.Config into the controller and into
+	// every service/repo call so the data layer is never invoked without a tenant scope.
+	lotsController := controllers.NewLotsController(*lotsService, config.TenantID)
 
 	route := router.Group("/lots")
 	route.Use(tools.JWTAuthMiddleware(config.JWTSecret))
@@ -29,7 +31,7 @@ func RegisterLotsRoutes(router *gin.RouterGroup, db *gorm.DB, pool *pgxpool.Pool
 
 		route.GET("/", read, lotsController.GetAllLots)
 		if pool != nil {
-			cfg := tools.LotsTableConfig()
+			cfg := tools.LotsTableConfig(config.TenantID)
 			route.GET("/table", read, tools.GenericListHandler(pool, cfg))
 			route.GET("/table/export", read, tools.GenericExportHandler(pool, cfg, "lots.csv"))
 		}

--- a/routes/stock_alerts_routes.go
+++ b/routes/stock_alerts_routes.go
@@ -19,7 +19,10 @@ var _ ports.StockAlertsRepository = (*repositories.StockAlertsRepository)(nil)
 
 func RegisterStockAlertsRoutes(router *gin.RouterGroup, db *gorm.DB, config configuration.Config, redisClient *goredis.Client, rolesRepo ports.RolesRepository) {
 	_, stockAlertsService := wire.NewStockAlerts(db, redisClient)
-	stockAlertsController := controllers.NewStockAlertsController(*stockAlertsService)
+	// S3.5 W2-B: TenantID flows from configuration.Config into the controller and into
+	// every service/repo call. Cron callers (admin_cron_controller, main goroutine) wire
+	// tenantID separately by iterating the tenants table.
+	stockAlertsController := controllers.NewStockAlertsController(*stockAlertsService, config.TenantID)
 
 	// 5 requests per minute per IP on the analyze endpoint (expensive: full DB scan + transaction).
 	analyzeRateLimiter := tools.NewIPRateLimiter(rate.Every(time.Minute/5), 5)

--- a/services/lots_service.go
+++ b/services/lots_service.go
@@ -11,8 +11,8 @@ import (
 )
 
 type LotsService struct {
-	Repository     ports.LotsRepository
-	ArticlesRepo   ports.ArticlesRepository // optional: when set, GetLotsBySKU returns lots in rotation order (FIFO/FEFO)
+	Repository   ports.LotsRepository
+	ArticlesRepo ports.ArticlesRepository // optional: when set, GetLotsBySKU returns lots in rotation order (FIFO/FEFO)
 }
 
 // NewLotsService builds the lots service. articlesRepo may be nil; when set, GetLotsBySKU orders lots by article rotation strategy.
@@ -23,21 +23,24 @@ func NewLotsService(repo ports.LotsRepository, articlesRepo ports.ArticlesReposi
 	}
 }
 
-func (s *LotsService) GetAllLots() ([]database.Lot, *responses.InternalResponse) {
-	return s.Repository.GetAllLots()
+// S3.5 W2-B: every public method takes tenantID so the controller can pass Config.TenantID
+// (or middleware-resolved tenant context) and isolation is enforced one layer below the HTTP boundary.
+
+func (s *LotsService) GetAllLots(tenantID string) ([]database.Lot, *responses.InternalResponse) {
+	return s.Repository.GetAllLots(tenantID)
 }
 
-func (s *LotsService) GetLotByID(id string) (*database.Lot, *responses.InternalResponse) {
-	return s.Repository.GetLotByID(id)
+func (s *LotsService) GetLotByID(tenantID, id string) (*database.Lot, *responses.InternalResponse) {
+	return s.Repository.GetLotByIDForTenant(id, tenantID)
 }
 
-// GetTrace returns the full provenance trace for a lot: origin, movements, and current stock.
-func (s *LotsService) GetTrace(lotID string) (*responses.LotTraceResponse, *responses.InternalResponse) {
-	return s.Repository.GetLotTrace(lotID)
+// GetTrace returns the full provenance trace for a lot owned by tenantID.
+func (s *LotsService) GetTrace(tenantID, lotID string) (*responses.LotTraceResponse, *responses.InternalResponse) {
+	return s.Repository.GetLotTrace(tenantID, lotID)
 }
 
-func (s *LotsService) GetLotsBySKU(sku *string) ([]database.Lot, *responses.InternalResponse) {
-	lots, resp := s.Repository.GetLotsBySKU(sku)
+func (s *LotsService) GetLotsBySKU(tenantID string, sku *string) ([]database.Lot, *responses.InternalResponse) {
+	lots, resp := s.Repository.GetLotsBySKU(tenantID, sku)
 	if resp != nil || lots == nil || len(lots) == 0 {
 		return lots, resp
 	}
@@ -84,14 +87,14 @@ func sortLotsByRotationStrategy(lots []database.Lot, strategy string) {
 	})
 }
 
-func (s *LotsService) Create(data *requests.CreateLotRequest) *responses.InternalResponse {
-	return s.Repository.CreateLot(data)
+func (s *LotsService) Create(tenantID string, data *requests.CreateLotRequest) *responses.InternalResponse {
+	return s.Repository.CreateLot(tenantID, data)
 }
 
-func (s *LotsService) UpdateUpdateLot(id string, data map[string]interface{}) *responses.InternalResponse {
-	return s.Repository.UpdateLot(id, data)
+func (s *LotsService) UpdateUpdateLot(tenantID, id string, data map[string]interface{}) *responses.InternalResponse {
+	return s.Repository.UpdateLot(tenantID, id, data)
 }
 
-func (s *LotsService) DeleteLot(id string) *responses.InternalResponse {
-	return s.Repository.DeleteLot(id)
+func (s *LotsService) DeleteLot(tenantID, id string) *responses.InternalResponse {
+	return s.Repository.DeleteLot(tenantID, id)
 }

--- a/services/lots_service_test.go
+++ b/services/lots_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"testing"
 	"time"
 
 	"github.com/eflowcr/eSTOCK_backend/models/database"
@@ -8,54 +9,74 @@ import (
 	"github.com/eflowcr/eSTOCK_backend/models/responses"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
+)
+
+// Tenant constants used by the tests. The "other" tenant is used to assert isolation.
+const (
+	testTenantA = "00000000-0000-0000-0000-00000000000a"
+	testTenantB = "00000000-0000-0000-0000-00000000000b"
 )
 
 // mockLotsRepo is an in-memory fake for unit testing LotsService.
+//
+// S3.5 W2-B: filters every read by tenantID so tests can assert isolation between
+// tenants (Get/Create/Update/Delete from tenant A must not affect tenant B).
 type mockLotsRepo struct {
-	lots      []database.Lot
-	getAllErr *responses.InternalResponse
-	createErr *responses.InternalResponse
+	lots             []database.Lot
+	getAllErr        *responses.InternalResponse
+	createErr        *responses.InternalResponse
+	lastCreateTenant string
+	lastUpdateTenant string
+	lastDeleteTenant string
 }
 
-func (m *mockLotsRepo) GetAllLots() ([]database.Lot, *responses.InternalResponse) {
+func (m *mockLotsRepo) GetAllLots(tenantID string) ([]database.Lot, *responses.InternalResponse) {
 	if m.getAllErr != nil {
 		return nil, m.getAllErr
 	}
 	if m.lots == nil {
 		return nil, nil
 	}
-	return m.lots, nil
-}
-
-func (m *mockLotsRepo) GetLotsBySKU(sku *string) ([]database.Lot, *responses.InternalResponse) {
-	if m.lots == nil {
-		return nil, nil
-	}
-	if sku == nil || *sku == "" {
-		return m.lots, nil
-	}
-	var out []database.Lot
+	out := make([]database.Lot, 0, len(m.lots))
 	for _, l := range m.lots {
-		if l.SKU == *sku {
+		if l.TenantID == "" || l.TenantID == tenantID {
 			out = append(out, l)
 		}
 	}
 	return out, nil
 }
 
-func (m *mockLotsRepo) CreateLot(data *requests.CreateLotRequest) *responses.InternalResponse {
+func (m *mockLotsRepo) GetLotsBySKU(tenantID string, sku *string) ([]database.Lot, *responses.InternalResponse) {
+	if m.lots == nil {
+		return nil, nil
+	}
+	out := make([]database.Lot, 0, len(m.lots))
+	for _, l := range m.lots {
+		if l.TenantID != "" && l.TenantID != tenantID {
+			continue
+		}
+		if sku == nil || *sku == "" || l.SKU == *sku {
+			out = append(out, l)
+		}
+	}
+	return out, nil
+}
+
+func (m *mockLotsRepo) CreateLot(tenantID string, data *requests.CreateLotRequest) *responses.InternalResponse {
+	m.lastCreateTenant = tenantID
 	if m.createErr != nil {
 		return m.createErr
 	}
 	return nil
 }
 
-func (m *mockLotsRepo) UpdateLot(id string, data map[string]interface{}) *responses.InternalResponse {
+func (m *mockLotsRepo) UpdateLot(tenantID, id string, data map[string]interface{}) *responses.InternalResponse {
+	m.lastUpdateTenant = tenantID
 	return nil
 }
 
-func (m *mockLotsRepo) DeleteLot(id string) *responses.InternalResponse {
+func (m *mockLotsRepo) DeleteLot(tenantID, id string) *responses.InternalResponse {
+	m.lastDeleteTenant = tenantID
 	return nil
 }
 
@@ -68,7 +89,16 @@ func (m *mockLotsRepo) GetLotByID(id string) (*database.Lot, *responses.Internal
 	return nil, &responses.InternalResponse{Message: "not found", Handled: true, StatusCode: responses.StatusNotFound}
 }
 
-func (m *mockLotsRepo) GetLotTrace(_ string) (*responses.LotTraceResponse, *responses.InternalResponse) {
+func (m *mockLotsRepo) GetLotByIDForTenant(id, tenantID string) (*database.Lot, *responses.InternalResponse) {
+	for i := range m.lots {
+		if m.lots[i].ID == id && (m.lots[i].TenantID == "" || m.lots[i].TenantID == tenantID) {
+			return &m.lots[i], nil
+		}
+	}
+	return nil, &responses.InternalResponse{Message: "not found", Handled: true, StatusCode: responses.StatusNotFound}
+}
+
+func (m *mockLotsRepo) GetLotTrace(_ string, _ string) (*responses.LotTraceResponse, *responses.InternalResponse) {
 	return nil, nil
 }
 
@@ -147,11 +177,31 @@ func TestLotsService_GetAllLots(t *testing.T) {
 		},
 	}
 	svc := NewLotsService(repo, nil)
-	list, errResp := svc.GetAllLots()
+	list, errResp := svc.GetAllLots(testTenantA)
 	require.Nil(t, errResp)
 	require.Len(t, list, 2)
 	assert.Equal(t, "SKU-A", list[0].SKU)
 	assert.Equal(t, "SKU-B", list[1].SKU)
+}
+
+// S3.5 W2-B: GetAllLots must not return rows owned by another tenant.
+func TestLotsService_GetAllLots_TenantIsolation(t *testing.T) {
+	repo := &mockLotsRepo{
+		lots: []database.Lot{
+			{ID: "1", LotNumber: "L1", SKU: "SKU-A", Quantity: 10, TenantID: testTenantA},
+			{ID: "2", LotNumber: "L2", SKU: "SKU-B", Quantity: 20, TenantID: testTenantB},
+		},
+	}
+	svc := NewLotsService(repo, nil)
+	listA, errResp := svc.GetAllLots(testTenantA)
+	require.Nil(t, errResp)
+	require.Len(t, listA, 1)
+	assert.Equal(t, "SKU-A", listA[0].SKU)
+
+	listB, errResp := svc.GetAllLots(testTenantB)
+	require.Nil(t, errResp)
+	require.Len(t, listB, 1)
+	assert.Equal(t, "SKU-B", listB[0].SKU)
 }
 
 func TestLotsService_GetLotsBySKU_NilSku_ReturnsAll(t *testing.T) {
@@ -162,7 +212,7 @@ func TestLotsService_GetLotsBySKU_NilSku_ReturnsAll(t *testing.T) {
 		},
 	}
 	svc := NewLotsService(repo, nil)
-	list, errResp := svc.GetLotsBySKU(nil)
+	list, errResp := svc.GetLotsBySKU(testTenantA, nil)
 	require.Nil(t, errResp)
 	require.Len(t, list, 2)
 }
@@ -177,11 +227,27 @@ func TestLotsService_GetLotsBySKU_Filtered(t *testing.T) {
 	}
 	svc := NewLotsService(repo, nil)
 	sku := "S1"
-	list, errResp := svc.GetLotsBySKU(&sku)
+	list, errResp := svc.GetLotsBySKU(testTenantA, &sku)
 	require.Nil(t, errResp)
 	require.Len(t, list, 2)
 	assert.Equal(t, "S1", list[0].SKU)
 	assert.Equal(t, "S1", list[1].SKU)
+}
+
+// S3.5 W2-B: same SKU exists for two tenants — service must only return caller's tenant's lots.
+func TestLotsService_GetLotsBySKU_TenantIsolation(t *testing.T) {
+	repo := &mockLotsRepo{
+		lots: []database.Lot{
+			{ID: "1", SKU: "SHARED", LotNumber: "A-L1", TenantID: testTenantA},
+			{ID: "2", SKU: "SHARED", LotNumber: "B-L1", TenantID: testTenantB},
+		},
+	}
+	svc := NewLotsService(repo, nil)
+	sku := "SHARED"
+	listA, errResp := svc.GetLotsBySKU(testTenantA, &sku)
+	require.Nil(t, errResp)
+	require.Len(t, listA, 1)
+	assert.Equal(t, "A-L1", listA[0].LotNumber)
 }
 
 func TestLotsService_CreateLot_Success(t *testing.T) {
@@ -192,8 +258,9 @@ func TestLotsService_CreateLot_Success(t *testing.T) {
 		SKU:       "ART-1",
 		Quantity:  100,
 	}
-	errResp := svc.Create(req)
+	errResp := svc.Create(testTenantA, req)
 	require.Nil(t, errResp)
+	assert.Equal(t, testTenantA, repo.lastCreateTenant, "tenantID must be threaded through to repo")
 }
 
 func TestLotsService_CreateLot_Error(t *testing.T) {
@@ -205,7 +272,7 @@ func TestLotsService_CreateLot_Error(t *testing.T) {
 	}
 	svc := NewLotsService(repo, nil)
 	req := &requests.CreateLotRequest{LotNumber: "L", SKU: "S", Quantity: 1}
-	errResp := svc.Create(req)
+	errResp := svc.Create(testTenantA, req)
 	require.NotNil(t, errResp)
 	assert.False(t, errResp.Handled)
 }
@@ -224,7 +291,7 @@ func TestLotsService_GetLotsBySKU_OrdersByFIFO(t *testing.T) {
 	articlesRepo := &mockArticlesRepoForLots{rotationStrategy: "fifo"}
 	svc := NewLotsService(repo, articlesRepo)
 	sku := "S1"
-	list, errResp := svc.GetLotsBySKU(&sku)
+	list, errResp := svc.GetLotsBySKU(testTenantA, &sku)
 	require.Nil(t, errResp)
 	require.Len(t, list, 3)
 	// FIFO: oldest first -> L3 (t3), L1 (t1), L2 (t2)
@@ -245,7 +312,7 @@ func TestLotsService_GetLotsBySKU_OrdersByFEFO(t *testing.T) {
 	articlesRepo := &mockArticlesRepoForLots{rotationStrategy: "fefo"}
 	svc := NewLotsService(repo, articlesRepo)
 	sku := "S1"
-	list, errResp := svc.GetLotsBySKU(&sku)
+	list, errResp := svc.GetLotsBySKU(testTenantA, &sku)
 	require.Nil(t, errResp)
 	require.Len(t, list, 2)
 	// FEFO: earliest expiry first -> L2 (exp2), L1 (exp1)
@@ -269,7 +336,7 @@ func TestLotsService_CreateLot_WithExtendedFields(t *testing.T) {
 		ManufacturedAt: &mfgDate,
 		BestBeforeDate: &bbd,
 	}
-	errResp := svc.Create(req)
+	errResp := svc.Create(testTenantA, req)
 	require.Nil(t, errResp)
 }
 
@@ -279,7 +346,7 @@ func TestLotsService_GetLotByID_Found(t *testing.T) {
 		{ID: "lot-abc", LotNumber: "L1", SKU: "SKU-001", CreatedAt: now},
 	}}
 	svc := NewLotsService(repo, nil)
-	lot, errResp := svc.GetLotByID("lot-abc")
+	lot, errResp := svc.GetLotByID(testTenantA, "lot-abc")
 	require.Nil(t, errResp)
 	require.NotNil(t, lot)
 	assert.Equal(t, "L1", lot.LotNumber)
@@ -288,7 +355,19 @@ func TestLotsService_GetLotByID_Found(t *testing.T) {
 func TestLotsService_GetLotByID_NotFound(t *testing.T) {
 	repo := &mockLotsRepo{}
 	svc := NewLotsService(repo, nil)
-	_, errResp := svc.GetLotByID("nonexistent")
+	_, errResp := svc.GetLotByID(testTenantA, "nonexistent")
+	require.NotNil(t, errResp)
+	assert.Equal(t, responses.StatusNotFound, errResp.StatusCode)
+}
+
+// S3.5 W2-B: lot belongs to tenant B; tenant A must see NotFound (no info leak).
+func TestLotsService_GetLotByID_CrossTenantReturnsNotFound(t *testing.T) {
+	now := time.Now()
+	repo := &mockLotsRepo{lots: []database.Lot{
+		{ID: "lot-b", LotNumber: "B-L1", SKU: "SKU-001", CreatedAt: now, TenantID: testTenantB},
+	}}
+	svc := NewLotsService(repo, nil)
+	_, errResp := svc.GetLotByID(testTenantA, "lot-b")
 	require.NotNil(t, errResp)
 	assert.Equal(t, responses.StatusNotFound, errResp.StatusCode)
 }
@@ -306,9 +385,19 @@ func TestLotsService_FEFO_UsesExpirationDate_NotBBD(t *testing.T) {
 	sku := "SKU-FEFO"
 	artRepo := &mockArticlesRepoForLots{rotationStrategy: "fefo"}
 	svc := NewLotsService(repo, artRepo)
-	list, _ := svc.GetLotsBySKU(&sku)
+	list, _ := svc.GetLotsBySKU(testTenantA, &sku)
 	require.Len(t, list, 2)
 	// FEFO by expiration_date: L2 (5 days) before L1 (10 days)
 	assert.Equal(t, "L2", list[0].LotNumber)
 	assert.Equal(t, "L1", list[1].LotNumber)
+}
+
+// S3.5 W2-B: Update/Delete propagate tenantID to the repo.
+func TestLotsService_UpdateAndDelete_PropagateTenantID(t *testing.T) {
+	repo := &mockLotsRepo{}
+	svc := NewLotsService(repo, nil)
+	require.Nil(t, svc.UpdateUpdateLot(testTenantA, "lot-1", map[string]interface{}{"quantity": 5.0}))
+	assert.Equal(t, testTenantA, repo.lastUpdateTenant)
+	require.Nil(t, svc.DeleteLot(testTenantA, "lot-1"))
+	assert.Equal(t, testTenantA, repo.lastDeleteTenant)
 }

--- a/services/stock_alerts_service.go
+++ b/services/stock_alerts_service.go
@@ -16,22 +16,25 @@ func NewStockAlertsService(repo ports.StockAlertsRepository) *StockAlertsService
 	}
 }
 
-func (s *StockAlertsService) GetAllStockAlerts(resolved bool) ([]database.StockAlert, *responses.InternalResponse) {
-	return s.Repository.GetAllStockAlerts(resolved)
+// S3.5 W2-B: every method threads tenantID. Cron callers must iterate the active tenants
+// list and invoke Analyze/LotExpiration per tenant; HTTP callers pass Config.TenantID.
+
+func (s *StockAlertsService) GetAllStockAlerts(tenantID string, resolved bool) ([]database.StockAlert, *responses.InternalResponse) {
+	return s.Repository.GetAllStockAlerts(tenantID, resolved)
 }
 
-func (s *StockAlertsService) Analyze() (*responses.StockAlertResponse, *responses.InternalResponse) {
-	return s.Repository.Analyze()
+func (s *StockAlertsService) Analyze(tenantID string) (*responses.StockAlertResponse, *responses.InternalResponse) {
+	return s.Repository.Analyze(tenantID)
 }
 
-func (s *StockAlertsService) LotExpiration() (*responses.StockAlertResponse, *responses.InternalResponse) {
-	return s.Repository.LotExpiration()
+func (s *StockAlertsService) LotExpiration(tenantID string) (*responses.StockAlertResponse, *responses.InternalResponse) {
+	return s.Repository.LotExpiration(tenantID)
 }
 
-func (s *StockAlertsService) ResolveAlert(alertID string) *responses.InternalResponse {
-	return s.Repository.ResolveAlert(alertID)
+func (s *StockAlertsService) ResolveAlert(tenantID, alertID string) *responses.InternalResponse {
+	return s.Repository.ResolveAlert(tenantID, alertID)
 }
 
-func (s *StockAlertsService) ExportAlertsToExcel() ([]byte, *responses.InternalResponse) {
-	return s.Repository.ExportAlertsToExcel()
+func (s *StockAlertsService) ExportAlertsToExcel(tenantID string) ([]byte, *responses.InternalResponse) {
+	return s.Repository.ExportAlertsToExcel(tenantID)
 }

--- a/services/stock_alerts_service_test.go
+++ b/services/stock_alerts_service_test.go
@@ -11,35 +11,50 @@ import (
 )
 
 // mockStockAlertsRepo is an in-memory fake for unit testing StockAlertsService.
+//
+// S3.5 W2-B: every method receives the tenantID so tests assert it gets propagated
+// from the service layer.
 type mockStockAlertsRepo struct {
-	alerts           []database.StockAlert
-	alertsErr        *responses.InternalResponse
-	analyzeResp      *responses.StockAlertResponse
-	analyzeErr       *responses.InternalResponse
-	lotExpirationResp *responses.StockAlertResponse
-	lotExpirationErr  *responses.InternalResponse
-	resolveErr       *responses.InternalResponse
-	excelBytes       []byte
-	excelErr         *responses.InternalResponse
+	alerts             []database.StockAlert
+	alertsErr          *responses.InternalResponse
+	analyzeResp        *responses.StockAlertResponse
+	analyzeErr         *responses.InternalResponse
+	lotExpirationResp  *responses.StockAlertResponse
+	lotExpirationErr   *responses.InternalResponse
+	resolveErr         *responses.InternalResponse
+	excelBytes         []byte
+	excelErr           *responses.InternalResponse
+	lastGetAllTenant   string
+	lastAnalyzeTenant  string
+	lastLotExpTenant   string
+	lastResolveTenant  string
+	lastExcelTenant    string
+	lastResolveAlertID string
 }
 
-func (m *mockStockAlertsRepo) GetAllStockAlerts(resolved bool) ([]database.StockAlert, *responses.InternalResponse) {
+func (m *mockStockAlertsRepo) GetAllStockAlerts(tenantID string, resolved bool) ([]database.StockAlert, *responses.InternalResponse) {
+	m.lastGetAllTenant = tenantID
 	return m.alerts, m.alertsErr
 }
 
-func (m *mockStockAlertsRepo) Analyze() (*responses.StockAlertResponse, *responses.InternalResponse) {
+func (m *mockStockAlertsRepo) Analyze(tenantID string) (*responses.StockAlertResponse, *responses.InternalResponse) {
+	m.lastAnalyzeTenant = tenantID
 	return m.analyzeResp, m.analyzeErr
 }
 
-func (m *mockStockAlertsRepo) LotExpiration() (*responses.StockAlertResponse, *responses.InternalResponse) {
+func (m *mockStockAlertsRepo) LotExpiration(tenantID string) (*responses.StockAlertResponse, *responses.InternalResponse) {
+	m.lastLotExpTenant = tenantID
 	return m.lotExpirationResp, m.lotExpirationErr
 }
 
-func (m *mockStockAlertsRepo) ResolveAlert(alertID string) *responses.InternalResponse {
+func (m *mockStockAlertsRepo) ResolveAlert(tenantID, alertID string) *responses.InternalResponse {
+	m.lastResolveTenant = tenantID
+	m.lastResolveAlertID = alertID
 	return m.resolveErr
 }
 
-func (m *mockStockAlertsRepo) ExportAlertsToExcel() ([]byte, *responses.InternalResponse) {
+func (m *mockStockAlertsRepo) ExportAlertsToExcel(tenantID string) ([]byte, *responses.InternalResponse) {
+	m.lastExcelTenant = tenantID
 	return m.excelBytes, m.excelErr
 }
 
@@ -51,11 +66,12 @@ func TestStockAlertsService_GetAllStockAlerts_Success(t *testing.T) {
 	repo := &mockStockAlertsRepo{alerts: alerts}
 	svc := NewStockAlertsService(repo)
 
-	result, errResp := svc.GetAllStockAlerts(false)
+	result, errResp := svc.GetAllStockAlerts(testTenantA, false)
 	require.Nil(t, errResp)
 	require.Len(t, result, 2)
 	assert.Equal(t, "SKU1", result[0].SKU)
 	assert.Equal(t, "critical", result[0].AlertLevel)
+	assert.Equal(t, testTenantA, repo.lastGetAllTenant, "tenantID must reach the repo")
 }
 
 func TestStockAlertsService_GetAllStockAlerts_Resolved(t *testing.T) {
@@ -65,7 +81,7 @@ func TestStockAlertsService_GetAllStockAlerts_Resolved(t *testing.T) {
 	repo := &mockStockAlertsRepo{alerts: alerts}
 	svc := NewStockAlertsService(repo)
 
-	result, errResp := svc.GetAllStockAlerts(true)
+	result, errResp := svc.GetAllStockAlerts(testTenantA, true)
 	require.Nil(t, errResp)
 	require.Len(t, result, 1)
 	assert.True(t, result[0].IsResolved)
@@ -81,7 +97,7 @@ func TestStockAlertsService_GetAllStockAlerts_Error(t *testing.T) {
 	}
 	svc := NewStockAlertsService(repo)
 
-	result, errResp := svc.GetAllStockAlerts(false)
+	result, errResp := svc.GetAllStockAlerts(testTenantA, false)
 	require.NotNil(t, errResp)
 	assert.Nil(t, result)
 	assert.False(t, errResp.Handled)
@@ -96,12 +112,13 @@ func TestStockAlertsService_Analyze_Success(t *testing.T) {
 	repo := &mockStockAlertsRepo{analyzeResp: analyzeResp}
 	svc := NewStockAlertsService(repo)
 
-	result, errResp := svc.Analyze()
+	result, errResp := svc.Analyze(testTenantA)
 	require.Nil(t, errResp)
 	require.NotNil(t, result)
 	assert.Equal(t, "Analysis complete", result.Message)
 	assert.Equal(t, 1, result.Summary.Total)
 	assert.Equal(t, 1, result.Summary.Critical)
+	assert.Equal(t, testTenantA, repo.lastAnalyzeTenant)
 }
 
 func TestStockAlertsService_Analyze_Error(t *testing.T) {
@@ -114,7 +131,7 @@ func TestStockAlertsService_Analyze_Error(t *testing.T) {
 	}
 	svc := NewStockAlertsService(repo)
 
-	result, errResp := svc.Analyze()
+	result, errResp := svc.Analyze(testTenantA)
 	require.NotNil(t, errResp)
 	assert.Nil(t, result)
 	assert.False(t, errResp.Handled)
@@ -129,11 +146,12 @@ func TestStockAlertsService_LotExpiration_Success(t *testing.T) {
 	repo := &mockStockAlertsRepo{lotExpirationResp: lotResp}
 	svc := NewStockAlertsService(repo)
 
-	result, errResp := svc.LotExpiration()
+	result, errResp := svc.LotExpiration(testTenantA)
 	require.Nil(t, errResp)
 	require.NotNil(t, result)
 	assert.Equal(t, "Lot expiration analysis complete", result.Message)
 	assert.Equal(t, 1, result.Summary.Expiring)
+	assert.Equal(t, testTenantA, repo.lastLotExpTenant)
 }
 
 func TestStockAlertsService_LotExpiration_Error(t *testing.T) {
@@ -146,7 +164,7 @@ func TestStockAlertsService_LotExpiration_Error(t *testing.T) {
 	}
 	svc := NewStockAlertsService(repo)
 
-	result, errResp := svc.LotExpiration()
+	result, errResp := svc.LotExpiration(testTenantA)
 	require.NotNil(t, errResp)
 	assert.Nil(t, result)
 	assert.False(t, errResp.Handled)
@@ -156,8 +174,10 @@ func TestStockAlertsService_ResolveAlert_Success(t *testing.T) {
 	repo := &mockStockAlertsRepo{}
 	svc := NewStockAlertsService(repo)
 
-	errResp := svc.ResolveAlert("alert-1")
+	errResp := svc.ResolveAlert(testTenantA, "alert-1")
 	require.Nil(t, errResp)
+	assert.Equal(t, testTenantA, repo.lastResolveTenant)
+	assert.Equal(t, "alert-1", repo.lastResolveAlertID)
 }
 
 func TestStockAlertsService_ResolveAlert_NotFound(t *testing.T) {
@@ -170,7 +190,7 @@ func TestStockAlertsService_ResolveAlert_NotFound(t *testing.T) {
 	}
 	svc := NewStockAlertsService(repo)
 
-	errResp := svc.ResolveAlert("alert-99")
+	errResp := svc.ResolveAlert(testTenantA, "alert-99")
 	require.NotNil(t, errResp)
 	assert.True(t, errResp.Handled)
 	assert.Equal(t, responses.StatusNotFound, errResp.StatusCode)
@@ -181,9 +201,10 @@ func TestStockAlertsService_ExportAlertsToExcel_Success(t *testing.T) {
 	repo := &mockStockAlertsRepo{excelBytes: excelBytes}
 	svc := NewStockAlertsService(repo)
 
-	result, errResp := svc.ExportAlertsToExcel()
+	result, errResp := svc.ExportAlertsToExcel(testTenantA)
 	require.Nil(t, errResp)
 	assert.Equal(t, excelBytes, result)
+	assert.Equal(t, testTenantA, repo.lastExcelTenant)
 }
 
 func TestStockAlertsService_ExportAlertsToExcel_Error(t *testing.T) {
@@ -196,7 +217,7 @@ func TestStockAlertsService_ExportAlertsToExcel_Error(t *testing.T) {
 	}
 	svc := NewStockAlertsService(repo)
 
-	result, errResp := svc.ExportAlertsToExcel()
+	result, errResp := svc.ExportAlertsToExcel(testTenantA)
 	require.NotNil(t, errResp)
 	assert.Nil(t, result)
 	assert.False(t, errResp.Handled)

--- a/tools/cron.go
+++ b/tools/cron.go
@@ -88,19 +88,21 @@ func RunStaleReservationsCleanup(db *gorm.DB) error {
 }
 
 // RunStockAlertAnalysis corre el análisis de alertas de stock (low + expiring).
-// HR1-C2: usa pg_try_advisory_xact_lock (transaction-scoped) dentro de db.Transaction(),
-// igual que RunStaleReservationsCleanup. El lock se libera automáticamente al commit/rollback,
-// eliminando el bug donde lock y unlock corrían en distintas conexiones del pool (session-level
-// pg_try_advisory_lock + defer pg_advisory_unlock en conexiones distintas del pool).
-// analyzer() corre dentro de la misma transacción; GORM maneja transacciones anidadas vía
-// savepoints, por lo que los Begin() internos del repo no causan deadlock.
-func RunStockAlertAnalysis(db *gorm.DB, analyzer func() error) error {
+// HR1-C2: usa pg_try_advisory_xact_lock (transaction-scoped) dentro de db.Transaction().
+// El lock se libera automáticamente al commit/rollback.
+//
+// S3.5 W2-B: el analyzer ahora se ejecuta una vez por tenant activo. La firma
+// `analyzer(tenantID string) error` permite al caller (main, admin_cron) inyectar
+// la lógica concreta (Analyze + LotExpiration por tenant) sin dependencia de servicios
+// — evita ciclos de import. La iteración consulta `tenants` directamente; si la tabla
+// no existe (deploys S2/S2.5 antiguos) se hace fallback al tenant default para preservar
+// el comportamiento single-tenant.
+func RunStockAlertAnalysis(db *gorm.DB, analyzer func(tenantID string) error) error {
 	if db == nil {
 		return errors.New("cron: nil db")
 	}
 	return db.Transaction(func(tx *gorm.DB) error {
 		// Advisory lock a nivel de transacción — un pod a la vez.
-		// Se libera automáticamente al commit/rollback.
 		var locked bool
 		if err := tx.Raw("SELECT pg_try_advisory_xact_lock(987654321)").Scan(&locked).Error; err != nil {
 			return err
@@ -109,8 +111,49 @@ func RunStockAlertAnalysis(db *gorm.DB, analyzer func() error) error {
 			log.Debug().Msg("cron: stock_alerts: otro pod tiene el lock, skipping")
 			return nil
 		}
-		return analyzer()
+
+		tenantIDs, err := activeTenantIDs(tx)
+		if err != nil {
+			return fmt.Errorf("stock_alerts: list tenants: %w", err)
+		}
+
+		for _, tid := range tenantIDs {
+			if err := analyzer(tid); err != nil {
+				// Don't abort the whole run — log and continue so one bad tenant does
+				// not starve every other tenant of fresh alerts.
+				log.Error().Err(err).Str("tenant_id", tid).Msg("cron: stock_alerts: analyzer failed for tenant")
+			}
+		}
+		return nil
 	})
+}
+
+// activeTenantIDs returns the set of tenant UUIDs eligible for cron processing.
+// Falls back to the global default tenant UUID when the `tenants` table is missing
+// (older deployments) or empty — preserves single-tenant behavior pre-S3.
+func activeTenantIDs(tx *gorm.DB) ([]string, error) {
+	const defaultTenantID = "00000000-0000-0000-0000-000000000001"
+
+	// Cheap probe: if `tenants` doesn't exist, return the default tenant.
+	var exists bool
+	if err := tx.Raw("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'tenants')").
+		Scan(&exists).Error; err != nil || !exists {
+		return []string{defaultTenantID}, nil
+	}
+
+	var ids []string
+	if err := tx.Raw(`
+		SELECT id::text FROM tenants
+		 WHERE deleted_at IS NULL
+		   AND (is_active IS NULL OR is_active = true)
+		   AND (status IS NULL OR status NOT IN ('past_due','cancelled','suspended'))
+	`).Scan(&ids).Error; err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		return []string{defaultTenantID}, nil
+	}
+	return ids, nil
 }
 
 // LotExpirationWindow describes a lot approaching expiration.
@@ -363,10 +406,11 @@ func RunTrialExpirationCheck(db *gorm.DB, sendFn func(ctx context.Context, toEma
 // Los errores se loggean sin parar la ejecución del siguiente job.
 //
 // Callbacks (all optional, pass nil to skip):
+//   - analyzer: invoked per active tenant (S3.5 W2-B); receives the tenant UUID string.
 //   - lotNotifyFn: called per expiring lot event (eventType, title, body)
 //   - lowStockNotifyFn: called per unresolved low-stock alert (sku, message)
 //   - trialSendFn: called per trial tenant requiring a reminder or expiration email
-func CronDispatch(db *gorm.DB, analyzer func() error, lotNotifyFn func(eventType, title, body string) error, lowStockNotifyFn func(sku, message string) error, trialSendFn func(ctx context.Context, toEmail, tenantName, templateType string, daysLeft int) error) {
+func CronDispatch(db *gorm.DB, analyzer func(tenantID string) error, lotNotifyFn func(eventType, title, body string) error, lowStockNotifyFn func(sku, message string) error, trialSendFn func(ctx context.Context, toEmail, tenantName, templateType string, daysLeft int) error) {
 	if err := RunStockAlertAnalysis(db, analyzer); err != nil {
 		log.Error().Err(err).Msg("cron: stock alerts failed")
 	}

--- a/tools/cron_test.go
+++ b/tools/cron_test.go
@@ -213,8 +213,12 @@ func TestCronDispatch_BothJobsRun(t *testing.T) {
 	defer cleanup()
 
 	analyzerCalled := false
-	analyzer := func() error {
+	// S3.5 W2-B: analyzer is invoked per active tenant. With no tenants seeded, the
+	// fallback returns the default tenant UUID, so the callback fires exactly once.
+	var analyzerTenants []string
+	analyzer := func(tenantID string) error {
 		analyzerCalled = true
+		analyzerTenants = append(analyzerTenants, tenantID)
 		return errors.New("simulated stock_alerts failure")
 	}
 
@@ -222,6 +226,7 @@ func TestCronDispatch_BothJobsRun(t *testing.T) {
 	CronDispatch(db, analyzer, nil, nil, nil)
 
 	assert.True(t, analyzerCalled, "analyzer must be called")
+	assert.NotEmpty(t, analyzerTenants, "analyzer must receive at least the default tenant when no tenants exist")
 	// stale cleanup ran on empty tables without error (verified by no panic)
 }
 

--- a/tools/table_configs.go
+++ b/tools/table_configs.go
@@ -76,7 +76,21 @@ func LocationsTableConfig() TableConfig {
 }
 
 // LotsTableConfig returns the generic table configuration for lots.
-func LotsTableConfig() TableConfig {
+//
+// S3.5 W2-B: tenantID, when non-empty, is baked into DefaultWhere as a UUID literal so
+// the generic list/export handlers always scope rows to the calling tenant. The literal
+// is single-quoted and ::uuid-cast — Postgres rejects malformed UUIDs at plan time, so
+// an invalid string from a misconfigured route surfaces as a SQL error rather than a
+// silent cross-tenant leak.
+func LotsTableConfig(tenantID ...string) TableConfig {
+	tid := ""
+	if len(tenantID) > 0 {
+		tid = tenantID[0]
+	}
+	defaultWhere := ""
+	if tid != "" {
+		defaultWhere = "l.tenant_id = '" + tid + "'::uuid"
+	}
 	return TableConfig{
 		EntityName: "lotes",
 		FromClause: "lots l",
@@ -89,11 +103,11 @@ func LotsTableConfig() TableConfig {
 			"status":        "l.status",
 			"created_at":    "l.created_at",
 		},
-		SearchFields: []string{"l.lot_number", "l.sku"},
-		DefaultWhere: "",
-		SelectFields: "l.id, l.lot_number, l.sku, l.quantity, l.expiration_date, l.status, l.created_at",
-		CSVFields:    []string{"id", "lot_number", "sku", "quantity", "expiration_at", "status", "created_at"},
-		CSVHeaders:   []string{"ID", "Lote", "SKU", "Cantidad", "Expira en", "Estado", "Creado en"},
+		SearchFields:   []string{"l.lot_number", "l.sku"},
+		DefaultWhere:   defaultWhere,
+		SelectFields:   "l.id, l.lot_number, l.sku, l.quantity, l.expiration_date, l.status, l.created_at",
+		CSVFields:      []string{"id", "lot_number", "sku", "quantity", "expiration_at", "status", "created_at"},
+		CSVHeaders:     []string{"ID", "Lote", "SKU", "Cantidad", "Expira en", "Estado", "Creado en"},
 		DefaultSortBy:  "created_at",
 		DefaultSortDir: "desc",
 	}


### PR DESCRIPTION
## Summary

S3.5 W2-B closes the multi-tenant master-data gap on the last two operational tables in the `lots` + `stock_alerts` slice. Before this PR a second tenant could read/mutate the first tenant's lots, and `Analyze()` would TRUNCATE the global stock_alerts table on every dashboard load — the audit doc flagged both as blockers for `ENABLE_SIGNUP=true`.

Two commits, one per table:

- **lots (000030)** — adds `tenant_id` UUID NOT NULL, composite indexes `(tenant_id, created_at)` + `(tenant_id, sku)`, per-tenant unique `(tenant_id, sku, lot_number)`. Repository (GORM + SQLC) + service + controller + route + generic table config all thread `tenantID`. New `GetLotByIDForTenant` for HTTP callers; `GetLotByID` retained for internal joins where the parent record proves tenancy.
- **stock_alerts (000031)** — adds `tenant_id` UUID NOT NULL + composite `(tenant_id, is_resolved, created_at)`. **Analyze() refactor**: TRUNCATE → tenant-scoped DELETE; all inventory/movement/lot reads carry `WHERE tenant_id = ?`; Redis + in-memory caches keyed per tenant. Cron pipeline (`tools.RunStockAlertAnalysis`, `CronDispatch`, `cmd/main.go`, `admin_cron_controller`) now iterates active tenants from the `tenants` table (with default-tenant fallback for older deploys) and invokes the analyzer per tenant; one bad tenant logs and continues.

Sister waves W1 (articles) and W2-A (locations / serials / inventory_lots) own the remaining master-data tables and the migration numbers 000029 + 000032/3/4.

## Validation

- `go build ./...` clean
- `go vet ./...` clean
- `go test -count=1 -race -short ./...` all green (unit + most integration)
- `make sqlc` idempotent — second run is a no-op
- Migration 000030 + 000031 apply cleanly via testcontainers (verified by `TestCronDispatch_BothJobsRun` running the full migration chain). Down migrations are mechanical `DROP INDEX` + `DROP COLUMN`.

The pre-existing `TestPurchaseOrders_PONumber_Sequenced_PerTenant` integration failure is unrelated (PO-domain `FOR UPDATE` + aggregate, baseline broken).

## Test plan

- [ ] CI green on the new branch
- [ ] Manual two-tenant smoke against a dev database:
  - [ ] tenant A creates lot `LOT-001/SKU-A`, tenant B creates `LOT-001/SKU-A` — both succeed
  - [ ] `GET /api/lots/` as tenant A returns only A's rows
  - [ ] `PUT /api/lots/<B-id>` as tenant A returns 404
  - [ ] `POST /api/stock-alerts/analyze` as tenant A → only A's alerts; B's existing rows preserved
  - [ ] cron `POST /admin/cron/trigger?job=stock_alerts` analyses both tenants in one tick
- [ ] Roll forward + roll back 000030 and 000031 against a non-prod DB

## Refs

- Audit: `plans/sessions/audit-s35-w2-master-data.md` (lots + stock_alerts sections)
- Roadmap: `plans/2026-04-24-sprint-S3.5-roadmap.md`
- Memory: `feedback_estock_articles_no_tenant_isolation.md`