### PR TITLE
S3.5 W1: articles tenant_id isolation (HR-S3-W5 C2 fix)

### DIFF
--- a/controllers/articles_controller.go
+++ b/controllers/articles_controller.go
@@ -12,22 +12,26 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// ArticlesController — S3.5 W1: now carries TenantID injected from Config (env-injected
+// per-deployment). HR-S3-W5 C2 fix; future M2 will source tenantID from JWT claim instead.
 type ArticlesController struct {
 	Service       services.ArticlesService
 	AuditService  *services.AuditService
 	UserPrefsRepo ports.UserPreferencesRepository
+	TenantID      string
 }
 
-func NewArticlesController(service services.ArticlesService, auditSvc *services.AuditService, userPrefsRepo ports.UserPreferencesRepository) *ArticlesController {
+func NewArticlesController(service services.ArticlesService, auditSvc *services.AuditService, userPrefsRepo ports.UserPreferencesRepository, tenantID string) *ArticlesController {
 	return &ArticlesController{
 		Service:       service,
 		AuditService:  auditSvc,
 		UserPrefsRepo: userPrefsRepo,
+		TenantID:      tenantID,
 	}
 }
 
 func (c *ArticlesController) GetAllArticles(ctx *gin.Context) {
-	articles, response := c.Service.GetAllArticles()
+	articles, response := c.Service.GetAllArticles(c.TenantID)
 
 	if response != nil {
 		writeErrorResponse(ctx, "GetAllArticles", "get_all_articles", response)
@@ -48,7 +52,7 @@ func (c *ArticlesController) GetArticleByID(ctx *gin.Context) {
 		return
 	}
 
-	article, response := c.Service.GetArticleByID(articleID)
+	article, response := c.Service.GetArticleByID(articleID, c.TenantID)
 	if response != nil {
 		writeErrorResponse(ctx, "GetArticleByID", "get_article_by_id", response)
 		return
@@ -67,7 +71,7 @@ func (c *ArticlesController) GetBySku(ctx *gin.Context) {
 	if !ok {
 		return
 	}
-	article, response := c.Service.GetBySku(sku)
+	article, response := c.Service.GetBySku(sku, c.TenantID)
 	if response != nil {
 		writeErrorResponse(ctx, "GetBySku", "get_by_sku", response)
 		return
@@ -92,7 +96,7 @@ func (c *ArticlesController) CreateArticle(ctx *gin.Context) {
 		return
 	}
 
-	response := c.Service.CreateArticle(&articleRequest)
+	response := c.Service.CreateArticle(c.TenantID, &articleRequest)
 	if response != nil {
 		writeErrorResponse(ctx, "CreateArticle", "create_article", response)
 		return
@@ -116,7 +120,7 @@ func (c *ArticlesController) UpdateArticle(ctx *gin.Context) {
 		return
 	}
 
-	article, _ := c.Service.GetArticleByID(id)
+	article, _ := c.Service.GetArticleByID(id, c.TenantID)
 	var req requests.Article
 	if err := ctx.ShouldBindJSON(&req); err != nil {
 		tools.ResponseBadRequest(ctx, "UpdateArticle", "Carga útil no válida", "update_article")
@@ -127,7 +131,7 @@ func (c *ArticlesController) UpdateArticle(ctx *gin.Context) {
 		return
 	}
 
-	updatedArticle, errResp, warnings := c.Service.UpdateArticle(id, &req)
+	updatedArticle, errResp, warnings := c.Service.UpdateArticle(id, c.TenantID, &req)
 	if errResp != nil {
 		writeErrorResponse(ctx, "UpdateArticle", "update_article", errResp)
 		return
@@ -170,7 +174,7 @@ func (c *ArticlesController) ImportArticlesFromExcel(ctx *gin.Context) {
 		return
 	}
 
-	importedArticles, skippedArticles, errorResponses := c.Service.ImportArticlesFromExcel(fileBytes)
+	importedArticles, skippedArticles, errorResponses := c.Service.ImportArticlesFromExcel(c.TenantID, fileBytes)
 	if len(importedArticles) == 0 && len(skippedArticles) == 0 && len(errorResponses) > 0 {
 		resp := errorResponses[0]
 		writeErrorResponse(ctx, "ImportArticlesFromExcel", "import_articles_from_excel", resp)
@@ -178,12 +182,12 @@ func (c *ArticlesController) ImportArticlesFromExcel(ctx *gin.Context) {
 	}
 
 	tools.ResponseOK(ctx, "ImportArticlesFromExcel", "Artículos importados con éxito", "import_articles_from_excel", gin.H{
-		"successful": len(importedArticles),
-		"skipped":    len(skippedArticles),
-		"failed":     len(errorResponses),
-		"imported":   importedArticles,
+		"successful":   len(importedArticles),
+		"skipped":      len(skippedArticles),
+		"failed":       len(errorResponses),
+		"imported":     importedArticles,
 		"skipped_rows": skippedArticles,
-		"errors":     errorResponses,
+		"errors":       errorResponses,
 	}, false, "")
 }
 
@@ -197,7 +201,7 @@ func (c *ArticlesController) ValidateImportRows(ctx *gin.Context) {
 		tools.ResponseBadRequest(ctx, "ValidateImportRows", "No se proporcionaron filas", "validate_import_rows")
 		return
 	}
-	results, resp := c.Service.ValidateImportRows(rows)
+	results, resp := c.Service.ValidateImportRows(c.TenantID, rows)
 	if resp != nil {
 		writeErrorResponse(ctx, "ValidateImportRows", "validate_import_rows", resp)
 		return
@@ -218,7 +222,7 @@ func (c *ArticlesController) ImportArticlesFromJSON(ctx *gin.Context) {
 		return
 	}
 
-	imported, skipped, errorResponses := c.Service.ImportArticlesFromJSON(rows)
+	imported, skipped, errorResponses := c.Service.ImportArticlesFromJSON(c.TenantID, rows)
 	tools.ResponseOK(ctx, "ImportArticlesFromJSON", "Importación completada", "import_articles_from_json", gin.H{
 		"successful":   len(imported),
 		"skipped":      len(skipped),
@@ -230,7 +234,7 @@ func (c *ArticlesController) ImportArticlesFromJSON(ctx *gin.Context) {
 }
 
 func (c *ArticlesController) ExportArticlesToExcel(ctx *gin.Context) {
-	fileBytes, response := c.Service.ExportArticlesToExcel()
+	fileBytes, response := c.Service.ExportArticlesToExcel(c.TenantID)
 	if response != nil {
 		writeErrorResponse(ctx, "ExportArticlesToExcel", "export_articles_to_excel", response)
 		return
@@ -250,7 +254,7 @@ func (c *ArticlesController) DownloadImportTemplate(ctx *gin.Context) {
 		}
 	}
 
-	fileBytes, response := c.Service.GenerateImportTemplate(lang)
+	fileBytes, response := c.Service.GenerateImportTemplate(c.TenantID, lang)
 	if response != nil {
 		writeErrorResponse(ctx, "DownloadImportTemplate", "download_articles_import_template", response)
 		return
@@ -267,8 +271,8 @@ func (c *ArticlesController) DeleteArticle(ctx *gin.Context) {
 		return
 	}
 
-	article, _ := c.Service.GetArticleByID(id)
-	resp := c.Service.DeleteArticle(id)
+	article, _ := c.Service.GetArticleByID(id, c.TenantID)
+	resp := c.Service.DeleteArticle(id, c.TenantID)
 	if resp != nil {
 		writeErrorResponse(ctx, "DeleteArticle", "delete_article", resp)
 		return

--- a/controllers/articles_controller_test.go
+++ b/controllers/articles_controller_test.go
@@ -22,6 +22,10 @@ func init() {
 
 // ─── mock repo ───────────────────────────────────────────────────────────────
 
+// testTenantIDCtrl is the constant tenant UUID used by controller tests; matches
+// the migration 000029 backfill default.
+const testTenantIDCtrl = "00000000-0000-0000-0000-000000000001"
+
 type mockArticlesRepoCtrl struct {
 	articles  []database.Article
 	byID      map[string]*database.Article
@@ -30,10 +34,12 @@ type mockArticlesRepoCtrl struct {
 	deleteErr *responses.InternalResponse
 }
 
-func (m *mockArticlesRepoCtrl) GetAllArticles() ([]database.Article, *responses.InternalResponse) {
+// ── tenant-scoped (HTTP-facing) ─────────────────────────────────────────────
+
+func (m *mockArticlesRepoCtrl) GetAllArticlesForTenant(_ string) ([]database.Article, *responses.InternalResponse) {
 	return m.articles, nil
 }
-func (m *mockArticlesRepoCtrl) GetArticleByID(id string) (*database.Article, *responses.InternalResponse) {
+func (m *mockArticlesRepoCtrl) GetArticleByIDForTenant(id, _ string) (*database.Article, *responses.InternalResponse) {
 	if m.byID != nil {
 		if a, ok := m.byID[id]; ok {
 			return a, nil
@@ -41,7 +47,7 @@ func (m *mockArticlesRepoCtrl) GetArticleByID(id string) (*database.Article, *re
 	}
 	return nil, &responses.InternalResponse{Message: "not found", Handled: true, StatusCode: responses.StatusNotFound}
 }
-func (m *mockArticlesRepoCtrl) GetBySku(sku string) (*database.Article, *responses.InternalResponse) {
+func (m *mockArticlesRepoCtrl) GetBySkuForTenant(sku, _ string) (*database.Article, *responses.InternalResponse) {
 	if m.bySku != nil {
 		if a, ok := m.bySku[sku]; ok {
 			return a, nil
@@ -49,10 +55,10 @@ func (m *mockArticlesRepoCtrl) GetBySku(sku string) (*database.Article, *respons
 	}
 	return nil, &responses.InternalResponse{Message: "not found", Handled: true, StatusCode: responses.StatusNotFound}
 }
-func (m *mockArticlesRepoCtrl) CreateArticle(data *requests.Article) *responses.InternalResponse {
+func (m *mockArticlesRepoCtrl) CreateArticleForTenant(_ string, _ *requests.Article) *responses.InternalResponse {
 	return m.createErr
 }
-func (m *mockArticlesRepoCtrl) UpdateArticle(id string, data *requests.Article) (*database.Article, *responses.InternalResponse) {
+func (m *mockArticlesRepoCtrl) UpdateArticleForTenant(id, _ string, _ *requests.Article) (*database.Article, *responses.InternalResponse) {
 	if m.byID != nil {
 		if a, ok := m.byID[id]; ok {
 			return a, nil
@@ -60,32 +66,44 @@ func (m *mockArticlesRepoCtrl) UpdateArticle(id string, data *requests.Article) 
 	}
 	return nil, &responses.InternalResponse{Message: "not found", Handled: true, StatusCode: responses.StatusNotFound}
 }
-func (m *mockArticlesRepoCtrl) GetLotsBySKU(sku string) ([]database.Lot, error)     { return nil, nil }
-func (m *mockArticlesRepoCtrl) GetSerialsBySKU(sku string) ([]database.Serial, error) { return nil, nil }
-func (m *mockArticlesRepoCtrl) ImportArticlesFromExcel(fileBytes []byte) ([]string, []string, []*responses.InternalResponse) {
-	return nil, nil, nil
-}
-func (m *mockArticlesRepoCtrl) ImportArticlesFromJSON(_ []requests.ArticleImportRow) ([]string, []string, []*responses.InternalResponse) {
-	return nil, nil, nil
-}
-func (m *mockArticlesRepoCtrl) ExportArticlesToExcel() ([]byte, *responses.InternalResponse) {
-	return []byte("xlsx"), nil
-}
-func (m *mockArticlesRepoCtrl) GenerateImportTemplate(_ string) ([]byte, *responses.InternalResponse) {
-	return []byte("tpl"), nil
-}
-func (m *mockArticlesRepoCtrl) ValidateImportRows(_ []requests.ArticleImportRow) ([]responses.ArticleValidationResult, *responses.InternalResponse) {
-	return nil, nil
-}
-func (m *mockArticlesRepoCtrl) DeleteArticle(id string) *responses.InternalResponse {
+func (m *mockArticlesRepoCtrl) DeleteArticleForTenant(_, _ string) *responses.InternalResponse {
 	return m.deleteErr
 }
+func (m *mockArticlesRepoCtrl) ImportArticlesFromExcelForTenant(_ string, _ []byte) ([]string, []string, []*responses.InternalResponse) {
+	return nil, nil, nil
+}
+func (m *mockArticlesRepoCtrl) ImportArticlesFromJSONForTenant(_ string, _ []requests.ArticleImportRow) ([]string, []string, []*responses.InternalResponse) {
+	return nil, nil, nil
+}
+func (m *mockArticlesRepoCtrl) ValidateImportRowsForTenant(_ string, _ []requests.ArticleImportRow) ([]responses.ArticleValidationResult, *responses.InternalResponse) {
+	return nil, nil
+}
+func (m *mockArticlesRepoCtrl) ExportArticlesToExcelForTenant(_ string) ([]byte, *responses.InternalResponse) {
+	return []byte("xlsx"), nil
+}
+func (m *mockArticlesRepoCtrl) GenerateImportTemplateForTenant(_, _ string) ([]byte, *responses.InternalResponse) {
+	return []byte("tpl"), nil
+}
+
+// ── legacy (non-tenant) ─────────────────────────────────────────────────────
+
+func (m *mockArticlesRepoCtrl) GetAllArticles() ([]database.Article, *responses.InternalResponse) {
+	return m.articles, nil
+}
+func (m *mockArticlesRepoCtrl) GetArticleByID(id string) (*database.Article, *responses.InternalResponse) {
+	return m.GetArticleByIDForTenant(id, "")
+}
+func (m *mockArticlesRepoCtrl) GetBySku(sku string) (*database.Article, *responses.InternalResponse) {
+	return m.GetBySkuForTenant(sku, "")
+}
+func (m *mockArticlesRepoCtrl) GetLotsBySKU(_ string) ([]database.Lot, error)       { return nil, nil }
+func (m *mockArticlesRepoCtrl) GetSerialsBySKU(_ string) ([]database.Serial, error) { return nil, nil }
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
 func newArticlesController(repo *mockArticlesRepoCtrl) *ArticlesController {
 	svc := services.NewArticlesService(repo)
-	return NewArticlesController(*svc, nil, nil)
+	return NewArticlesController(*svc, nil, nil, testTenantIDCtrl)
 }
 
 func performRequest(handler gin.HandlerFunc, method, path string, body interface{}, params gin.Params) *httptest.ResponseRecorder {

--- a/db/migrations/000029_articles_tenant_id.down.sql
+++ b/db/migrations/000029_articles_tenant_id.down.sql
@@ -1,0 +1,13 @@
+-- 000029_articles_tenant_id.down.sql
+-- Reverses 000029_articles_tenant_id.up.sql.
+--
+-- WARNING: this rollback is only safe in single-tenant environments. If multiple
+-- tenants share overlapping SKUs (which becomes valid post-up), dropping tenant_id
+-- collapses them and the existing `articles_sku_key` global unique remains intact —
+-- but the rows themselves stay (no data loss); only the per-tenant scoping disappears.
+
+DROP INDEX IF EXISTS idx_articles_tenant_category;
+DROP INDEX IF EXISTS idx_articles_tenant_created;
+DROP INDEX IF EXISTS articles_tenant_sku_key;
+
+ALTER TABLE articles DROP COLUMN IF EXISTS tenant_id;

--- a/db/migrations/000029_articles_tenant_id.up.sql
+++ b/db/migrations/000029_articles_tenant_id.up.sql
@@ -1,0 +1,55 @@
+-- 000029_articles_tenant_id.up.sql
+-- Sprint S3.5 W1 — articles tenant isolation (HR-S3-W5 C2 fix).
+--
+-- Articles table was born tenant-agnostic (000002_estock_schema). With S3 SaaS
+-- multi-tenant signup live, every second tenant signing up was silently inheriting
+-- tenant 1's articles via SeedFarma's `WHERE sku=? FirstOrCreate` pattern.
+--
+-- This migration adds tenant_id, backfills with the default tenant UUID
+-- (matching the convention in 000019_tenant_id_operational and 000023_saas_lifecycle),
+-- and adds a per-tenant composite unique on (tenant_id, sku).
+--
+-- FK NOTE: We intentionally KEEP the existing `articles_sku_key` global UNIQUE on
+-- (sku) for now. There are 8+ FKs referencing articles(sku) (inventory.sku,
+-- stock_transfer_items.sku, article_suppliers.article_sku, purchase_order_items.article_sku,
+-- sales_order_items.article_sku, delivery_note_items.article_sku, backorders.article_sku,
+-- and similar). Dropping the global unique would require redesigning every dependent
+-- FK as composite (tenant_id, sku). That cross-table retrofit is deferred to a future
+-- sprint after every dependent table has its own tenant_id (W2 covers lots/inventory_lots/
+-- locations/serials, but inventory and stock_transfer_items still need work). The new
+-- composite unique below is what the application code uses for per-tenant SKU dedup;
+-- the global unique remains as a safety net + FK target until then.
+
+-- 1. Add tenant_id column with default backfill to default tenant (matches S2/S3 convention).
+ALTER TABLE articles
+  ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001'::uuid;
+
+-- 2. Drop the DEFAULT after backfill so future inserts must explicitly set tenant_id.
+ALTER TABLE articles ALTER COLUMN tenant_id DROP DEFAULT;
+
+-- 3. Per-tenant SKU uniqueness — application reads dedup via this index.
+--
+-- KNOWN LIMITATION: until the FK retrofit lands, the legacy `articles_sku_key`
+-- (global UNIQUE on sku) still prevents two different tenants from registering
+-- the same SKU value. The composite below is what application logic reads from
+-- (per-tenant lookups, "exists by tenant + sku" checks, etc.); it becomes the
+-- ENFORCEMENT mechanism only once the global unique is dropped — see
+-- feedback_estock_articles_no_tenant_isolation.md and the W2/W4 follow-ups.
+--
+-- For S3.5 W1 specifically, this means SeedFarma for a SECOND tenant must use
+-- SKUs that don't collide with the first tenant's catalog. The W4 wave will
+-- update SeedFarma to either prefix SKUs per-tenant or share the master catalog
+-- explicitly. Fixing the data-leak symptom (tenant 2 inheriting tenant 1 rows
+-- silently) is achieved here by scoping every read/write by tenant_id; the
+-- "same SKU across tenants" capability is a separate, larger structural change.
+CREATE UNIQUE INDEX articles_tenant_sku_key ON articles(tenant_id, sku);
+
+-- 4. Composite covering index for the common list query (sorted by created_at DESC).
+CREATE INDEX idx_articles_tenant_created ON articles(tenant_id, created_at DESC);
+
+-- 5. Composite index for category filter (common in catalog UI). category_id was added in S2 M2.
+CREATE INDEX idx_articles_tenant_category ON articles(tenant_id, category_id)
+  WHERE category_id IS NOT NULL;
+
+-- 6. Optional: FK to tenants table for referential integrity (HR-S2.5 deferred from 000019).
+--    Skipped to keep migration reversible and consistent with 000019; can be added later.

--- a/db/query/articles/articles.sql
+++ b/db/query/articles/articles.sql
@@ -1,8 +1,13 @@
--- Articles CRUD and related queries for sqlc
--- Schema: db/migrations (articles, lots, serials tables)
+-- Articles CRUD and related queries for sqlc.
+-- Schema: db/migrations (articles, lots, serials tables).
+-- S3.5 W1 — every read/write is now tenant-scoped via tenant_id (HR-S3-W5 C2).
+-- The legacy global queries (ListArticles, GetArticleBySku, ArticleExistsBySku) remain
+-- ONLY for internal lookups (FK validation, stock alerts cron, dashboards) where the
+-- caller has no JWT/Config tenant context. HTTP endpoints MUST use the *ForTenant variants.
 
 -- name: ListArticles :many
-SELECT id, sku, name, description, unit_price, presentation,
+-- INTERNAL USE ONLY (cron, FK lookups). HTTP handlers must call ListArticlesForTenant.
+SELECT id, tenant_id, sku, name, description, unit_price, presentation,
        track_by_lot, track_by_serial, track_expiration, rotation_strategy,
        min_quantity, max_quantity, image_url, is_active,
        created_at, updated_at,
@@ -12,8 +17,22 @@ SELECT id, sku, name, description, unit_price, presentation,
 FROM articles
 ORDER BY created_at ASC;
 
+-- name: ListArticlesForTenant :many
+-- HTTP-facing list. Uses idx_articles_tenant_created (composite covering index).
+SELECT id, tenant_id, sku, name, description, unit_price, presentation,
+       track_by_lot, track_by_serial, track_expiration, rotation_strategy,
+       min_quantity, max_quantity, image_url, is_active,
+       created_at, updated_at,
+       category_id, shelf_life_in_days, safety_stock, batch_number_series,
+       serial_number_series, min_order_qty, default_location_id,
+       receiving_notes, shipping_notes
+FROM articles
+WHERE tenant_id = $1
+ORDER BY created_at DESC;
+
 -- name: GetArticleByID :one
-SELECT id, sku, name, description, unit_price, presentation,
+-- INTERNAL USE ONLY. HTTP handlers must call GetArticleByIDForTenant.
+SELECT id, tenant_id, sku, name, description, unit_price, presentation,
        track_by_lot, track_by_serial, track_expiration, rotation_strategy,
        min_quantity, max_quantity, image_url, is_active,
        created_at, updated_at,
@@ -24,8 +43,22 @@ FROM articles
 WHERE id = $1
 LIMIT 1;
 
+-- name: GetArticleByIDForTenant :one
+-- HR-style tenant guard. Use for HTTP responses to prevent cross-tenant enumeration.
+SELECT id, tenant_id, sku, name, description, unit_price, presentation,
+       track_by_lot, track_by_serial, track_expiration, rotation_strategy,
+       min_quantity, max_quantity, image_url, is_active,
+       created_at, updated_at,
+       category_id, shelf_life_in_days, safety_stock, batch_number_series,
+       serial_number_series, min_order_qty, default_location_id,
+       receiving_notes, shipping_notes
+FROM articles
+WHERE id = $1 AND tenant_id = $2
+LIMIT 1;
+
 -- name: GetArticleBySku :one
-SELECT id, sku, name, description, unit_price, presentation,
+-- INTERNAL USE ONLY (FK lookups, dashboards). HTTP handlers must call GetArticleBySkuForTenant.
+SELECT id, tenant_id, sku, name, description, unit_price, presentation,
        track_by_lot, track_by_serial, track_expiration, rotation_strategy,
        min_quantity, max_quantity, image_url, is_active,
        created_at, updated_at,
@@ -36,22 +69,40 @@ FROM articles
 WHERE sku = $1
 LIMIT 1;
 
+-- name: GetArticleBySkuForTenant :one
+-- Per-tenant SKU lookup. Hits articles_tenant_sku_key index.
+SELECT id, tenant_id, sku, name, description, unit_price, presentation,
+       track_by_lot, track_by_serial, track_expiration, rotation_strategy,
+       min_quantity, max_quantity, image_url, is_active,
+       created_at, updated_at,
+       category_id, shelf_life_in_days, safety_stock, batch_number_series,
+       serial_number_series, min_order_qty, default_location_id,
+       receiving_notes, shipping_notes
+FROM articles
+WHERE sku = $1 AND tenant_id = $2
+LIMIT 1;
+
 -- name: ArticleExistsBySku :one
+-- INTERNAL USE ONLY. Tenant-scoped variant below.
 SELECT EXISTS(SELECT 1 FROM articles WHERE sku = $1) AS exists;
 
+-- name: ArticleExistsBySkuForTenant :one
+SELECT EXISTS(SELECT 1 FROM articles WHERE sku = $1 AND tenant_id = $2) AS exists;
+
 -- name: CreateArticle :one
+-- All inserts now require tenant_id ($1).
 INSERT INTO articles (
-    sku, name, description, unit_price, presentation,
+    tenant_id, sku, name, description, unit_price, presentation,
     track_by_lot, track_by_serial, track_expiration, rotation_strategy,
     min_quantity, max_quantity, image_url,
     category_id, shelf_life_in_days, safety_stock, batch_number_series,
     serial_number_series, min_order_qty, default_location_id,
     receiving_notes, shipping_notes
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
-    $13, $14, $15, $16, $17, $18, $19, $20, $21
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
+    $14, $15, $16, $17, $18, $19, $20, $21, $22
 )
-RETURNING id, sku, name, description, unit_price, presentation,
+RETURNING id, tenant_id, sku, name, description, unit_price, presentation,
           track_by_lot, track_by_serial, track_expiration, rotation_strategy,
           min_quantity, max_quantity, image_url, is_active,
           created_at, updated_at,
@@ -60,6 +111,7 @@ RETURNING id, sku, name, description, unit_price, presentation,
           receiving_notes, shipping_notes;
 
 -- name: UpdateArticle :one
+-- Tenant guard via WHERE id = $1 AND tenant_id = $24 — prevents cross-tenant update.
 UPDATE articles
 SET
     sku = $2,
@@ -85,8 +137,8 @@ SET
     receiving_notes = $22,
     shipping_notes = $23,
     updated_at = CURRENT_TIMESTAMP
-WHERE id = $1
-RETURNING id, sku, name, description, unit_price, presentation,
+WHERE id = $1 AND tenant_id = $24
+RETURNING id, tenant_id, sku, name, description, unit_price, presentation,
           track_by_lot, track_by_serial, track_expiration, rotation_strategy,
           min_quantity, max_quantity, image_url, is_active,
           created_at, updated_at,
@@ -95,16 +147,19 @@ RETURNING id, sku, name, description, unit_price, presentation,
           receiving_notes, shipping_notes;
 
 -- name: DeleteArticle :exec
-DELETE FROM articles WHERE id = $1;
+-- Tenant guard prevents cross-tenant delete.
+DELETE FROM articles WHERE id = $1 AND tenant_id = $2;
 
--- Lots by SKU (for UpdateArticle warnings)
+-- Lots by SKU (for UpdateArticle warnings) — internal, no tenant filter (lots table
+-- not yet tenant-scoped; tracked in S3.5 W2).
 -- name: ListLotsBySku :many
 SELECT id, lot_number, sku, quantity, expiration_date, created_at, updated_at, status,
        lot_notes, manufactured_at, best_before_date
 FROM lots
 WHERE sku = $1;
 
--- Serials by SKU (for UpdateArticle warnings)
+-- Serials by SKU (for UpdateArticle warnings) — internal, no tenant filter (serials
+-- table not yet tenant-scoped; tracked in S3.5 W2).
 -- name: ListSerialsBySku :many
 SELECT id, serial_number, sku, status, created_at, updated_at
 FROM serials

--- a/db/sqlc/articles.sql.go
+++ b/db/sqlc/articles.sql.go
@@ -15,6 +15,7 @@ const articleExistsBySku = `-- name: ArticleExistsBySku :one
 SELECT EXISTS(SELECT 1 FROM articles WHERE sku = $1) AS exists
 `
 
+// INTERNAL USE ONLY. Tenant-scoped variant below.
 func (q *Queries) ArticleExistsBySku(ctx context.Context, sku string) (bool, error) {
 	row := q.db.QueryRow(ctx, articleExistsBySku, sku)
 	var exists bool
@@ -22,19 +23,35 @@ func (q *Queries) ArticleExistsBySku(ctx context.Context, sku string) (bool, err
 	return exists, err
 }
 
+const articleExistsBySkuForTenant = `-- name: ArticleExistsBySkuForTenant :one
+SELECT EXISTS(SELECT 1 FROM articles WHERE sku = $1 AND tenant_id = $2) AS exists
+`
+
+type ArticleExistsBySkuForTenantParams struct {
+	Sku      string      `json:"sku"`
+	TenantID pgtype.UUID `json:"tenant_id"`
+}
+
+func (q *Queries) ArticleExistsBySkuForTenant(ctx context.Context, arg ArticleExistsBySkuForTenantParams) (bool, error) {
+	row := q.db.QueryRow(ctx, articleExistsBySkuForTenant, arg.Sku, arg.TenantID)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const createArticle = `-- name: CreateArticle :one
 INSERT INTO articles (
-    sku, name, description, unit_price, presentation,
+    tenant_id, sku, name, description, unit_price, presentation,
     track_by_lot, track_by_serial, track_expiration, rotation_strategy,
     min_quantity, max_quantity, image_url,
     category_id, shelf_life_in_days, safety_stock, batch_number_series,
     serial_number_series, min_order_qty, default_location_id,
     receiving_notes, shipping_notes
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
-    $13, $14, $15, $16, $17, $18, $19, $20, $21
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
+    $14, $15, $16, $17, $18, $19, $20, $21, $22
 )
-RETURNING id, sku, name, description, unit_price, presentation,
+RETURNING id, tenant_id, sku, name, description, unit_price, presentation,
           track_by_lot, track_by_serial, track_expiration, rotation_strategy,
           min_quantity, max_quantity, image_url, is_active,
           created_at, updated_at,
@@ -44,6 +61,7 @@ RETURNING id, sku, name, description, unit_price, presentation,
 `
 
 type CreateArticleParams struct {
+	TenantID           pgtype.UUID    `json:"tenant_id"`
 	Sku                string         `json:"sku"`
 	Name               string         `json:"name"`
 	Description        pgtype.Text    `json:"description"`
@@ -69,6 +87,7 @@ type CreateArticleParams struct {
 
 type CreateArticleRow struct {
 	ID                 string           `json:"id"`
+	TenantID           pgtype.UUID      `json:"tenant_id"`
 	Sku                string           `json:"sku"`
 	Name               string           `json:"name"`
 	Description        pgtype.Text      `json:"description"`
@@ -95,8 +114,10 @@ type CreateArticleRow struct {
 	ShippingNotes      pgtype.Text      `json:"shipping_notes"`
 }
 
+// All inserts now require tenant_id ($1).
 func (q *Queries) CreateArticle(ctx context.Context, arg CreateArticleParams) (CreateArticleRow, error) {
 	row := q.db.QueryRow(ctx, createArticle,
+		arg.TenantID,
 		arg.Sku,
 		arg.Name,
 		arg.Description,
@@ -122,6 +143,7 @@ func (q *Queries) CreateArticle(ctx context.Context, arg CreateArticleParams) (C
 	var i CreateArticleRow
 	err := row.Scan(
 		&i.ID,
+		&i.TenantID,
 		&i.Sku,
 		&i.Name,
 		&i.Description,
@@ -151,16 +173,22 @@ func (q *Queries) CreateArticle(ctx context.Context, arg CreateArticleParams) (C
 }
 
 const deleteArticle = `-- name: DeleteArticle :exec
-DELETE FROM articles WHERE id = $1
+DELETE FROM articles WHERE id = $1 AND tenant_id = $2
 `
 
-func (q *Queries) DeleteArticle(ctx context.Context, id string) error {
-	_, err := q.db.Exec(ctx, deleteArticle, id)
+type DeleteArticleParams struct {
+	ID       string      `json:"id"`
+	TenantID pgtype.UUID `json:"tenant_id"`
+}
+
+// Tenant guard prevents cross-tenant delete.
+func (q *Queries) DeleteArticle(ctx context.Context, arg DeleteArticleParams) error {
+	_, err := q.db.Exec(ctx, deleteArticle, arg.ID, arg.TenantID)
 	return err
 }
 
 const getArticleByID = `-- name: GetArticleByID :one
-SELECT id, sku, name, description, unit_price, presentation,
+SELECT id, tenant_id, sku, name, description, unit_price, presentation,
        track_by_lot, track_by_serial, track_expiration, rotation_strategy,
        min_quantity, max_quantity, image_url, is_active,
        created_at, updated_at,
@@ -174,6 +202,7 @@ LIMIT 1
 
 type GetArticleByIDRow struct {
 	ID                 string           `json:"id"`
+	TenantID           pgtype.UUID      `json:"tenant_id"`
 	Sku                string           `json:"sku"`
 	Name               string           `json:"name"`
 	Description        pgtype.Text      `json:"description"`
@@ -200,11 +229,95 @@ type GetArticleByIDRow struct {
 	ShippingNotes      pgtype.Text      `json:"shipping_notes"`
 }
 
+// INTERNAL USE ONLY. HTTP handlers must call GetArticleByIDForTenant.
 func (q *Queries) GetArticleByID(ctx context.Context, id string) (GetArticleByIDRow, error) {
 	row := q.db.QueryRow(ctx, getArticleByID, id)
 	var i GetArticleByIDRow
 	err := row.Scan(
 		&i.ID,
+		&i.TenantID,
+		&i.Sku,
+		&i.Name,
+		&i.Description,
+		&i.UnitPrice,
+		&i.Presentation,
+		&i.TrackByLot,
+		&i.TrackBySerial,
+		&i.TrackExpiration,
+		&i.RotationStrategy,
+		&i.MinQuantity,
+		&i.MaxQuantity,
+		&i.ImageUrl,
+		&i.IsActive,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.CategoryID,
+		&i.ShelfLifeInDays,
+		&i.SafetyStock,
+		&i.BatchNumberSeries,
+		&i.SerialNumberSeries,
+		&i.MinOrderQty,
+		&i.DefaultLocationID,
+		&i.ReceivingNotes,
+		&i.ShippingNotes,
+	)
+	return i, err
+}
+
+const getArticleByIDForTenant = `-- name: GetArticleByIDForTenant :one
+SELECT id, tenant_id, sku, name, description, unit_price, presentation,
+       track_by_lot, track_by_serial, track_expiration, rotation_strategy,
+       min_quantity, max_quantity, image_url, is_active,
+       created_at, updated_at,
+       category_id, shelf_life_in_days, safety_stock, batch_number_series,
+       serial_number_series, min_order_qty, default_location_id,
+       receiving_notes, shipping_notes
+FROM articles
+WHERE id = $1 AND tenant_id = $2
+LIMIT 1
+`
+
+type GetArticleByIDForTenantParams struct {
+	ID       string      `json:"id"`
+	TenantID pgtype.UUID `json:"tenant_id"`
+}
+
+type GetArticleByIDForTenantRow struct {
+	ID                 string           `json:"id"`
+	TenantID           pgtype.UUID      `json:"tenant_id"`
+	Sku                string           `json:"sku"`
+	Name               string           `json:"name"`
+	Description        pgtype.Text      `json:"description"`
+	UnitPrice          pgtype.Numeric   `json:"unit_price"`
+	Presentation       string           `json:"presentation"`
+	TrackByLot         bool             `json:"track_by_lot"`
+	TrackBySerial      bool             `json:"track_by_serial"`
+	TrackExpiration    bool             `json:"track_expiration"`
+	RotationStrategy   string           `json:"rotation_strategy"`
+	MinQuantity        pgtype.Int4      `json:"min_quantity"`
+	MaxQuantity        pgtype.Int4      `json:"max_quantity"`
+	ImageUrl           pgtype.Text      `json:"image_url"`
+	IsActive           pgtype.Bool      `json:"is_active"`
+	CreatedAt          pgtype.Timestamp `json:"created_at"`
+	UpdatedAt          pgtype.Timestamp `json:"updated_at"`
+	CategoryID         pgtype.Text      `json:"category_id"`
+	ShelfLifeInDays    pgtype.Int4      `json:"shelf_life_in_days"`
+	SafetyStock        pgtype.Numeric   `json:"safety_stock"`
+	BatchNumberSeries  pgtype.Text      `json:"batch_number_series"`
+	SerialNumberSeries pgtype.Text      `json:"serial_number_series"`
+	MinOrderQty        pgtype.Numeric   `json:"min_order_qty"`
+	DefaultLocationID  pgtype.Text      `json:"default_location_id"`
+	ReceivingNotes     pgtype.Text      `json:"receiving_notes"`
+	ShippingNotes      pgtype.Text      `json:"shipping_notes"`
+}
+
+// HR-style tenant guard. Use for HTTP responses to prevent cross-tenant enumeration.
+func (q *Queries) GetArticleByIDForTenant(ctx context.Context, arg GetArticleByIDForTenantParams) (GetArticleByIDForTenantRow, error) {
+	row := q.db.QueryRow(ctx, getArticleByIDForTenant, arg.ID, arg.TenantID)
+	var i GetArticleByIDForTenantRow
+	err := row.Scan(
+		&i.ID,
+		&i.TenantID,
 		&i.Sku,
 		&i.Name,
 		&i.Description,
@@ -234,7 +347,7 @@ func (q *Queries) GetArticleByID(ctx context.Context, id string) (GetArticleByID
 }
 
 const getArticleBySku = `-- name: GetArticleBySku :one
-SELECT id, sku, name, description, unit_price, presentation,
+SELECT id, tenant_id, sku, name, description, unit_price, presentation,
        track_by_lot, track_by_serial, track_expiration, rotation_strategy,
        min_quantity, max_quantity, image_url, is_active,
        created_at, updated_at,
@@ -248,6 +361,7 @@ LIMIT 1
 
 type GetArticleBySkuRow struct {
 	ID                 string           `json:"id"`
+	TenantID           pgtype.UUID      `json:"tenant_id"`
 	Sku                string           `json:"sku"`
 	Name               string           `json:"name"`
 	Description        pgtype.Text      `json:"description"`
@@ -274,11 +388,95 @@ type GetArticleBySkuRow struct {
 	ShippingNotes      pgtype.Text      `json:"shipping_notes"`
 }
 
+// INTERNAL USE ONLY (FK lookups, dashboards). HTTP handlers must call GetArticleBySkuForTenant.
 func (q *Queries) GetArticleBySku(ctx context.Context, sku string) (GetArticleBySkuRow, error) {
 	row := q.db.QueryRow(ctx, getArticleBySku, sku)
 	var i GetArticleBySkuRow
 	err := row.Scan(
 		&i.ID,
+		&i.TenantID,
+		&i.Sku,
+		&i.Name,
+		&i.Description,
+		&i.UnitPrice,
+		&i.Presentation,
+		&i.TrackByLot,
+		&i.TrackBySerial,
+		&i.TrackExpiration,
+		&i.RotationStrategy,
+		&i.MinQuantity,
+		&i.MaxQuantity,
+		&i.ImageUrl,
+		&i.IsActive,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.CategoryID,
+		&i.ShelfLifeInDays,
+		&i.SafetyStock,
+		&i.BatchNumberSeries,
+		&i.SerialNumberSeries,
+		&i.MinOrderQty,
+		&i.DefaultLocationID,
+		&i.ReceivingNotes,
+		&i.ShippingNotes,
+	)
+	return i, err
+}
+
+const getArticleBySkuForTenant = `-- name: GetArticleBySkuForTenant :one
+SELECT id, tenant_id, sku, name, description, unit_price, presentation,
+       track_by_lot, track_by_serial, track_expiration, rotation_strategy,
+       min_quantity, max_quantity, image_url, is_active,
+       created_at, updated_at,
+       category_id, shelf_life_in_days, safety_stock, batch_number_series,
+       serial_number_series, min_order_qty, default_location_id,
+       receiving_notes, shipping_notes
+FROM articles
+WHERE sku = $1 AND tenant_id = $2
+LIMIT 1
+`
+
+type GetArticleBySkuForTenantParams struct {
+	Sku      string      `json:"sku"`
+	TenantID pgtype.UUID `json:"tenant_id"`
+}
+
+type GetArticleBySkuForTenantRow struct {
+	ID                 string           `json:"id"`
+	TenantID           pgtype.UUID      `json:"tenant_id"`
+	Sku                string           `json:"sku"`
+	Name               string           `json:"name"`
+	Description        pgtype.Text      `json:"description"`
+	UnitPrice          pgtype.Numeric   `json:"unit_price"`
+	Presentation       string           `json:"presentation"`
+	TrackByLot         bool             `json:"track_by_lot"`
+	TrackBySerial      bool             `json:"track_by_serial"`
+	TrackExpiration    bool             `json:"track_expiration"`
+	RotationStrategy   string           `json:"rotation_strategy"`
+	MinQuantity        pgtype.Int4      `json:"min_quantity"`
+	MaxQuantity        pgtype.Int4      `json:"max_quantity"`
+	ImageUrl           pgtype.Text      `json:"image_url"`
+	IsActive           pgtype.Bool      `json:"is_active"`
+	CreatedAt          pgtype.Timestamp `json:"created_at"`
+	UpdatedAt          pgtype.Timestamp `json:"updated_at"`
+	CategoryID         pgtype.Text      `json:"category_id"`
+	ShelfLifeInDays    pgtype.Int4      `json:"shelf_life_in_days"`
+	SafetyStock        pgtype.Numeric   `json:"safety_stock"`
+	BatchNumberSeries  pgtype.Text      `json:"batch_number_series"`
+	SerialNumberSeries pgtype.Text      `json:"serial_number_series"`
+	MinOrderQty        pgtype.Numeric   `json:"min_order_qty"`
+	DefaultLocationID  pgtype.Text      `json:"default_location_id"`
+	ReceivingNotes     pgtype.Text      `json:"receiving_notes"`
+	ShippingNotes      pgtype.Text      `json:"shipping_notes"`
+}
+
+// Per-tenant SKU lookup. Hits articles_tenant_sku_key index.
+func (q *Queries) GetArticleBySkuForTenant(ctx context.Context, arg GetArticleBySkuForTenantParams) (GetArticleBySkuForTenantRow, error) {
+	row := q.db.QueryRow(ctx, getArticleBySkuForTenant, arg.Sku, arg.TenantID)
+	var i GetArticleBySkuForTenantRow
+	err := row.Scan(
+		&i.ID,
+		&i.TenantID,
 		&i.Sku,
 		&i.Name,
 		&i.Description,
@@ -309,7 +507,7 @@ func (q *Queries) GetArticleBySku(ctx context.Context, sku string) (GetArticleBy
 
 const listArticles = `-- name: ListArticles :many
 
-SELECT id, sku, name, description, unit_price, presentation,
+SELECT id, tenant_id, sku, name, description, unit_price, presentation,
        track_by_lot, track_by_serial, track_expiration, rotation_strategy,
        min_quantity, max_quantity, image_url, is_active,
        created_at, updated_at,
@@ -322,6 +520,7 @@ ORDER BY created_at ASC
 
 type ListArticlesRow struct {
 	ID                 string           `json:"id"`
+	TenantID           pgtype.UUID      `json:"tenant_id"`
 	Sku                string           `json:"sku"`
 	Name               string           `json:"name"`
 	Description        pgtype.Text      `json:"description"`
@@ -348,8 +547,13 @@ type ListArticlesRow struct {
 	ShippingNotes      pgtype.Text      `json:"shipping_notes"`
 }
 
-// Articles CRUD and related queries for sqlc
-// Schema: db/migrations (articles, lots, serials tables)
+// Articles CRUD and related queries for sqlc.
+// Schema: db/migrations (articles, lots, serials tables).
+// S3.5 W1 — every read/write is now tenant-scoped via tenant_id (HR-S3-W5 C2).
+// The legacy global queries (ListArticles, GetArticleBySku, ArticleExistsBySku) remain
+// ONLY for internal lookups (FK validation, stock alerts cron, dashboards) where the
+// caller has no JWT/Config tenant context. HTTP endpoints MUST use the *ForTenant variants.
+// INTERNAL USE ONLY (cron, FK lookups). HTTP handlers must call ListArticlesForTenant.
 func (q *Queries) ListArticles(ctx context.Context) ([]ListArticlesRow, error) {
 	rows, err := q.db.Query(ctx, listArticles)
 	if err != nil {
@@ -361,6 +565,97 @@ func (q *Queries) ListArticles(ctx context.Context) ([]ListArticlesRow, error) {
 		var i ListArticlesRow
 		if err := rows.Scan(
 			&i.ID,
+			&i.TenantID,
+			&i.Sku,
+			&i.Name,
+			&i.Description,
+			&i.UnitPrice,
+			&i.Presentation,
+			&i.TrackByLot,
+			&i.TrackBySerial,
+			&i.TrackExpiration,
+			&i.RotationStrategy,
+			&i.MinQuantity,
+			&i.MaxQuantity,
+			&i.ImageUrl,
+			&i.IsActive,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.CategoryID,
+			&i.ShelfLifeInDays,
+			&i.SafetyStock,
+			&i.BatchNumberSeries,
+			&i.SerialNumberSeries,
+			&i.MinOrderQty,
+			&i.DefaultLocationID,
+			&i.ReceivingNotes,
+			&i.ShippingNotes,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listArticlesForTenant = `-- name: ListArticlesForTenant :many
+SELECT id, tenant_id, sku, name, description, unit_price, presentation,
+       track_by_lot, track_by_serial, track_expiration, rotation_strategy,
+       min_quantity, max_quantity, image_url, is_active,
+       created_at, updated_at,
+       category_id, shelf_life_in_days, safety_stock, batch_number_series,
+       serial_number_series, min_order_qty, default_location_id,
+       receiving_notes, shipping_notes
+FROM articles
+WHERE tenant_id = $1
+ORDER BY created_at DESC
+`
+
+type ListArticlesForTenantRow struct {
+	ID                 string           `json:"id"`
+	TenantID           pgtype.UUID      `json:"tenant_id"`
+	Sku                string           `json:"sku"`
+	Name               string           `json:"name"`
+	Description        pgtype.Text      `json:"description"`
+	UnitPrice          pgtype.Numeric   `json:"unit_price"`
+	Presentation       string           `json:"presentation"`
+	TrackByLot         bool             `json:"track_by_lot"`
+	TrackBySerial      bool             `json:"track_by_serial"`
+	TrackExpiration    bool             `json:"track_expiration"`
+	RotationStrategy   string           `json:"rotation_strategy"`
+	MinQuantity        pgtype.Int4      `json:"min_quantity"`
+	MaxQuantity        pgtype.Int4      `json:"max_quantity"`
+	ImageUrl           pgtype.Text      `json:"image_url"`
+	IsActive           pgtype.Bool      `json:"is_active"`
+	CreatedAt          pgtype.Timestamp `json:"created_at"`
+	UpdatedAt          pgtype.Timestamp `json:"updated_at"`
+	CategoryID         pgtype.Text      `json:"category_id"`
+	ShelfLifeInDays    pgtype.Int4      `json:"shelf_life_in_days"`
+	SafetyStock        pgtype.Numeric   `json:"safety_stock"`
+	BatchNumberSeries  pgtype.Text      `json:"batch_number_series"`
+	SerialNumberSeries pgtype.Text      `json:"serial_number_series"`
+	MinOrderQty        pgtype.Numeric   `json:"min_order_qty"`
+	DefaultLocationID  pgtype.Text      `json:"default_location_id"`
+	ReceivingNotes     pgtype.Text      `json:"receiving_notes"`
+	ShippingNotes      pgtype.Text      `json:"shipping_notes"`
+}
+
+// HTTP-facing list. Uses idx_articles_tenant_created (composite covering index).
+func (q *Queries) ListArticlesForTenant(ctx context.Context, tenantID pgtype.UUID) ([]ListArticlesForTenantRow, error) {
+	rows, err := q.db.Query(ctx, listArticlesForTenant, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListArticlesForTenantRow{}
+	for rows.Next() {
+		var i ListArticlesForTenantRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.TenantID,
 			&i.Sku,
 			&i.Name,
 			&i.Description,
@@ -403,7 +698,8 @@ FROM lots
 WHERE sku = $1
 `
 
-// Lots by SKU (for UpdateArticle warnings)
+// Lots by SKU (for UpdateArticle warnings) — internal, no tenant filter (lots table
+// not yet tenant-scoped; tracked in S3.5 W2).
 func (q *Queries) ListLotsBySku(ctx context.Context, sku string) ([]Lot, error) {
 	rows, err := q.db.Query(ctx, listLotsBySku, sku)
 	if err != nil {
@@ -442,7 +738,8 @@ FROM serials
 WHERE sku = $1
 `
 
-// Serials by SKU (for UpdateArticle warnings)
+// Serials by SKU (for UpdateArticle warnings) — internal, no tenant filter (serials
+// table not yet tenant-scoped; tracked in S3.5 W2).
 func (q *Queries) ListSerialsBySku(ctx context.Context, sku string) ([]Serial, error) {
 	rows, err := q.db.Query(ctx, listSerialsBySku, sku)
 	if err != nil {
@@ -496,8 +793,8 @@ SET
     receiving_notes = $22,
     shipping_notes = $23,
     updated_at = CURRENT_TIMESTAMP
-WHERE id = $1
-RETURNING id, sku, name, description, unit_price, presentation,
+WHERE id = $1 AND tenant_id = $24
+RETURNING id, tenant_id, sku, name, description, unit_price, presentation,
           track_by_lot, track_by_serial, track_expiration, rotation_strategy,
           min_quantity, max_quantity, image_url, is_active,
           created_at, updated_at,
@@ -530,10 +827,12 @@ type UpdateArticleParams struct {
 	DefaultLocationID  pgtype.Text    `json:"default_location_id"`
 	ReceivingNotes     pgtype.Text    `json:"receiving_notes"`
 	ShippingNotes      pgtype.Text    `json:"shipping_notes"`
+	TenantID           pgtype.UUID    `json:"tenant_id"`
 }
 
 type UpdateArticleRow struct {
 	ID                 string           `json:"id"`
+	TenantID           pgtype.UUID      `json:"tenant_id"`
 	Sku                string           `json:"sku"`
 	Name               string           `json:"name"`
 	Description        pgtype.Text      `json:"description"`
@@ -560,6 +859,7 @@ type UpdateArticleRow struct {
 	ShippingNotes      pgtype.Text      `json:"shipping_notes"`
 }
 
+// Tenant guard via WHERE id = $1 AND tenant_id = $24 — prevents cross-tenant update.
 func (q *Queries) UpdateArticle(ctx context.Context, arg UpdateArticleParams) (UpdateArticleRow, error) {
 	row := q.db.QueryRow(ctx, updateArticle,
 		arg.ID,
@@ -585,10 +885,12 @@ func (q *Queries) UpdateArticle(ctx context.Context, arg UpdateArticleParams) (U
 		arg.DefaultLocationID,
 		arg.ReceivingNotes,
 		arg.ShippingNotes,
+		arg.TenantID,
 	)
 	var i UpdateArticleRow
 	err := row.Scan(
 		&i.ID,
+		&i.TenantID,
 		&i.Sku,
 		&i.Name,
 		&i.Description,

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -67,6 +67,7 @@ type Article struct {
 	DefaultLocationID  pgtype.Text    `json:"default_location_id"`
 	ReceivingNotes     pgtype.Text    `json:"receiving_notes"`
 	ShippingNotes      pgtype.Text    `json:"shipping_notes"`
+	TenantID           pgtype.UUID    `json:"tenant_id"`
 }
 
 type ArticleSupplier struct {

--- a/db/sqlc/querier.go
+++ b/db/sqlc/querier.go
@@ -12,9 +12,12 @@ import (
 )
 
 type Querier interface {
+	// INTERNAL USE ONLY. Tenant-scoped variant below.
 	ArticleExistsBySku(ctx context.Context, sku string) (bool, error)
+	ArticleExistsBySkuForTenant(ctx context.Context, arg ArticleExistsBySkuForTenantParams) (bool, error)
 	CountAuditLogs(ctx context.Context, arg CountAuditLogsParams) (int64, error)
 	CreateAdjustmentReasonCode(ctx context.Context, arg CreateAdjustmentReasonCodeParams) (AdjustmentReasonCode, error)
+	// All inserts now require tenant_id ($1).
 	CreateArticle(ctx context.Context, arg CreateArticleParams) (CreateArticleRow, error)
 	// Audit logs: who did what, when, how
 	// Schema: db/migrations (000003_audit_logs_schema)
@@ -35,7 +38,8 @@ type Querier interface {
 	CreateStockTransfer(ctx context.Context, arg CreateStockTransferParams) (CreateStockTransferRow, error)
 	CreateStockTransferLine(ctx context.Context, arg CreateStockTransferLineParams) (StockTransferLine, error)
 	DeleteAdjustmentReasonCode(ctx context.Context, id string) error
-	DeleteArticle(ctx context.Context, id string) error
+	// Tenant guard prevents cross-tenant delete.
+	DeleteArticle(ctx context.Context, arg DeleteArticleParams) error
 	DeleteLocation(ctx context.Context, id string) error
 	DeleteLocationType(ctx context.Context, id string) error
 	DeleteLot(ctx context.Context, id string) error
@@ -48,8 +52,14 @@ type Querier interface {
 	DeleteStockTransferLinesByTransferID(ctx context.Context, stockTransferID string) error
 	GetAdjustmentReasonCodeByCode(ctx context.Context, code string) (AdjustmentReasonCode, error)
 	GetAdjustmentReasonCodeByID(ctx context.Context, id string) (AdjustmentReasonCode, error)
+	// INTERNAL USE ONLY. HTTP handlers must call GetArticleByIDForTenant.
 	GetArticleByID(ctx context.Context, id string) (GetArticleByIDRow, error)
+	// HR-style tenant guard. Use for HTTP responses to prevent cross-tenant enumeration.
+	GetArticleByIDForTenant(ctx context.Context, arg GetArticleByIDForTenantParams) (GetArticleByIDForTenantRow, error)
+	// INTERNAL USE ONLY (FK lookups, dashboards). HTTP handlers must call GetArticleBySkuForTenant.
 	GetArticleBySku(ctx context.Context, sku string) (GetArticleBySkuRow, error)
+	// Per-tenant SKU lookup. Hits articles_tenant_sku_key index.
+	GetArticleBySkuForTenant(ctx context.Context, arg GetArticleBySkuForTenantParams) (GetArticleBySkuForTenantRow, error)
 	GetCategoryByID(ctx context.Context, id string) (Category, error)
 	// Internal use only: no tenant filter. Use GetClientByIDForTenant for HTTP responses (HR1-M3).
 	GetClientByID(ctx context.Context, id string) (Client, error)
@@ -84,9 +94,16 @@ type Querier interface {
 	// Adjustment reason codes CRUD for sqlc. Schema: db/migrations (adjustment_reason_codes table)
 	ListAdjustmentReasonCodes(ctx context.Context) ([]AdjustmentReasonCode, error)
 	ListAdjustmentReasonCodesAdmin(ctx context.Context) ([]AdjustmentReasonCode, error)
-	// Articles CRUD and related queries for sqlc
-	// Schema: db/migrations (articles, lots, serials tables)
+	// Articles CRUD and related queries for sqlc.
+	// Schema: db/migrations (articles, lots, serials tables).
+	// S3.5 W1 — every read/write is now tenant-scoped via tenant_id (HR-S3-W5 C2).
+	// The legacy global queries (ListArticles, GetArticleBySku, ArticleExistsBySku) remain
+	// ONLY for internal lookups (FK validation, stock alerts cron, dashboards) where the
+	// caller has no JWT/Config tenant context. HTTP endpoints MUST use the *ForTenant variants.
+	// INTERNAL USE ONLY (cron, FK lookups). HTTP handlers must call ListArticlesForTenant.
 	ListArticles(ctx context.Context) ([]ListArticlesRow, error)
+	// HTTP-facing list. Uses idx_articles_tenant_created (composite covering index).
+	ListArticlesForTenant(ctx context.Context, tenantID pgtype.UUID) ([]ListArticlesForTenantRow, error)
 	ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([]AuditLog, error)
 	// M8: Push search/is_active filters and pagination to SQL (HR1 deferred).
 	// Pass NULL for any optional param to skip that filter.
@@ -107,7 +124,8 @@ type Querier interface {
 	// Lots CRUD for sqlc
 	// Schema: db/migrations (lots table)
 	ListLots(ctx context.Context) ([]Lot, error)
-	// Lots by SKU (for UpdateArticle warnings)
+	// Lots by SKU (for UpdateArticle warnings) — internal, no tenant filter (lots table
+	// not yet tenant-scoped; tracked in S3.5 W2).
 	ListLotsBySku(ctx context.Context, sku string) ([]Lot, error)
 	// Presentation conversions CRUD. Schema: db/migrations (presentation_conversions table)
 	ListPresentationConversions(ctx context.Context) ([]PresentationConversion, error)
@@ -119,7 +137,8 @@ type Querier interface {
 	// Schema: db/migrations (presentations table)
 	ListPresentations(ctx context.Context) ([]Presentation, error)
 	ListRoles(ctx context.Context) ([]Role, error)
-	// Serials by SKU (for UpdateArticle warnings)
+	// Serials by SKU (for UpdateArticle warnings) — internal, no tenant filter (serials
+	// table not yet tenant-scoped; tracked in S3.5 W2).
 	ListSerialsBySku(ctx context.Context, sku string) ([]Serial, error)
 	ListStockTransferLinesByTransferID(ctx context.Context, stockTransferID string) ([]StockTransferLine, error)
 	// Stock transfers and lines. Schema: db/migrations (stock_transfers, stock_transfer_lines).
@@ -133,6 +152,7 @@ type Querier interface {
 	// HR1-M3: tenant_id guard prevents cross-tenant soft-delete.
 	SoftDeleteClient(ctx context.Context, arg SoftDeleteClientParams) error
 	UpdateAdjustmentReasonCode(ctx context.Context, arg UpdateAdjustmentReasonCodeParams) (AdjustmentReasonCode, error)
+	// Tenant guard via WHERE id = $1 AND tenant_id = $24 — prevents cross-tenant update.
 	UpdateArticle(ctx context.Context, arg UpdateArticleParams) (UpdateArticleRow, error)
 	UpdateCategory(ctx context.Context, arg UpdateCategoryParams) (Category, error)
 	// HR1-M3: tenant_id guard prevents cross-tenant update.

--- a/models/database/article.go
+++ b/models/database/article.go
@@ -6,6 +6,11 @@ import (
 
 type Article struct {
 	ID               string    `gorm:"column:id;primaryKey" json:"id"`
+	// TenantID was added in S3.5 W1 (migration 000029). Articles are now scoped per tenant
+	// via the composite UNIQUE(tenant_id, sku) index. The legacy global UNIQUE(sku) is
+	// preserved as a FK target for inventory/article_suppliers/po_items/etc; it will be
+	// retired in a future sprint once those child FKs are migrated to composite.
+	TenantID         string    `gorm:"column:tenant_id;type:uuid;not null" json:"-"`
 	SKU              string    `gorm:"column:sku;unique" json:"sku"`
 	Name             string    `gorm:"column:name" json:"name"`
 	Description      *string   `gorm:"column:description" json:"description"`

--- a/ports/articles.go
+++ b/ports/articles.go
@@ -7,19 +7,34 @@ import (
 )
 
 // ArticlesRepository defines persistence operations for articles.
-// Implemented by *repositories.ArticlesRepository (GORM).
+//
+// S3.5 W1 — every HTTP-facing operation now requires a tenantID parameter
+// (HR-S3-W5 C2 fix). The legacy non-tenant methods are retained ONLY for internal
+// use cases that genuinely span tenants (FK resolution from inventory rows,
+// stock-alerts cron, dashboards). They MUST NOT be reached from HTTP controllers.
+//
+// Implemented by *repositories.ArticlesRepositorySQLC (Postgres) and
+// *repositories.ArticlesRepository (GORM fallback for sqlserver).
 type ArticlesRepository interface {
+	// ── tenant-scoped (HTTP-facing) ──────────────────────────────────────────
+	GetAllArticlesForTenant(tenantID string) ([]database.Article, *responses.InternalResponse)
+	GetArticleByIDForTenant(id, tenantID string) (*database.Article, *responses.InternalResponse)
+	GetBySkuForTenant(sku, tenantID string) (*database.Article, *responses.InternalResponse)
+	CreateArticleForTenant(tenantID string, data *requests.Article) *responses.InternalResponse
+	UpdateArticleForTenant(id, tenantID string, data *requests.Article) (*database.Article, *responses.InternalResponse)
+	DeleteArticleForTenant(id, tenantID string) *responses.InternalResponse
+	ImportArticlesFromExcelForTenant(tenantID string, fileBytes []byte) ([]string, []string, []*responses.InternalResponse)
+	ImportArticlesFromJSONForTenant(tenantID string, rows []requests.ArticleImportRow) ([]string, []string, []*responses.InternalResponse)
+	ValidateImportRowsForTenant(tenantID string, rows []requests.ArticleImportRow) ([]responses.ArticleValidationResult, *responses.InternalResponse)
+	ExportArticlesToExcelForTenant(tenantID string) ([]byte, *responses.InternalResponse)
+	GenerateImportTemplateForTenant(tenantID, language string) ([]byte, *responses.InternalResponse)
+
+	// ── internal (no tenant filter) ──────────────────────────────────────────
+	// These remain for stock-alerts cron, FK resolution from inventory.sku/lots.sku,
+	// and other system-level reads that legitimately span tenants.
 	GetAllArticles() ([]database.Article, *responses.InternalResponse)
 	GetArticleByID(id string) (*database.Article, *responses.InternalResponse)
 	GetBySku(sku string) (*database.Article, *responses.InternalResponse)
-	CreateArticle(data *requests.Article) *responses.InternalResponse
-	UpdateArticle(id string, data *requests.Article) (*database.Article, *responses.InternalResponse)
 	GetLotsBySKU(sku string) ([]database.Lot, error)
 	GetSerialsBySKU(sku string) ([]database.Serial, error)
-	ImportArticlesFromExcel(fileBytes []byte) ([]string, []string, []*responses.InternalResponse)
-	ImportArticlesFromJSON(rows []requests.ArticleImportRow) ([]string, []string, []*responses.InternalResponse)
-	ValidateImportRows(rows []requests.ArticleImportRow) ([]responses.ArticleValidationResult, *responses.InternalResponse)
-	ExportArticlesToExcel() ([]byte, *responses.InternalResponse)
-	GenerateImportTemplate(language string) ([]byte, *responses.InternalResponse)
-	DeleteArticle(id string) *responses.InternalResponse
 }

--- a/repositories/articles_repository.go
+++ b/repositories/articles_repository.go
@@ -14,205 +14,147 @@ import (
 	"gorm.io/gorm"
 )
 
+// ArticlesRepository is the GORM-backed implementation of ports.ArticlesRepository,
+// used as a fallback when no pgxpool is available (e.g. sqlserver). The Postgres
+// production path uses ArticlesRepositorySQLC.
+//
+// S3.5 W1: per-tenant variants added below; legacy non-tenant methods retained as
+// thin wrappers around the global table for internal/cron callers.
 type ArticlesRepository struct {
 	DB *gorm.DB
 }
 
-func (r *ArticlesRepository) GetAllArticles() ([]database.Article, *responses.InternalResponse) {
-	var articles []database.Article
+// ─── tenant-scoped (HTTP-facing) ─────────────────────────────────────────────
 
+func (r *ArticlesRepository) GetAllArticlesForTenant(tenantID string) ([]database.Article, *responses.InternalResponse) {
+	var articles []database.Article
 	err := r.DB.
 		Table(database.Article{}.TableName()).
-		Order("created_at ASC").
+		Where("tenant_id = ?", tenantID).
+		Order("created_at DESC").
 		Find(&articles).Error
-
 	if err != nil {
-		return nil, &responses.InternalResponse{
-			Error:   err,
-			Message: "Error al obtener los artículos",
-			Handled: false,
-		}
+		return nil, &responses.InternalResponse{Error: err, Message: "Error al obtener los artículos", Handled: false}
 	}
-
 	return articles, nil
 }
 
-func (r *ArticlesRepository) GetArticleByID(id string) (*database.Article, *responses.InternalResponse) {
+func (r *ArticlesRepository) GetArticleByIDForTenant(id, tenantID string) (*database.Article, *responses.InternalResponse) {
 	var article database.Article
-
 	err := r.DB.
 		Table(database.Article{}.TableName()).
-		Where("id = ?", id).
+		Where("id = ? AND tenant_id = ?", id, tenantID).
 		First(&article).Error
-
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, &responses.InternalResponse{
-				Message:    "Artículo no encontrado",
-				Handled:    true,
-				StatusCode: responses.StatusNotFound,
-			}
+			return nil, &responses.InternalResponse{Message: "Artículo no encontrado", Handled: true, StatusCode: responses.StatusNotFound}
 		}
-		return nil, &responses.InternalResponse{
-			Error:   err,
-			Message: "Error al obtener el artículo",
-			Handled: false,
-		}
+		return nil, &responses.InternalResponse{Error: err, Message: "Error al obtener el artículo", Handled: false}
 	}
-
 	return &article, nil
 }
 
-func (r *ArticlesRepository) GetBySku(sku string) (*database.Article, *responses.InternalResponse) {
+func (r *ArticlesRepository) GetBySkuForTenant(sku, tenantID string) (*database.Article, *responses.InternalResponse) {
 	var article database.Article
-
 	err := r.DB.
 		Table(database.Article{}.TableName()).
-		Where("sku = ?", sku).
+		Where("sku = ? AND tenant_id = ?", sku, tenantID).
 		First(&article).Error
-
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, &responses.InternalResponse{
-				Message:    "Artículo no encontrado",
-				Handled:    true,
-				StatusCode: responses.StatusNotFound,
-			}
+			return nil, &responses.InternalResponse{Message: "Artículo no encontrado", Handled: true, StatusCode: responses.StatusNotFound}
 		}
-		return nil, &responses.InternalResponse{
-			Error:   err,
-			Message: "Error al obtener el artículo por SKU",
-			Handled: false,
-		}
+		return nil, &responses.InternalResponse{Error: err, Message: "Error al obtener el artículo por SKU", Handled: false}
 	}
-
 	return &article, nil
 }
 
-func (r *ArticlesRepository) CreateArticle(data *requests.Article) *responses.InternalResponse {
+func (r *ArticlesRepository) CreateArticleForTenant(tenantID string, data *requests.Article) *responses.InternalResponse {
 	var existing database.Article
-	err := r.DB.First(&existing, "sku = ?", data.SKU).Error
+	err := r.DB.
+		Where("sku = ? AND tenant_id = ?", data.SKU, tenantID).
+		First(&existing).Error
 	if err == nil {
-		return &responses.InternalResponse{
-			Message:    "Ya existe un artículo con el mismo SKU",
-			Handled:    true,
-			StatusCode: responses.StatusConflict,
-		}
+		return &responses.InternalResponse{Message: "Ya existe un artículo con el mismo SKU", Handled: true, StatusCode: responses.StatusConflict}
 	}
-
 	if err != gorm.ErrRecordNotFound {
-		return &responses.InternalResponse{
-			Error:   err,
-			Message: "Error al verificar el artículo existente",
-			Handled: false,
-		}
+		return &responses.InternalResponse{Error: err, Message: "Error al verificar el artículo existente", Handled: false}
 	}
 
 	var article database.Article
 	tools.CopyStructFields(data, &article)
+	article.TenantID = tenantID
 	article.CreatedAt = tools.GetCurrentTime()
 	article.UpdatedAt = tools.GetCurrentTime()
-
 	if article.IsActive == nil {
 		trueVal := true
 		article.IsActive = &trueVal
 	}
 
-	err = r.DB.Create(&article).Error
-	if err != nil {
-		return &responses.InternalResponse{
-			Error:   err,
-			Message: "Error al crear el artículo",
-			Handled: false,
-		}
+	if err := r.DB.Create(&article).Error; err != nil {
+		return &responses.InternalResponse{Error: err, Message: "Error al crear el artículo", Handled: false}
 	}
-
 	return nil
 }
 
-func (r *ArticlesRepository) UpdateArticle(id string, data *requests.Article) (*database.Article, *responses.InternalResponse) {
+func (r *ArticlesRepository) UpdateArticleForTenant(id, tenantID string, data *requests.Article) (*database.Article, *responses.InternalResponse) {
 	var article database.Article
-	err := r.DB.First(&article, id).Error
+	err := r.DB.
+		Where("id = ? AND tenant_id = ?", id, tenantID).
+		First(&article).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, &responses.InternalResponse{
-				Message:    "Artículo no encontrado",
-				Handled:    true,
-				StatusCode: responses.StatusNotFound,
-			}
+			return nil, &responses.InternalResponse{Message: "Artículo no encontrado", Handled: true, StatusCode: responses.StatusNotFound}
 		}
-		return nil, &responses.InternalResponse{
-			Error:   err,
-			Message: "Error al obtener el artículo",
-			Handled: false,
-		}
+		return nil, &responses.InternalResponse{Error: err, Message: "Error al obtener el artículo", Handled: false}
 	}
 
 	tools.CopyStructFields(data, &article)
+	article.TenantID = tenantID // ensure not overwritten
 	article.UpdatedAt = tools.GetCurrentTime()
 
-	err = r.DB.Save(&article).Error
-	if err != nil {
-		return nil, &responses.InternalResponse{
-			Error:   err,
-			Message: "Error al actualizar el artículo",
-			Handled: false,
-		}
+	if err := r.DB.Save(&article).Error; err != nil {
+		return nil, &responses.InternalResponse{Error: err, Message: "Error al actualizar el artículo", Handled: false}
 	}
-
 	return &article, nil
 }
 
-func (r *ArticlesRepository) GetLotsBySKU(sku string) ([]database.Lot, error) {
-	var lots []database.Lot
-	err := r.DB.Where("sku = ?", sku).Find(&lots).Error
-	return lots, err
+func (r *ArticlesRepository) DeleteArticleForTenant(id, tenantID string) *responses.InternalResponse {
+	err := r.DB.
+		Table(database.Article{}.TableName()).
+		Where("id = ? AND tenant_id = ?", id, tenantID).
+		Delete(&database.Article{}).Error
+	if err != nil {
+		return &responses.InternalResponse{Error: err, Message: "Error al eliminar el artículo", Handled: false}
+	}
+	return nil
 }
 
-func (r *ArticlesRepository) GetSerialsBySKU(sku string) ([]database.Serial, error) {
-	var serials []database.Serial
-	err := r.DB.Where("sku = ?", sku).Find(&serials).Error
-	return serials, err
-}
-
-func (r *ArticlesRepository) ImportArticlesFromExcel(fileBytes []byte) ([]string, []string, []*responses.InternalResponse) {
+func (r *ArticlesRepository) ImportArticlesFromExcelForTenant(tenantID string, fileBytes []byte) ([]string, []string, []*responses.InternalResponse) {
 	imported := []string{}
 	skipped := []string{}
 	errorsList := []*responses.InternalResponse{}
 
 	f, err := excelize.OpenReader(bytes.NewReader(fileBytes))
 	if err != nil {
-		errorsList = append(errorsList, &responses.InternalResponse{
-			Error:   err,
-			Message: "Error al abrir el archivo de Excel",
-			Handled: false,
-		})
+		errorsList = append(errorsList, &responses.InternalResponse{Error: err, Message: "Error al abrir el archivo de Excel", Handled: false})
 		return imported, skipped, errorsList
 	}
 
-	// Use first sheet regardless of language-based name ("Artículos", "Articles", "Sheet1")
 	sheets := f.GetSheetList()
 	if len(sheets) == 0 {
-		errorsList = append(errorsList, &responses.InternalResponse{
-			Message: "El archivo no contiene hojas de datos",
-			Handled: true,
-		})
+		errorsList = append(errorsList, &responses.InternalResponse{Message: "El archivo no contiene hojas de datos", Handled: true})
 		return imported, skipped, errorsList
 	}
 	sheet := sheets[0]
 
 	rows, err := f.GetRows(sheet)
 	if err != nil {
-		errorsList = append(errorsList, &responses.InternalResponse{
-			Error:   err,
-			Message: "Error al leer las filas de Excel",
-			Handled: false,
-		})
+		errorsList = append(errorsList, &responses.InternalResponse{Error: err, Message: "Error al leer las filas de Excel", Handled: false})
 		return imported, skipped, errorsList
 	}
 
 	for i, row := range rows {
-		// Skip header, instructions, column-header row, and example row (rows 1-8, index 0-7)
 		if i < 8 {
 			continue
 		}
@@ -222,13 +164,9 @@ func (r *ArticlesRepository) ImportArticlesFromExcel(fileBytes []byte) ([]string
 
 		sku := strings.TrimSpace(row[0])
 		name := strings.TrimSpace(row[1])
-
-		// Skip rows where required fields are empty
 		if sku == "" || name == "" {
 			continue
 		}
-
-		// Detect and skip example row gracefully
 		if strings.EqualFold(sku, "ART-001") {
 			skipped = append(skipped, fmt.Sprintf("Fila %d: fila de ejemplo omitida", i+1))
 			continue
@@ -244,10 +182,7 @@ func (r *ArticlesRepository) ImportArticlesFromExcel(fileBytes []byte) ([]string
 		minQtyStr := strings.TrimSpace(row[9])
 
 		if presentation == "" {
-			errorsList = append(errorsList, &responses.InternalResponse{
-				Message: fmt.Sprintf("Fila %d: presentación requerida", i+1),
-				Handled: true,
-			})
+			errorsList = append(errorsList, &responses.InternalResponse{Message: fmt.Sprintf("Fila %d: presentación requerida", i+1), Handled: true})
 			continue
 		}
 
@@ -300,36 +235,26 @@ func (r *ArticlesRepository) ImportArticlesFromExcel(fileBytes []byte) ([]string
 			ImageURL:         nil,
 		}
 
-		resp := r.CreateArticle(article)
+		resp := r.CreateArticleForTenant(tenantID, article)
 		if resp != nil {
-			errorsList = append(errorsList, &responses.InternalResponse{
-				Error:   resp.Error,
-				Message: fmt.Sprintf("Fila %d: %s", i+1, resp.Message),
-				Handled: resp.Handled,
-			})
+			errorsList = append(errorsList, &responses.InternalResponse{Error: resp.Error, Message: fmt.Sprintf("Fila %d: %s", i+1, resp.Message), Handled: resp.Handled})
 			continue
 		}
-
 		imported = append(imported, sku)
 	}
 
 	return imported, skipped, errorsList
 }
 
-// ImportArticlesFromJSON imports articles from a pre-validated JSON payload (used by the frontend preview flow).
-func (r *ArticlesRepository) ValidateImportRows(rows []requests.ArticleImportRow) ([]responses.ArticleValidationResult, *responses.InternalResponse) {
+func (r *ArticlesRepository) ValidateImportRowsForTenant(tenantID string, rows []requests.ArticleImportRow) ([]responses.ArticleValidationResult, *responses.InternalResponse) {
 	results := make([]responses.ArticleValidationResult, 0, len(rows))
 	seenSKUs := make(map[string]bool)
 
 	for i, row := range rows {
 		sku := strings.TrimSpace(row.SKU)
 		name := strings.TrimSpace(row.Name)
-		result := responses.ArticleValidationResult{
-			RowIndex: i,
-			Row:      row,
-		}
+		result := responses.ArticleValidationResult{RowIndex: i, Row: row}
 
-		// Field validation
 		if sku == "" || name == "" || strings.TrimSpace(row.Presentation) == "" {
 			result.Status = responses.ArticleStatusError
 			result.FieldErrors = map[string]string{}
@@ -346,7 +271,6 @@ func (r *ArticlesRepository) ValidateImportRows(rows []requests.ArticleImportRow
 			continue
 		}
 
-		// Duplicate within batch
 		skuKey := strings.ToLower(sku)
 		if seenSKUs[skuKey] {
 			result.Status = responses.ArticleStatusDuplicate
@@ -355,8 +279,7 @@ func (r *ArticlesRepository) ValidateImportRows(rows []requests.ArticleImportRow
 		}
 		seenSKUs[skuKey] = true
 
-		// Exact SKU match in DB
-		existing, _ := r.GetBySku(sku)
+		existing, _ := r.GetBySkuForTenant(sku, tenantID)
 		if existing != nil {
 			isActive := false
 			if existing.IsActive != nil {
@@ -374,13 +297,13 @@ func (r *ArticlesRepository) ValidateImportRows(rows []requests.ArticleImportRow
 			continue
 		}
 
-		// Similar name check (LIKE search)
 		keyword := name
 		if len(keyword) > 20 {
 			keyword = keyword[:20]
 		}
 		var similar []database.Article
-		r.DB.Where("LOWER(name) LIKE LOWER(?) AND sku != ?", "%"+keyword+"%", sku).Limit(3).Find(&similar)
+		r.DB.Where("LOWER(name) LIKE LOWER(?) AND sku != ? AND tenant_id = ?", "%"+keyword+"%", sku, tenantID).
+			Limit(3).Find(&similar)
 		if len(similar) > 0 {
 			result.Status = responses.ArticleStatusSimilar
 			result.SimilarArticles = make([]responses.ArticleValidationMatch, 0, len(similar))
@@ -404,11 +327,10 @@ func (r *ArticlesRepository) ValidateImportRows(rows []requests.ArticleImportRow
 		result.Status = responses.ArticleStatusNew
 		results = append(results, result)
 	}
-
 	return results, nil
 }
 
-func (r *ArticlesRepository) ImportArticlesFromJSON(rows []requests.ArticleImportRow) ([]string, []string, []*responses.InternalResponse) {
+func (r *ArticlesRepository) ImportArticlesFromJSONForTenant(tenantID string, rows []requests.ArticleImportRow) ([]string, []string, []*responses.InternalResponse) {
 	imported := []string{}
 	skipped := []string{}
 	errorsList := []*responses.InternalResponse{}
@@ -428,10 +350,7 @@ func (r *ArticlesRepository) ImportArticlesFromJSON(rows []requests.ArticleImpor
 
 		presentation := strings.TrimSpace(row.Presentation)
 		if presentation == "" {
-			errorsList = append(errorsList, &responses.InternalResponse{
-				Message: fmt.Sprintf("Fila %d: presentación requerida", i+1),
-				Handled: true,
-			})
+			errorsList = append(errorsList, &responses.InternalResponse{Message: fmt.Sprintf("Fila %d: presentación requerida", i+1), Handled: true})
 			continue
 		}
 
@@ -474,13 +393,9 @@ func (r *ArticlesRepository) ImportArticlesFromJSON(rows []requests.ArticleImpor
 			MaxQuantity:      maxQty,
 		}
 
-		resp := r.CreateArticle(article)
+		resp := r.CreateArticleForTenant(tenantID, article)
 		if resp != nil {
-			errorsList = append(errorsList, &responses.InternalResponse{
-				Error:   resp.Error,
-				Message: fmt.Sprintf("Fila %d: %s", i+1, resp.Message),
-				Handled: resp.Handled,
-			})
+			errorsList = append(errorsList, &responses.InternalResponse{Error: resp.Error, Message: fmt.Sprintf("Fila %d: %s", i+1, resp.Message), Handled: resp.Handled})
 			continue
 		}
 		imported = append(imported, sku)
@@ -489,8 +404,8 @@ func (r *ArticlesRepository) ImportArticlesFromJSON(rows []requests.ArticleImpor
 	return imported, skipped, errorsList
 }
 
-func (r *ArticlesRepository) ExportArticlesToExcel() ([]byte, *responses.InternalResponse) {
-	articles, errResp := r.GetAllArticles()
+func (r *ArticlesRepository) ExportArticlesToExcelForTenant(tenantID string) ([]byte, *responses.InternalResponse) {
+	articles, errResp := r.GetAllArticlesForTenant(tenantID)
 	if errResp != nil {
 		return nil, errResp
 	}
@@ -537,22 +452,85 @@ func (r *ArticlesRepository) ExportArticlesToExcel() ([]byte, *responses.Interna
 
 	var buf bytes.Buffer
 	if err := f.Write(&buf); err != nil {
-		return nil, &responses.InternalResponse{
-			Error:   err,
-			Message: "Error al generar el archivo de Excel",
-			Handled: false,
-		}
+		return nil, &responses.InternalResponse{Error: err, Message: "Error al generar el archivo de Excel", Handled: false}
 	}
 
 	return buf.Bytes(), nil
 }
 
-func (r *ArticlesRepository) GenerateImportTemplate(language string) ([]byte, *responses.InternalResponse) {
+func (r *ArticlesRepository) GenerateImportTemplateForTenant(tenantID, language string) ([]byte, *responses.InternalResponse) {
 	var presentations []string
-	r.DB.Table("articles").Distinct("presentation").Pluck("presentation", &presentations)
+	r.DB.Table("articles").Where("tenant_id = ?", tenantID).Distinct("presentation").Pluck("presentation", &presentations)
 	return buildImportTemplate(presentations, language)
 }
 
+// ─── legacy non-tenant methods ───────────────────────────────────────────────
+//
+// Retained as thin wrappers for internal callers (cron, FK lookups by SKU from
+// inventory/lots/serials rows that don't carry tenant_id yet — see W2). HTTP
+// handlers MUST call the *ForTenant variants instead.
+
+func (r *ArticlesRepository) GetAllArticles() ([]database.Article, *responses.InternalResponse) {
+	var articles []database.Article
+	err := r.DB.Table(database.Article{}.TableName()).Order("created_at ASC").Find(&articles).Error
+	if err != nil {
+		return nil, &responses.InternalResponse{Error: err, Message: "Error al obtener los artículos", Handled: false}
+	}
+	return articles, nil
+}
+
+func (r *ArticlesRepository) GetArticleByID(id string) (*database.Article, *responses.InternalResponse) {
+	var article database.Article
+	err := r.DB.Table(database.Article{}.TableName()).Where("id = ?", id).First(&article).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, &responses.InternalResponse{Message: "Artículo no encontrado", Handled: true, StatusCode: responses.StatusNotFound}
+		}
+		return nil, &responses.InternalResponse{Error: err, Message: "Error al obtener el artículo", Handled: false}
+	}
+	return &article, nil
+}
+
+func (r *ArticlesRepository) GetBySku(sku string) (*database.Article, *responses.InternalResponse) {
+	var article database.Article
+	err := r.DB.Table(database.Article{}.TableName()).Where("sku = ?", sku).First(&article).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, &responses.InternalResponse{Message: "Artículo no encontrado", Handled: true, StatusCode: responses.StatusNotFound}
+		}
+		return nil, &responses.InternalResponse{Error: err, Message: "Error al obtener el artículo por SKU", Handled: false}
+	}
+	return &article, nil
+}
+
+func (r *ArticlesRepository) GetLotsBySKU(sku string) ([]database.Lot, error) {
+	var lots []database.Lot
+	err := r.DB.Where("sku = ?", sku).Find(&lots).Error
+	return lots, err
+}
+
+func (r *ArticlesRepository) GetSerialsBySKU(sku string) ([]database.Serial, error) {
+	var serials []database.Serial
+	err := r.DB.Where("sku = ?", sku).Find(&serials).Error
+	return serials, err
+}
+
+func boolToSiNo(value bool) string {
+	if value {
+		return "Sí"
+	}
+	return "No"
+}
+
+func parseBoolCell(s string) bool {
+	s = strings.ToLower(strings.TrimSpace(s))
+	return s == "si" || s == "sí" || s == "yes" || s == "true" || s == "1"
+}
+
+// buildImportTemplate is shared by both repository implementations to produce the
+// import xlsx template (header + column rows + presentation validations). Lives here
+// because it depends only on excelize + the article template helpers; it has no
+// per-tenant data of its own (the caller supplies the tenant-scoped presentations list).
 func buildImportTemplate(presentations []string, language string) ([]byte, *responses.InternalResponse) {
 	l := getLang(language)
 	dataSheet := l["sheet_data"]
@@ -593,33 +571,4 @@ func buildImportTemplate(presentations []string, language string) ([]byte, *resp
 		}
 	}
 	return buf.Bytes(), nil
-}
-
-func boolToSiNo(value bool) string {
-	if value {
-		return "Sí"
-	}
-	return "No"
-}
-
-func parseBoolCell(s string) bool {
-	s = strings.ToLower(strings.TrimSpace(s))
-	return s == "si" || s == "sí" || s == "yes" || s == "true" || s == "1"
-}
-
-func (r *ArticlesRepository) DeleteArticle(id string) *responses.InternalResponse {
-	err := r.DB.
-		Table(database.Article{}.TableName()).
-		Where("id = ?", id).
-		Delete(&database.Article{}).Error
-
-	if err != nil {
-		return &responses.InternalResponse{
-			Error:   err,
-			Message: "Error al eliminar el artículo",
-			Handled: false,
-		}
-	}
-
-	return nil
 }

--- a/repositories/articles_repository_sqlc.go
+++ b/repositories/articles_repository_sqlc.go
@@ -21,6 +21,12 @@ import (
 	"github.com/xuri/excelize/v2"
 )
 
+// defaultTenantUUID matches the backfill default in 000019/000023/000029 migrations.
+// Used by the legacy non-tenant repo methods so existing internal callers (cron jobs,
+// integration tests) keep working without an immediate refactor. New HTTP-facing code
+// MUST use the *ForTenant variants with a real tenantID.
+const defaultTenantUUID = "00000000-0000-0000-0000-000000000001"
+
 // ArticlesRepositorySQLC implements ports.ArticlesRepository using sqlc-generated queries.
 type ArticlesRepositorySQLC struct {
 	queries *sqlc.Queries
@@ -34,17 +40,23 @@ func NewArticlesRepositorySQLC(queries *sqlc.Queries) *ArticlesRepositorySQLC {
 // Ensure ArticlesRepositorySQLC implements ports.ArticlesRepository at compile time.
 var _ ports.ArticlesRepository = (*ArticlesRepositorySQLC)(nil)
 
-func (r *ArticlesRepositorySQLC) GetAllArticles() ([]database.Article, *responses.InternalResponse) {
+// ─── tenant-scoped (HTTP-facing) ─────────────────────────────────────────────
+
+func (r *ArticlesRepositorySQLC) GetAllArticlesForTenant(tenantID string) ([]database.Article, *responses.InternalResponse) {
 	ctx := context.Background()
-	list, err := r.queries.ListArticles(ctx)
+	tid, err := stringToPgUUID(tenantID)
 	if err != nil {
-		tools.LogRepoError("articles", "ListArticles", err, "Error al obtener los artículos")
+		return nil, &responses.InternalResponse{Error: err, Message: "tenant_id inválido", Handled: true, StatusCode: responses.StatusBadRequest}
+	}
+	list, err := r.queries.ListArticlesForTenant(ctx, tid)
+	if err != nil {
+		tools.LogRepoError("articles", "ListArticlesForTenant", err, "Error al obtener los artículos")
 		return nil, &responses.InternalResponse{Error: err, Message: "Error al obtener los artículos", Handled: false}
 	}
 	out := make([]database.Article, len(list))
 	for i, a := range list {
 		out[i] = articleRowToDatabase(articleRowData{
-			ID: a.ID, Sku: a.Sku, Name: a.Name, Description: a.Description, UnitPrice: a.UnitPrice,
+			ID: a.ID, TenantID: a.TenantID, Sku: a.Sku, Name: a.Name, Description: a.Description, UnitPrice: a.UnitPrice,
 			Presentation: a.Presentation, TrackByLot: a.TrackByLot, TrackBySerial: a.TrackBySerial,
 			TrackExpiration: a.TrackExpiration, RotationStrategy: a.RotationStrategy,
 			MinQuantity: a.MinQuantity, MaxQuantity: a.MaxQuantity, ImageUrl: a.ImageUrl,
@@ -58,22 +70,22 @@ func (r *ArticlesRepositorySQLC) GetAllArticles() ([]database.Article, *response
 	return out, nil
 }
 
-func (r *ArticlesRepositorySQLC) GetArticleByID(id string) (*database.Article, *responses.InternalResponse) {
+func (r *ArticlesRepositorySQLC) GetArticleByIDForTenant(id, tenantID string) (*database.Article, *responses.InternalResponse) {
 	ctx := context.Background()
-	a, err := r.queries.GetArticleByID(ctx, id)
+	tid, err := stringToPgUUID(tenantID)
+	if err != nil {
+		return nil, &responses.InternalResponse{Error: err, Message: "tenant_id inválido", Handled: true, StatusCode: responses.StatusBadRequest}
+	}
+	a, err := r.queries.GetArticleByIDForTenant(ctx, sqlc.GetArticleByIDForTenantParams{ID: id, TenantID: tid})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, &responses.InternalResponse{
-				Message:    "Artículo no encontrado",
-				Handled:    true,
-				StatusCode: responses.StatusNotFound,
-			}
+			return nil, &responses.InternalResponse{Message: "Artículo no encontrado", Handled: true, StatusCode: responses.StatusNotFound}
 		}
-		tools.LogRepoError("articles", "GetArticleByID", err, "Error al obtener el artículo")
+		tools.LogRepoError("articles", "GetArticleByIDForTenant", err, "Error al obtener el artículo")
 		return nil, &responses.InternalResponse{Error: err, Message: "Error al obtener el artículo", Handled: false}
 	}
 	art := articleRowToDatabase(articleRowData{
-		ID: a.ID, Sku: a.Sku, Name: a.Name, Description: a.Description, UnitPrice: a.UnitPrice,
+		ID: a.ID, TenantID: a.TenantID, Sku: a.Sku, Name: a.Name, Description: a.Description, UnitPrice: a.UnitPrice,
 		Presentation: a.Presentation, TrackByLot: a.TrackByLot, TrackBySerial: a.TrackBySerial,
 		TrackExpiration: a.TrackExpiration, RotationStrategy: a.RotationStrategy,
 		MinQuantity: a.MinQuantity, MaxQuantity: a.MaxQuantity, ImageUrl: a.ImageUrl,
@@ -86,22 +98,22 @@ func (r *ArticlesRepositorySQLC) GetArticleByID(id string) (*database.Article, *
 	return &art, nil
 }
 
-func (r *ArticlesRepositorySQLC) GetBySku(sku string) (*database.Article, *responses.InternalResponse) {
+func (r *ArticlesRepositorySQLC) GetBySkuForTenant(sku, tenantID string) (*database.Article, *responses.InternalResponse) {
 	ctx := context.Background()
-	a, err := r.queries.GetArticleBySku(ctx, sku)
+	tid, err := stringToPgUUID(tenantID)
+	if err != nil {
+		return nil, &responses.InternalResponse{Error: err, Message: "tenant_id inválido", Handled: true, StatusCode: responses.StatusBadRequest}
+	}
+	a, err := r.queries.GetArticleBySkuForTenant(ctx, sqlc.GetArticleBySkuForTenantParams{Sku: sku, TenantID: tid})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, &responses.InternalResponse{
-				Message:    "Artículo no encontrado",
-				Handled:    true,
-				StatusCode: responses.StatusNotFound,
-			}
+			return nil, &responses.InternalResponse{Message: "Artículo no encontrado", Handled: true, StatusCode: responses.StatusNotFound}
 		}
-		tools.LogRepoError("articles", "GetBySku", err, "Error al obtener el artículo por SKU")
+		tools.LogRepoError("articles", "GetBySkuForTenant", err, "Error al obtener el artículo por SKU")
 		return nil, &responses.InternalResponse{Error: err, Message: "Error al obtener el artículo por SKU", Handled: false}
 	}
 	art := articleRowToDatabase(articleRowData{
-		ID: a.ID, Sku: a.Sku, Name: a.Name, Description: a.Description, UnitPrice: a.UnitPrice,
+		ID: a.ID, TenantID: a.TenantID, Sku: a.Sku, Name: a.Name, Description: a.Description, UnitPrice: a.UnitPrice,
 		Presentation: a.Presentation, TrackByLot: a.TrackByLot, TrackBySerial: a.TrackBySerial,
 		TrackExpiration: a.TrackExpiration, RotationStrategy: a.RotationStrategy,
 		MinQuantity: a.MinQuantity, MaxQuantity: a.MaxQuantity, ImageUrl: a.ImageUrl,
@@ -114,19 +126,20 @@ func (r *ArticlesRepositorySQLC) GetBySku(sku string) (*database.Article, *respo
 	return &art, nil
 }
 
-func (r *ArticlesRepositorySQLC) CreateArticle(data *requests.Article) *responses.InternalResponse {
+func (r *ArticlesRepositorySQLC) CreateArticleForTenant(tenantID string, data *requests.Article) *responses.InternalResponse {
 	ctx := context.Background()
-	exists, err := r.queries.ArticleExistsBySku(ctx, data.SKU)
+	tid, err := stringToPgUUID(tenantID)
 	if err != nil {
-		tools.LogRepoError("articles", "CreateArticle", err, "Error al verificar el artículo existente")
+		return &responses.InternalResponse{Error: err, Message: "tenant_id inválido", Handled: true, StatusCode: responses.StatusBadRequest}
+	}
+
+	exists, err := r.queries.ArticleExistsBySkuForTenant(ctx, sqlc.ArticleExistsBySkuForTenantParams{Sku: data.SKU, TenantID: tid})
+	if err != nil {
+		tools.LogRepoError("articles", "CreateArticleForTenant", err, "Error al verificar el artículo existente")
 		return &responses.InternalResponse{Error: err, Message: "Error al verificar el artículo existente", Handled: false}
 	}
 	if exists {
-		return &responses.InternalResponse{
-			Message:    "Ya existe un artículo con el mismo SKU",
-			Handled:    true,
-			StatusCode: responses.StatusConflict,
-		}
+		return &responses.InternalResponse{Message: "Ya existe un artículo con el mismo SKU", Handled: true, StatusCode: responses.StatusConflict}
 	}
 
 	rotationStrategy := strings.TrimSpace(strings.ToLower(data.RotationStrategy))
@@ -135,6 +148,7 @@ func (r *ArticlesRepositorySQLC) CreateArticle(data *requests.Article) *response
 	}
 
 	arg := sqlc.CreateArticleParams{
+		TenantID:           tid,
 		Sku:                data.SKU,
 		Name:               data.Name,
 		Description:        ptrStringToPgText(data.Description),
@@ -162,27 +176,24 @@ func (r *ArticlesRepositorySQLC) CreateArticle(data *requests.Article) *response
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-			return &responses.InternalResponse{
-				Message:    "Ya existe un artículo con el mismo SKU",
-				Handled:    true,
-				StatusCode: responses.StatusConflict,
-			}
+			return &responses.InternalResponse{Message: "Ya existe un artículo con el mismo SKU", Handled: true, StatusCode: responses.StatusConflict}
 		}
 		return &responses.InternalResponse{Error: err, Message: "Error al crear el artículo", Handled: false}
 	}
 	return nil
 }
 
-func (r *ArticlesRepositorySQLC) UpdateArticle(id string, data *requests.Article) (*database.Article, *responses.InternalResponse) {
+func (r *ArticlesRepositorySQLC) UpdateArticleForTenant(id, tenantID string, data *requests.Article) (*database.Article, *responses.InternalResponse) {
 	ctx := context.Background()
-	existing, err := r.queries.GetArticleByID(ctx, id)
+	tid, err := stringToPgUUID(tenantID)
+	if err != nil {
+		return nil, &responses.InternalResponse{Error: err, Message: "tenant_id inválido", Handled: true, StatusCode: responses.StatusBadRequest}
+	}
+	// Tenant-scoped existence check.
+	existing, err := r.queries.GetArticleByIDForTenant(ctx, sqlc.GetArticleByIDForTenantParams{ID: id, TenantID: tid})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, &responses.InternalResponse{
-				Message:    "Artículo no encontrado",
-				Handled:    true,
-				StatusCode: responses.StatusNotFound,
-			}
+			return nil, &responses.InternalResponse{Message: "Artículo no encontrado", Handled: true, StatusCode: responses.StatusNotFound}
 		}
 		return nil, &responses.InternalResponse{Error: err, Message: "Error al obtener el artículo", Handled: false}
 	}
@@ -194,6 +205,7 @@ func (r *ArticlesRepositorySQLC) UpdateArticle(id string, data *requests.Article
 
 	arg := sqlc.UpdateArticleParams{
 		ID:                 existing.ID,
+		TenantID:           tid,
 		Sku:                data.SKU,
 		Name:               data.Name,
 		Description:        ptrStringToPgText(data.Description),
@@ -223,7 +235,7 @@ func (r *ArticlesRepositorySQLC) UpdateArticle(id string, data *requests.Article
 		return nil, &responses.InternalResponse{Error: err, Message: "Error al actualizar el artículo", Handled: false}
 	}
 	art := articleRowToDatabase(articleRowData{
-		ID: updated.ID, Sku: updated.Sku, Name: updated.Name, Description: updated.Description, UnitPrice: updated.UnitPrice,
+		ID: updated.ID, TenantID: updated.TenantID, Sku: updated.Sku, Name: updated.Name, Description: updated.Description, UnitPrice: updated.UnitPrice,
 		Presentation: updated.Presentation, TrackByLot: updated.TrackByLot, TrackBySerial: updated.TrackBySerial,
 		TrackExpiration: updated.TrackExpiration, RotationStrategy: updated.RotationStrategy,
 		MinQuantity: updated.MinQuantity, MaxQuantity: updated.MaxQuantity, ImageUrl: updated.ImageUrl,
@@ -236,43 +248,20 @@ func (r *ArticlesRepositorySQLC) UpdateArticle(id string, data *requests.Article
 	return &art, nil
 }
 
-func (r *ArticlesRepositorySQLC) GetLotsBySKU(sku string) ([]database.Lot, error) {
+func (r *ArticlesRepositorySQLC) DeleteArticleForTenant(id, tenantID string) *responses.InternalResponse {
 	ctx := context.Background()
-	list, err := r.queries.ListLotsBySku(ctx, sku)
+	tid, err := stringToPgUUID(tenantID)
 	if err != nil {
-		return nil, err
+		return &responses.InternalResponse{Error: err, Message: "tenant_id inválido", Handled: true, StatusCode: responses.StatusBadRequest}
 	}
-	out := make([]database.Lot, len(list))
-	for i, l := range list {
-		out[i] = sqlcLotToDatabase(l)
-	}
-	return out, nil
-}
-
-func (r *ArticlesRepositorySQLC) GetSerialsBySKU(sku string) ([]database.Serial, error) {
-	ctx := context.Background()
-	list, err := r.queries.ListSerialsBySku(ctx, sku)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]database.Serial, len(list))
-	for i, s := range list {
-		out[i] = sqlcSerialToDatabase(s)
-	}
-	return out, nil
-}
-
-func (r *ArticlesRepositorySQLC) DeleteArticle(id string) *responses.InternalResponse {
-	ctx := context.Background()
-	err := r.queries.DeleteArticle(ctx, id)
-	if err != nil {
-		tools.LogRepoError("articles", "DeleteArticle", err, "Error al eliminar el artículo")
+	if err := r.queries.DeleteArticle(ctx, sqlc.DeleteArticleParams{ID: id, TenantID: tid}); err != nil {
+		tools.LogRepoError("articles", "DeleteArticleForTenant", err, "Error al eliminar el artículo")
 		return &responses.InternalResponse{Error: err, Message: "Error al eliminar el artículo", Handled: false}
 	}
 	return nil
 }
 
-func (r *ArticlesRepositorySQLC) ImportArticlesFromExcel(fileBytes []byte) ([]string, []string, []*responses.InternalResponse) {
+func (r *ArticlesRepositorySQLC) ImportArticlesFromExcelForTenant(tenantID string, fileBytes []byte) ([]string, []string, []*responses.InternalResponse) {
 	imported, skipped, errs := []string{}, []string{}, []*responses.InternalResponse{}
 
 	f, err := excelize.OpenReader(bytes.NewReader(fileBytes))
@@ -316,7 +305,7 @@ func (r *ArticlesRepositorySQLC) ImportArticlesFromExcel(fileBytes []byte) ([]st
 		if len(row) > 10 {
 			rowReq.RotationStrategy = strings.TrimSpace(row[10])
 		}
-		imp, sk, rowErrs := r.ImportArticlesFromJSON([]requests.ArticleImportRow{rowReq})
+		imp, sk, rowErrs := r.ImportArticlesFromJSONForTenant(tenantID, []requests.ArticleImportRow{rowReq})
 		imported = append(imported, imp...)
 		skipped = append(skipped, sk...)
 		errs = append(errs, rowErrs...)
@@ -324,7 +313,7 @@ func (r *ArticlesRepositorySQLC) ImportArticlesFromExcel(fileBytes []byte) ([]st
 	return imported, skipped, errs
 }
 
-func (r *ArticlesRepositorySQLC) ImportArticlesFromJSON(rows []requests.ArticleImportRow) ([]string, []string, []*responses.InternalResponse) {
+func (r *ArticlesRepositorySQLC) ImportArticlesFromJSONForTenant(tenantID string, rows []requests.ArticleImportRow) ([]string, []string, []*responses.InternalResponse) {
 	imported, skipped, errs := []string{}, []string{}, []*responses.InternalResponse{}
 	for i, row := range rows {
 		sku := strings.TrimSpace(row.SKU)
@@ -369,7 +358,7 @@ func (r *ArticlesRepositorySQLC) ImportArticlesFromJSON(rows []requests.ArticleI
 			TrackExpiration: parseBoolCell(row.TrackExpiration), RotationStrategy: rs,
 			MinQuantity: minQty, MaxQuantity: maxQty,
 		}
-		resp := r.CreateArticle(article)
+		resp := r.CreateArticleForTenant(tenantID, article)
 		if resp != nil {
 			errs = append(errs, &responses.InternalResponse{Error: resp.Error, Message: fmt.Sprintf("Fila %d: %s", i+1, resp.Message), Handled: resp.Handled})
 			continue
@@ -379,8 +368,108 @@ func (r *ArticlesRepositorySQLC) ImportArticlesFromJSON(rows []requests.ArticleI
 	return imported, skipped, errs
 }
 
-func (r *ArticlesRepositorySQLC) ExportArticlesToExcel() ([]byte, *responses.InternalResponse) {
-	articles, errResp := r.GetAllArticles()
+func (r *ArticlesRepositorySQLC) ValidateImportRowsForTenant(tenantID string, rows []requests.ArticleImportRow) ([]responses.ArticleValidationResult, *responses.InternalResponse) {
+	results := make([]responses.ArticleValidationResult, 0, len(rows))
+	seenSKUs := make(map[string]bool)
+
+	// Load only this tenant's articles for in-memory similarity check.
+	allArticles, errResp := r.GetAllArticlesForTenant(tenantID)
+	if errResp != nil {
+		return nil, errResp
+	}
+
+	tid, err := stringToPgUUID(tenantID)
+	if err != nil {
+		return nil, &responses.InternalResponse{Error: err, Message: "tenant_id inválido", Handled: true, StatusCode: responses.StatusBadRequest}
+	}
+
+	for i, row := range rows {
+		sku := strings.TrimSpace(row.SKU)
+		name := strings.TrimSpace(row.Name)
+		result := responses.ArticleValidationResult{RowIndex: i, Row: row}
+
+		// Field validation
+		if sku == "" || name == "" || strings.TrimSpace(row.Presentation) == "" {
+			result.Status = responses.ArticleStatusError
+			result.FieldErrors = map[string]string{}
+			if sku == "" {
+				result.FieldErrors["sku"] = "SKU requerido"
+			}
+			if name == "" {
+				result.FieldErrors["name"] = "Nombre requerido"
+			}
+			if strings.TrimSpace(row.Presentation) == "" {
+				result.FieldErrors["presentation"] = "Presentación requerida"
+			}
+			results = append(results, result)
+			continue
+		}
+
+		// Duplicate within batch
+		skuKey := strings.ToLower(sku)
+		if seenSKUs[skuKey] {
+			result.Status = responses.ArticleStatusDuplicate
+			results = append(results, result)
+			continue
+		}
+		seenSKUs[skuKey] = true
+
+		// Exact SKU match within tenant.
+		ctx := context.Background()
+		existing, err := r.queries.GetArticleBySkuForTenant(ctx, sqlc.GetArticleBySkuForTenantParams{Sku: sku, TenantID: tid})
+		if err == nil {
+			isActive := false
+			if existing.IsActive.Valid {
+				isActive = existing.IsActive.Bool
+			}
+			result.Status = responses.ArticleStatusExists
+			result.ExistingArticle = &responses.ArticleValidationMatch{
+				ID: existing.ID, SKU: existing.Sku, Name: existing.Name,
+				Presentation: existing.Presentation, IsActive: isActive,
+			}
+			results = append(results, result)
+			continue
+		}
+
+		// In-memory similarity check (per-tenant subset).
+		keyword := strings.ToLower(name)
+		if len(keyword) > 20 {
+			keyword = keyword[:20]
+		}
+		var matches []responses.ArticleValidationMatch
+		for _, a := range allArticles {
+			if strings.EqualFold(a.SKU, sku) {
+				continue
+			}
+			if strings.Contains(strings.ToLower(a.Name), keyword) {
+				isActive := false
+				if a.IsActive != nil {
+					isActive = *a.IsActive
+				}
+				matches = append(matches, responses.ArticleValidationMatch{
+					ID: a.ID, SKU: a.SKU, Name: a.Name,
+					Presentation: a.Presentation, IsActive: isActive,
+				})
+				if len(matches) == 3 {
+					break
+				}
+			}
+		}
+		if len(matches) > 0 {
+			result.Status = responses.ArticleStatusSimilar
+			result.SimilarArticles = matches
+			results = append(results, result)
+			continue
+		}
+
+		result.Status = responses.ArticleStatusNew
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+func (r *ArticlesRepositorySQLC) ExportArticlesToExcelForTenant(tenantID string) ([]byte, *responses.InternalResponse) {
+	articles, errResp := r.GetAllArticlesForTenant(tenantID)
 	if errResp != nil {
 		return nil, errResp
 	}
@@ -435,11 +524,133 @@ func (r *ArticlesRepositorySQLC) ExportArticlesToExcel() ([]byte, *responses.Int
 	return buf.Bytes(), nil
 }
 
-// --- mapping helpers ---
+func (r *ArticlesRepositorySQLC) GenerateImportTemplateForTenant(tenantID, language string) ([]byte, *responses.InternalResponse) {
+	articles, errResp := r.GetAllArticlesForTenant(tenantID)
+	if errResp != nil {
+		return nil, errResp
+	}
+	var presentations []string
+	for _, a := range articles {
+		presentations = append(presentations, a.Presentation)
+	}
+	return buildImportTemplate(presentations, language)
+}
 
-// articleRowData holds the common shape of sqlc article row types (ListArticlesRow, GetArticleByIDRow, GetArticleBySkuRow, UpdateArticleRow).
+// ─── legacy non-tenant methods ───────────────────────────────────────────────
+//
+// These remain as thin convenience wrappers for internal callers (cron jobs,
+// FK lookups from inventory rows, dashboards). They MUST NOT be called from
+// HTTP handlers — those go through *ForTenant instead. The legacy GetAll/GetByID/
+// GetBySku still query across tenants (matching their pre-S3.5 behaviour) so that
+// inventory/lots/serials lookups (which carry SKU only, not tenant_id) keep
+// working until W2 retrofits child tables with tenant_id.
+
+func (r *ArticlesRepositorySQLC) GetAllArticles() ([]database.Article, *responses.InternalResponse) {
+	ctx := context.Background()
+	list, err := r.queries.ListArticles(ctx)
+	if err != nil {
+		tools.LogRepoError("articles", "ListArticles", err, "Error al obtener los artículos")
+		return nil, &responses.InternalResponse{Error: err, Message: "Error al obtener los artículos", Handled: false}
+	}
+	out := make([]database.Article, len(list))
+	for i, a := range list {
+		out[i] = articleRowToDatabase(articleRowData{
+			ID: a.ID, TenantID: a.TenantID, Sku: a.Sku, Name: a.Name, Description: a.Description, UnitPrice: a.UnitPrice,
+			Presentation: a.Presentation, TrackByLot: a.TrackByLot, TrackBySerial: a.TrackBySerial,
+			TrackExpiration: a.TrackExpiration, RotationStrategy: a.RotationStrategy,
+			MinQuantity: a.MinQuantity, MaxQuantity: a.MaxQuantity, ImageUrl: a.ImageUrl,
+			IsActive: a.IsActive, CreatedAt: a.CreatedAt, UpdatedAt: a.UpdatedAt,
+			CategoryID: a.CategoryID, ShelfLifeInDays: a.ShelfLifeInDays, SafetyStock: a.SafetyStock,
+			BatchNumberSeries: a.BatchNumberSeries, SerialNumberSeries: a.SerialNumberSeries,
+			MinOrderQty: a.MinOrderQty, DefaultLocationID: a.DefaultLocationID,
+			ReceivingNotes: a.ReceivingNotes, ShippingNotes: a.ShippingNotes,
+		})
+	}
+	return out, nil
+}
+
+func (r *ArticlesRepositorySQLC) GetArticleByID(id string) (*database.Article, *responses.InternalResponse) {
+	ctx := context.Background()
+	a, err := r.queries.GetArticleByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, &responses.InternalResponse{Message: "Artículo no encontrado", Handled: true, StatusCode: responses.StatusNotFound}
+		}
+		tools.LogRepoError("articles", "GetArticleByID", err, "Error al obtener el artículo")
+		return nil, &responses.InternalResponse{Error: err, Message: "Error al obtener el artículo", Handled: false}
+	}
+	art := articleRowToDatabase(articleRowData{
+		ID: a.ID, TenantID: a.TenantID, Sku: a.Sku, Name: a.Name, Description: a.Description, UnitPrice: a.UnitPrice,
+		Presentation: a.Presentation, TrackByLot: a.TrackByLot, TrackBySerial: a.TrackBySerial,
+		TrackExpiration: a.TrackExpiration, RotationStrategy: a.RotationStrategy,
+		MinQuantity: a.MinQuantity, MaxQuantity: a.MaxQuantity, ImageUrl: a.ImageUrl,
+		IsActive: a.IsActive, CreatedAt: a.CreatedAt, UpdatedAt: a.UpdatedAt,
+		CategoryID: a.CategoryID, ShelfLifeInDays: a.ShelfLifeInDays, SafetyStock: a.SafetyStock,
+		BatchNumberSeries: a.BatchNumberSeries, SerialNumberSeries: a.SerialNumberSeries,
+		MinOrderQty: a.MinOrderQty, DefaultLocationID: a.DefaultLocationID,
+		ReceivingNotes: a.ReceivingNotes, ShippingNotes: a.ShippingNotes,
+	})
+	return &art, nil
+}
+
+func (r *ArticlesRepositorySQLC) GetBySku(sku string) (*database.Article, *responses.InternalResponse) {
+	ctx := context.Background()
+	a, err := r.queries.GetArticleBySku(ctx, sku)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, &responses.InternalResponse{Message: "Artículo no encontrado", Handled: true, StatusCode: responses.StatusNotFound}
+		}
+		tools.LogRepoError("articles", "GetBySku", err, "Error al obtener el artículo por SKU")
+		return nil, &responses.InternalResponse{Error: err, Message: "Error al obtener el artículo por SKU", Handled: false}
+	}
+	art := articleRowToDatabase(articleRowData{
+		ID: a.ID, TenantID: a.TenantID, Sku: a.Sku, Name: a.Name, Description: a.Description, UnitPrice: a.UnitPrice,
+		Presentation: a.Presentation, TrackByLot: a.TrackByLot, TrackBySerial: a.TrackBySerial,
+		TrackExpiration: a.TrackExpiration, RotationStrategy: a.RotationStrategy,
+		MinQuantity: a.MinQuantity, MaxQuantity: a.MaxQuantity, ImageUrl: a.ImageUrl,
+		IsActive: a.IsActive, CreatedAt: a.CreatedAt, UpdatedAt: a.UpdatedAt,
+		CategoryID: a.CategoryID, ShelfLifeInDays: a.ShelfLifeInDays, SafetyStock: a.SafetyStock,
+		BatchNumberSeries: a.BatchNumberSeries, SerialNumberSeries: a.SerialNumberSeries,
+		MinOrderQty: a.MinOrderQty, DefaultLocationID: a.DefaultLocationID,
+		ReceivingNotes: a.ReceivingNotes, ShippingNotes: a.ShippingNotes,
+	})
+	return &art, nil
+}
+
+func (r *ArticlesRepositorySQLC) GetLotsBySKU(sku string) ([]database.Lot, error) {
+	ctx := context.Background()
+	list, err := r.queries.ListLotsBySku(ctx, sku)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]database.Lot, len(list))
+	for i, l := range list {
+		out[i] = sqlcLotToDatabase(l)
+	}
+	return out, nil
+}
+
+func (r *ArticlesRepositorySQLC) GetSerialsBySKU(sku string) ([]database.Serial, error) {
+	ctx := context.Background()
+	list, err := r.queries.ListSerialsBySku(ctx, sku)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]database.Serial, len(list))
+	for i, s := range list {
+		out[i] = sqlcSerialToDatabase(s)
+	}
+	return out, nil
+}
+
+// ─── mapping helpers ─────────────────────────────────────────────────────────
+
+// articleRowData holds the common shape of sqlc article row types
+// (ListArticlesRow, ListArticlesForTenantRow, GetArticleByIDRow, GetArticleByIDForTenantRow,
+// GetArticleBySkuRow, GetArticleBySkuForTenantRow, UpdateArticleRow, CreateArticleRow).
 type articleRowData struct {
 	ID                 string
+	TenantID           pgtype.UUID
 	Sku                string
 	Name               string
 	Description        pgtype.Text
@@ -473,6 +684,7 @@ func articleRowToDatabase(a articleRowData) database.Article {
 	}
 	return database.Article{
 		ID:                 a.ID,
+		TenantID:           pgUUIDToString(a.TenantID),
 		SKU:                a.Sku,
 		Name:               a.Name,
 		Description:        pgTextToPtrString(a.Description),
@@ -643,96 +855,4 @@ func ptrStringToPgDate(s *string) pgtype.Date {
 		return pgtype.Date{}
 	}
 	return pgtype.Date{Time: t, Valid: true}
-}
-
-
-func (r *ArticlesRepositorySQLC) ValidateImportRows(rows []requests.ArticleImportRow) ([]responses.ArticleValidationResult, *responses.InternalResponse) {
-	results := make([]responses.ArticleValidationResult, 0, len(rows))
-	seenSKUs := make(map[string]bool)
-
-	// Load all articles once for in-memory similarity check
-	allArticles, errResp := r.GetAllArticles()
-	if errResp != nil {
-		return nil, errResp
-	}
-
-	for i, row := range rows {
-		sku := strings.TrimSpace(row.SKU)
-		name := strings.TrimSpace(row.Name)
-		result := responses.ArticleValidationResult{RowIndex: i, Row: row}
-
-		// Field validation
-		if sku == "" || name == "" || strings.TrimSpace(row.Presentation) == "" {
-			result.Status = responses.ArticleStatusError
-			result.FieldErrors = map[string]string{}
-			if sku == "" { result.FieldErrors["sku"] = "SKU requerido" }
-			if name == "" { result.FieldErrors["name"] = "Nombre requerido" }
-			if strings.TrimSpace(row.Presentation) == "" { result.FieldErrors["presentation"] = "Presentación requerida" }
-			results = append(results, result)
-			continue
-		}
-
-		// Duplicate within batch
-		skuKey := strings.ToLower(sku)
-		if seenSKUs[skuKey] {
-			result.Status = responses.ArticleStatusDuplicate
-			results = append(results, result)
-			continue
-		}
-		seenSKUs[skuKey] = true
-
-		// Exact SKU match
-		ctx := context.Background()
-		existing, err := r.queries.GetArticleBySku(ctx, sku)
-		if err == nil {
-			isActive := false
-			if existing.IsActive.Valid { isActive = existing.IsActive.Bool }
-			result.Status = responses.ArticleStatusExists
-			result.ExistingArticle = &responses.ArticleValidationMatch{
-				ID: existing.ID, SKU: existing.Sku, Name: existing.Name,
-				Presentation: existing.Presentation, IsActive: isActive,
-			}
-			results = append(results, result)
-			continue
-		}
-
-		// In-memory similarity check
-		keyword := strings.ToLower(name)
-		if len(keyword) > 20 { keyword = keyword[:20] }
-		var matches []responses.ArticleValidationMatch
-		for _, a := range allArticles {
-			if strings.ToLower(a.SKU) == strings.ToLower(sku) { continue }
-			if strings.Contains(strings.ToLower(a.Name), keyword) {
-				isActive := false
-				if a.IsActive != nil { isActive = *a.IsActive }
-				matches = append(matches, responses.ArticleValidationMatch{
-					ID: a.ID, SKU: a.SKU, Name: a.Name,
-					Presentation: a.Presentation, IsActive: isActive,
-				})
-				if len(matches) == 3 { break }
-			}
-		}
-		if len(matches) > 0 {
-			result.Status = responses.ArticleStatusSimilar
-			result.SimilarArticles = matches
-			results = append(results, result)
-			continue
-		}
-
-		result.Status = responses.ArticleStatusNew
-		results = append(results, result)
-	}
-	return results, nil
-}
-
-func (r *ArticlesRepositorySQLC) GenerateImportTemplate(language string) ([]byte, *responses.InternalResponse) {
-	articles, errResp := r.GetAllArticles()
-	if errResp != nil {
-		return nil, errResp
-	}
-	var presentations []string
-	for _, a := range articles {
-		presentations = append(presentations, a.Presentation)
-	}
-	return buildImportTemplate(presentations, language)
 }

--- a/repositories/articles_repository_sqlc_integration_test.go
+++ b/repositories/articles_repository_sqlc_integration_test.go
@@ -20,6 +20,10 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 )
 
+// testTenantSqlc is the canonical tenant UUID used by SQLC integration tests.
+// Matches the migration 000029 backfill default so legacy reads still find seeded rows.
+const testTenantSqlc = "00000000-0000-0000-0000-000000000001"
+
 func setupTestDB(t *testing.T) (connStr string, cleanup func()) {
 	t.Helper()
 	if testing.Short() {
@@ -88,7 +92,7 @@ func TestArticlesRepositorySQLC_ListAndCreate(t *testing.T) {
 		Name:         "Test Article",
 		Presentation: "unit",
 	}
-	resp = repo.CreateArticle(data)
+	resp = repo.CreateArticleForTenant(testTenantSqlc, data)
 	require.Nil(t, resp)
 
 	// List has one
@@ -111,7 +115,7 @@ func TestArticlesRepositorySQLC_GetByIDAndBySku(t *testing.T) {
 		Name:         "Get Test",
 		Presentation: "unit",
 	}
-	resp := repo.CreateArticle(data)
+	resp := repo.CreateArticleForTenant(testTenantSqlc, data)
 	require.Nil(t, resp)
 
 	list, _ := repo.GetAllArticles()
@@ -170,7 +174,7 @@ func TestArticlesRepositorySQLC_CreateDuplicate_Conflict(t *testing.T) {
 		Name:         "First",
 		Presentation: "unit",
 	}
-	resp := repo.CreateArticle(data)
+	resp := repo.CreateArticleForTenant(testTenantSqlc, data)
 	require.Nil(t, resp)
 
 	// Duplicate SKU
@@ -179,7 +183,7 @@ func TestArticlesRepositorySQLC_CreateDuplicate_Conflict(t *testing.T) {
 		Name:         "Second",
 		Presentation: "unit",
 	}
-	resp = repo.CreateArticle(data2)
+	resp = repo.CreateArticleForTenant(testTenantSqlc, data2)
 	require.NotNil(t, resp)
 	assert.True(t, resp.Handled)
 	assert.Equal(t, responses.StatusConflict, resp.StatusCode)
@@ -198,7 +202,7 @@ func TestArticlesRepositorySQLC_UpdateAndDelete(t *testing.T) {
 		Name:         "Original",
 		Presentation: "unit",
 	}
-	resp := repo.CreateArticle(data)
+	resp := repo.CreateArticleForTenant(testTenantSqlc, data)
 	require.Nil(t, resp)
 
 	list, _ := repo.GetAllArticles()
@@ -211,13 +215,13 @@ func TestArticlesRepositorySQLC_UpdateAndDelete(t *testing.T) {
 		Name:         "Updated Name",
 		Presentation: "unit",
 	}
-	art, resp := repo.UpdateArticle(id, updated)
+	art, resp := repo.UpdateArticleForTenant(id, testTenantSqlc, updated)
 	require.Nil(t, resp)
 	require.NotNil(t, art)
 	assert.Equal(t, "Updated Name", art.Name)
 
 	// Delete
-	resp = repo.DeleteArticle(id)
+	resp = repo.DeleteArticleForTenant(id, testTenantSqlc)
 	require.Nil(t, resp)
 
 	// Get returns 404
@@ -238,7 +242,7 @@ func TestArticlesRepositorySQLC_Update_NotFound(t *testing.T) {
 		Name:         "X",
 		Presentation: "unit",
 	}
-	art, resp := repo.UpdateArticle("99999", data)
+	art, resp := repo.UpdateArticleForTenant("99999", testTenantSqlc, data)
 	require.Nil(t, art)
 	require.NotNil(t, resp)
 	assert.Equal(t, responses.StatusNotFound, resp.StatusCode)

--- a/repositories/tenant_isolation_test.go
+++ b/repositories/tenant_isolation_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/eflowcr/eSTOCK_backend/models/database"
+	"github.com/eflowcr/eSTOCK_backend/models/responses"
 	"github.com/eflowcr/eSTOCK_backend/tools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -249,4 +250,143 @@ func TestTenantIsolation_PickingTaskModelHasTenantIDField(t *testing.T) {
 func TestTenantIsolation_ReceivingTaskModelHasTenantIDField(t *testing.T) {
 	rt := database.ReceivingTask{ID: "test", TenantID: testTenantA}
 	assert.Equal(t, testTenantA, rt.TenantID)
+}
+
+// ─── Articles isolation (S3.5 W1 — HR-S3-W5 C2 fix) ──────────────────────────
+
+// seedArticleRow inserts an article row with an explicit tenant_id directly via SQL,
+// bypassing the GORM model so we can exercise the cross-tenant scenarios that the
+// production code is meant to prevent.
+func seedArticleRow(t *testing.T, db *gorm.DB, tenantID, sku, name string) string {
+	t.Helper()
+	id, err := tools.GenerateNanoid(db)
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`
+		INSERT INTO articles
+			(id, tenant_id, sku, name, presentation, track_by_lot, track_by_serial,
+			 track_expiration, rotation_strategy, is_active, safety_stock, min_order_qty,
+			 created_at, updated_at)
+		VALUES (?, ?::uuid, ?, ?, 'unit', false, false, false, 'fifo', true, 0, 0, NOW(), NOW())`,
+		id, tenantID, sku, name).Error)
+	return id
+}
+
+// TestArticles_TenantIsolation_GetAll_returnsOnlyOwnTenant seeds two tenants
+// then verifies the per-tenant GetAllArticlesForTenant only sees its own rows.
+// Regression guard for HR-S3-W5 C2 — the SeedFarma data leak that motivated
+// this entire sprint must never come back.
+func TestArticles_TenantIsolation_GetAll_returnsOnlyOwnTenant(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	idA1 := seedArticleRow(t, db, testTenantA, "ISO-ART-A1", "Article A1")
+	idA2 := seedArticleRow(t, db, testTenantA, "ISO-ART-A2", "Article A2")
+	idB1 := seedArticleRow(t, db, testTenantB, "ISO-ART-B1", "Article B1")
+
+	repo := &ArticlesRepository{DB: db}
+
+	rowsA, errA := repo.GetAllArticlesForTenant(testTenantA)
+	require.Nil(t, errA)
+	idsA := make([]string, 0, len(rowsA))
+	for _, r := range rowsA {
+		idsA = append(idsA, r.ID)
+		assert.Equal(t, testTenantA, r.TenantID, "GetAllArticlesForTenant(A) must only return tenant A rows")
+	}
+	assert.Contains(t, idsA, idA1)
+	assert.Contains(t, idsA, idA2)
+	assert.NotContains(t, idsA, idB1, "tenant A must not see tenant B's articles")
+
+	rowsB, errB := repo.GetAllArticlesForTenant(testTenantB)
+	require.Nil(t, errB)
+	require.Len(t, rowsB, 1)
+	assert.Equal(t, idB1, rowsB[0].ID)
+	assert.Equal(t, testTenantB, rowsB[0].TenantID)
+}
+
+// TestArticles_TenantIsolation_PerTenantSkuLookup exercises the per-tenant SKU
+// lookup against the new composite (tenant_id, sku) index. Two different SKUs are
+// used per tenant because the W1 migration intentionally retains the legacy
+// global UNIQUE(sku) for FK target preservation — see migration 000029 comments
+// and feedback_estock_articles_no_tenant_isolation.md. Once child-table FKs are
+// retrofitted (future sprint), the global unique can be dropped and the same
+// SKU will be allowed across tenants; that will earn a separate test.
+//
+// What this test PROVES today:
+//   - Per-tenant reads are scoped: tenant A cannot see tenant B's row by SKU even
+//     when both rows exist with the same row id pattern.
+//   - The new composite index enforces uniqueness within a single tenant
+//     (re-inserting (tenantA, "ART-A-001") fails).
+func TestArticles_TenantIsolation_PerTenantSkuLookup(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	const skuA = "ISO-LOOKUP-A-001"
+	const skuB = "ISO-LOOKUP-B-001"
+
+	idA := seedArticleRow(t, db, testTenantA, skuA, "Article A1")
+	idB := seedArticleRow(t, db, testTenantB, skuB, "Article B1")
+
+	repo := &ArticlesRepository{DB: db}
+
+	// Tenant A finds its own row, doesn't see tenant B's.
+	gotA, errA := repo.GetBySkuForTenant(skuA, testTenantA)
+	require.Nil(t, errA)
+	require.NotNil(t, gotA)
+	assert.Equal(t, idA, gotA.ID)
+	assert.Equal(t, testTenantA, gotA.TenantID)
+
+	notFoundA, errNF := repo.GetBySkuForTenant(skuB, testTenantA)
+	require.NotNil(t, errNF, "tenant A must not see tenant B's SKU")
+	assert.Equal(t, responses.StatusNotFound, errNF.StatusCode)
+	assert.Nil(t, notFoundA)
+
+	// Tenant B sees its own.
+	gotB, errB := repo.GetBySkuForTenant(skuB, testTenantB)
+	require.Nil(t, errB)
+	require.NotNil(t, gotB)
+	assert.Equal(t, idB, gotB.ID)
+
+	// Composite unique (tenant_id, sku) enforced: re-inserting the same pair fails.
+	dupErr := db.Exec(`
+		INSERT INTO articles
+			(id, tenant_id, sku, name, presentation, track_by_lot, track_by_serial,
+			 track_expiration, rotation_strategy, is_active, safety_stock, min_order_qty,
+			 created_at, updated_at)
+		VALUES (gen_random_uuid()::text, ?::uuid, ?, 'dup', 'unit', false, false, false,
+			'fifo', true, 0, 0, NOW(), NOW())`,
+		testTenantA, skuA).Error
+	require.Error(t, dupErr, "second insert of the same (tenant_id, sku) must violate articles_tenant_sku_key")
+}
+
+// TestArticles_TenantIsolation_GlobalSkuUniqueStillEnforced documents the W1
+// limitation: the legacy global UNIQUE(sku) is retained as a FK target for the
+// 8+ child tables that reference articles(sku). Two different tenants therefore
+// CANNOT yet share the same SKU. This test asserts the limitation explicitly so
+// any future migration that drops the global unique will need to update this
+// test too — providing a clear paper trail for the structural change.
+func TestArticles_TenantIsolation_GlobalSkuUniqueStillEnforced(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	const sharedSKU = "ISO-GLOBAL-SHARED-001"
+	seedArticleRow(t, db, testTenantA, sharedSKU, "Owned by tenant A")
+
+	// Tenant B cannot register the same SKU until the global unique is dropped.
+	dupErr := db.Exec(`
+		INSERT INTO articles
+			(id, tenant_id, sku, name, presentation, track_by_lot, track_by_serial,
+			 track_expiration, rotation_strategy, is_active, safety_stock, min_order_qty,
+			 created_at, updated_at)
+		VALUES (gen_random_uuid()::text, ?::uuid, ?, 'tenant B copy', 'unit', false, false,
+			false, 'fifo', true, 0, 0, NOW(), NOW())`,
+		testTenantB, sharedSKU).Error
+	require.Error(t, dupErr, "global articles_sku_key intentionally still enforces SKU uniqueness across tenants in W1")
+	assert.Contains(t, dupErr.Error(), "articles_sku_key")
+}
+
+// TestTenantIsolation_ArticleModelHasTenantIDField is a compile-time guard so the
+// TenantID struct field can't be silently removed.
+func TestTenantIsolation_ArticleModelHasTenantIDField(t *testing.T) {
+	a := database.Article{ID: "test", TenantID: testTenantA}
+	assert.Equal(t, testTenantA, a.TenantID)
 }

--- a/routes/articles_routes.go
+++ b/routes/articles_routes.go
@@ -19,7 +19,7 @@ var _ ports.ArticlesRepository = (*repositories.ArticlesRepositorySQLC)(nil)
 func RegisterArticlesRoutes(router *gin.RouterGroup, db *gorm.DB, pool *pgxpool.Pool, config configuration.Config, auditSvc *services.AuditService, rolesRepo ports.RolesRepository) {
 	_, articlesService := wire.NewArticlesWithDeps(db, pool)
 	userPrefsRepo := wire.NewUserPreferences(pool)
-	articlesController := controllers.NewArticlesController(*articlesService, auditSvc, userPrefsRepo)
+	articlesController := controllers.NewArticlesController(*articlesService, auditSvc, userPrefsRepo, config.TenantID)
 
 	route := router.Group("/articles")
 	route.Use(tools.JWTAuthMiddleware(config.JWTSecret))
@@ -31,7 +31,9 @@ func RegisterArticlesRoutes(router *gin.RouterGroup, db *gorm.DB, pool *pgxpool.
 
 		route.GET("/", read, articlesController.GetAllArticles)
 		if pool != nil {
-			cfg := tools.ArticlesTableConfig()
+			// S3.5 W1 — tenant-scoped DefaultWhere prevents cross-tenant data exposure
+			// in the generic table/export handlers (HR-S3-W5 C2 fix).
+			cfg := tools.ArticlesTableConfigForTenant(config.TenantID)
 			route.GET("/table", read, tools.GenericListHandler(pool, cfg))
 			route.GET("/table/export", read, tools.GenericExportHandler(pool, cfg, "articles.csv"))
 		}

--- a/services/articles_import_test.go
+++ b/services/articles_import_test.go
@@ -21,7 +21,7 @@ func TestArticlesService_ImportJSON_Success(t *testing.T) {
 		{SKU: "SKU-002", Name: "Product Two", Presentation: "box", TrackByLot: "Si"},
 	}
 
-	imported, skipped, errs := svc.ImportArticlesFromJSON(rows)
+	imported, skipped, errs := svc.ImportArticlesFromJSON(testTenantID, rows)
 	assert.Empty(t, errs)
 	assert.Empty(t, skipped)
 	assert.Len(t, imported, 0) // mock returns nil; real repo would return skus
@@ -31,7 +31,7 @@ func TestArticlesService_ImportJSON_EmptyRows(t *testing.T) {
 	repo := &mockArticlesRepo{}
 	svc := NewArticlesService(repo)
 
-	imported, skipped, errs := svc.ImportArticlesFromJSON([]requests.ArticleImportRow{})
+	imported, skipped, errs := svc.ImportArticlesFromJSON(testTenantID, []requests.ArticleImportRow{})
 	assert.Empty(t, errs)
 	assert.Empty(t, skipped)
 	assert.Empty(t, imported)
@@ -46,7 +46,7 @@ func TestArticlesService_ValidateImportRows_Delegates(t *testing.T) {
 	rows := []requests.ArticleImportRow{
 		{SKU: "A", Name: "Alfa", Presentation: "unit"},
 	}
-	results, errResp := svc.ValidateImportRows(rows)
+	results, errResp := svc.ValidateImportRows(testTenantID, rows)
 	// mock returns nil,nil — just verifies delegation doesn't panic
 	assert.Nil(t, errResp)
 	assert.Nil(t, results)
@@ -65,7 +65,7 @@ func TestArticlesService_RotationStrategy_FEFORequiresExpiration(t *testing.T) {
 		TrackExpiration:  false,
 		RotationStrategy: "fefo",
 	}
-	errResp := svc.CreateArticle(req)
+	errResp := svc.CreateArticle(testTenantID, req)
 	require.NotNil(t, errResp)
 	assert.True(t, errResp.Handled)
 	assert.Contains(t, errResp.Message, "FEFO")
@@ -82,7 +82,7 @@ func TestArticlesService_RotationStrategy_FIFONoExpiration(t *testing.T) {
 		TrackExpiration:  false,
 		RotationStrategy: "fifo",
 	}
-	errResp := svc.CreateArticle(req)
+	errResp := svc.CreateArticle(testTenantID, req)
 	assert.Nil(t, errResp)
 }
 
@@ -97,7 +97,7 @@ func TestArticlesService_RotationStrategy_FEFOWithExpiration(t *testing.T) {
 		TrackExpiration:  true,
 		RotationStrategy: "fefo",
 	}
-	errResp := svc.CreateArticle(req)
+	errResp := svc.CreateArticle(testTenantID, req)
 	assert.Nil(t, errResp)
 }
 
@@ -112,7 +112,7 @@ func TestArticlesService_UpdateArticle_LotTrackingDisabledWarning(t *testing.T) 
 	svc := NewArticlesService(repo)
 
 	req := &requests.Article{SKU: "SKU1", Name: "Art", Presentation: "unit", TrackByLot: false}
-	_, errResp, warnings := svc.UpdateArticle("1", req)
+	_, errResp, warnings := svc.UpdateArticle("1", testTenantID, req)
 	assert.Nil(t, errResp)
 	require.Len(t, warnings, 1)
 	assert.Equal(t, "lot_tracking_disabled", warnings[0]["type"])
@@ -127,7 +127,7 @@ func TestArticlesService_UpdateArticle_SerialTrackingDisabledWarning(t *testing.
 	svc := NewArticlesService(repo)
 
 	req := &requests.Article{SKU: "SKU1", Name: "Art", Presentation: "unit", TrackBySerial: false}
-	_, errResp, warnings := svc.UpdateArticle("1", req)
+	_, errResp, warnings := svc.UpdateArticle("1", testTenantID, req)
 	assert.Nil(t, errResp)
 	require.Len(t, warnings, 1)
 	assert.Equal(t, "serial_tracking_disabled", warnings[0]["type"])
@@ -137,7 +137,7 @@ func TestArticlesService_UpdateArticle_NotFound(t *testing.T) {
 	repo := &mockArticlesRepo{byID: map[string]*database.Article{}}
 	svc := NewArticlesService(repo)
 
-	_, errResp, _ := svc.UpdateArticle("999", &requests.Article{SKU: "X", Name: "X", Presentation: "unit"})
+	_, errResp, _ := svc.UpdateArticle("999", testTenantID, &requests.Article{SKU: "X", Name: "X", Presentation: "unit"})
 	require.NotNil(t, errResp)
 	assert.Equal(t, responses.StatusNotFound, errResp.StatusCode)
 }

--- a/services/articles_service.go
+++ b/services/articles_service.go
@@ -21,10 +21,13 @@ type locationLookupForArticles interface {
 	GetLocationByID(id string) (*database.Location, *responses.InternalResponse)
 }
 
+// ArticlesService — S3.5 W1: every public method now requires a tenantID. Controllers
+// pass it from Config.TenantID (env-injected); a future M2 wave will source it from
+// the JWT claim instead so multi-tenant signup can work end-to-end.
 type ArticlesService struct {
-	Repository    ports.ArticlesRepository
+	Repository     ports.ArticlesRepository
 	CategoriesRepo categoryLookupForArticles // optional: validate category_id on create/update
-	LocationsRepo  locationLookupForArticles  // optional: validate default_location_id
+	LocationsRepo  locationLookupForArticles // optional: validate default_location_id
 }
 
 func NewArticlesService(repo ports.ArticlesRepository) *ArticlesService {
@@ -45,16 +48,16 @@ func (s *ArticlesService) WithLocationsRepo(r locationLookupForArticles) *Articl
 	return s
 }
 
-func (s *ArticlesService) GetAllArticles() ([]database.Article, *responses.InternalResponse) {
-	return s.Repository.GetAllArticles()
+func (s *ArticlesService) GetAllArticles(tenantID string) ([]database.Article, *responses.InternalResponse) {
+	return s.Repository.GetAllArticlesForTenant(tenantID)
 }
 
-func (s *ArticlesService) GetArticleByID(id string) (*database.Article, *responses.InternalResponse) {
-	return s.Repository.GetArticleByID(id)
+func (s *ArticlesService) GetArticleByID(id, tenantID string) (*database.Article, *responses.InternalResponse) {
+	return s.Repository.GetArticleByIDForTenant(id, tenantID)
 }
 
-func (s *ArticlesService) GetBySku(sku string) (*database.Article, *responses.InternalResponse) {
-	return s.Repository.GetBySku(sku)
+func (s *ArticlesService) GetBySku(sku, tenantID string) (*database.Article, *responses.InternalResponse) {
+	return s.Repository.GetBySkuForTenant(sku, tenantID)
 }
 
 // EnrichArticle builds an ArticleResponse with embedded category and default_location objects.
@@ -63,25 +66,25 @@ func (s *ArticlesService) EnrichArticle(art *database.Article) *responses.Articl
 		return nil
 	}
 	r := &responses.ArticleResponse{
-		ID:               art.ID,
-		SKU:              art.SKU,
-		Name:             art.Name,
-		Description:      art.Description,
-		UnitPrice:        art.UnitPrice,
-		Presentation:     art.Presentation,
-		TrackByLot:       art.TrackByLot,
-		TrackBySerial:    art.TrackBySerial,
-		TrackExpiration:  art.TrackExpiration,
-		RotationStrategy: art.RotationStrategy,
-		MinQuantity:      art.MinQuantity,
-		MaxQuantity:      art.MaxQuantity,
-		ImageURL:         art.ImageURL,
-		IsActive:         art.IsActive,
-		CreatedAt:        art.CreatedAt,
-		UpdatedAt:        art.UpdatedAt,
-		CategoryID:       art.CategoryID,
-		ShelfLifeInDays:  art.ShelfLifeInDays,
-		SafetyStock:      art.SafetyStock,
+		ID:                 art.ID,
+		SKU:                art.SKU,
+		Name:               art.Name,
+		Description:        art.Description,
+		UnitPrice:          art.UnitPrice,
+		Presentation:       art.Presentation,
+		TrackByLot:         art.TrackByLot,
+		TrackBySerial:      art.TrackBySerial,
+		TrackExpiration:    art.TrackExpiration,
+		RotationStrategy:   art.RotationStrategy,
+		MinQuantity:        art.MinQuantity,
+		MaxQuantity:        art.MaxQuantity,
+		ImageURL:           art.ImageURL,
+		IsActive:           art.IsActive,
+		CreatedAt:          art.CreatedAt,
+		UpdatedAt:          art.UpdatedAt,
+		CategoryID:         art.CategoryID,
+		ShelfLifeInDays:    art.ShelfLifeInDays,
+		SafetyStock:        art.SafetyStock,
 		BatchNumberSeries:  art.BatchNumberSeries,
 		SerialNumberSeries: art.SerialNumberSeries,
 		MinOrderQty:        art.MinOrderQty,
@@ -104,22 +107,22 @@ func (s *ArticlesService) EnrichArticle(art *database.Article) *responses.Articl
 	return r
 }
 
-func (s *ArticlesService) CreateArticle(article *requests.Article) *responses.InternalResponse {
+func (s *ArticlesService) CreateArticle(tenantID string, article *requests.Article) *responses.InternalResponse {
 	if errResp := s.validateArticleFields(article); errResp != nil {
 		return errResp
 	}
 	if errResp := s.validateRotationStrategy(article.RotationStrategy, article.TrackExpiration); errResp != nil {
 		return errResp
 	}
-	resp := s.Repository.CreateArticle(article)
+	resp := s.Repository.CreateArticleForTenant(tenantID, article)
 	if resp != nil && resp.Error != nil && !resp.Handled {
 		tools.LogServiceError("articles", "CreateArticle", resp.Error, resp.Message)
 	}
 	return resp
 }
 
-func (s *ArticlesService) UpdateArticle(id string, data *requests.Article) (*database.Article, *responses.InternalResponse, []map[string]interface{}) {
-	article, errResp := s.Repository.GetArticleByID(id)
+func (s *ArticlesService) UpdateArticle(id, tenantID string, data *requests.Article) (*database.Article, *responses.InternalResponse, []map[string]interface{}) {
+	article, errResp := s.Repository.GetArticleByIDForTenant(id, tenantID)
 	if errResp != nil {
 		return nil, errResp, nil
 	}
@@ -159,32 +162,32 @@ func (s *ArticlesService) UpdateArticle(id string, data *requests.Article) (*dat
 		return nil, errResp, nil
 	}
 
-	updated, errResp := s.Repository.UpdateArticle(id, data)
+	updated, errResp := s.Repository.UpdateArticleForTenant(id, tenantID, data)
 	return updated, errResp, warnings
 }
 
-func (s *ArticlesService) ImportArticlesFromExcel(fileBytes []byte) ([]string, []string, []*responses.InternalResponse) {
-	return s.Repository.ImportArticlesFromExcel(fileBytes)
+func (s *ArticlesService) ImportArticlesFromExcel(tenantID string, fileBytes []byte) ([]string, []string, []*responses.InternalResponse) {
+	return s.Repository.ImportArticlesFromExcelForTenant(tenantID, fileBytes)
 }
 
-func (s *ArticlesService) ImportArticlesFromJSON(rows []requests.ArticleImportRow) ([]string, []string, []*responses.InternalResponse) {
-	return s.Repository.ImportArticlesFromJSON(rows)
+func (s *ArticlesService) ImportArticlesFromJSON(tenantID string, rows []requests.ArticleImportRow) ([]string, []string, []*responses.InternalResponse) {
+	return s.Repository.ImportArticlesFromJSONForTenant(tenantID, rows)
 }
 
-func (s *ArticlesService) ExportArticlesToExcel() ([]byte, *responses.InternalResponse) {
-	return s.Repository.ExportArticlesToExcel()
+func (s *ArticlesService) ExportArticlesToExcel(tenantID string) ([]byte, *responses.InternalResponse) {
+	return s.Repository.ExportArticlesToExcelForTenant(tenantID)
 }
 
-func (s *ArticlesService) ValidateImportRows(rows []requests.ArticleImportRow) ([]responses.ArticleValidationResult, *responses.InternalResponse) {
-	return s.Repository.ValidateImportRows(rows)
+func (s *ArticlesService) ValidateImportRows(tenantID string, rows []requests.ArticleImportRow) ([]responses.ArticleValidationResult, *responses.InternalResponse) {
+	return s.Repository.ValidateImportRowsForTenant(tenantID, rows)
 }
 
-func (s *ArticlesService) GenerateImportTemplate(language string) ([]byte, *responses.InternalResponse) {
-	return s.Repository.GenerateImportTemplate(language)
+func (s *ArticlesService) GenerateImportTemplate(tenantID, language string) ([]byte, *responses.InternalResponse) {
+	return s.Repository.GenerateImportTemplateForTenant(tenantID, language)
 }
 
-func (s *ArticlesService) DeleteArticle(id string) *responses.InternalResponse {
-	return s.Repository.DeleteArticle(id)
+func (s *ArticlesService) DeleteArticle(id, tenantID string) *responses.InternalResponse {
+	return s.Repository.DeleteArticleForTenant(id, tenantID)
 }
 
 // validateArticleFields validates the new M2 fields.

--- a/services/articles_service_test.go
+++ b/services/articles_service_test.go
@@ -12,26 +12,33 @@ import (
 	"testing"
 )
 
+// testTenantID is shared with purchase_orders_service_test.go — defined there.
+//
 // mockArticlesRepo is a in-memory fake for unit testing ArticlesService.
+// S3.5 W1: implements both ForTenant (HTTP-facing) and legacy non-tenant methods.
+// Tenant filtering is intentionally NOT enforced here — this is a unit-test mock,
+// not an isolation test. Real isolation lives in repositories/tenant_isolation_test.go.
 type mockArticlesRepo struct {
-	articles   []database.Article
-	byID       map[string]*database.Article
-	bySku      map[string]*database.Article
-	createErr  *responses.InternalResponse
-	getIDErr   *responses.InternalResponse
-	deleteErr  *responses.InternalResponse
-	lotsBySku  []database.Lot
+	articles     []database.Article
+	byID         map[string]*database.Article
+	bySku        map[string]*database.Article
+	createErr    *responses.InternalResponse
+	getIDErr     *responses.InternalResponse
+	deleteErr    *responses.InternalResponse
+	lotsBySku    []database.Lot
 	serialsBySku []database.Serial
 }
 
-func (m *mockArticlesRepo) GetAllArticles() ([]database.Article, *responses.InternalResponse) {
+// ── tenant-scoped (HTTP-facing) ─────────────────────────────────────────────
+
+func (m *mockArticlesRepo) GetAllArticlesForTenant(_ string) ([]database.Article, *responses.InternalResponse) {
 	if m.articles == nil {
 		return nil, nil
 	}
 	return m.articles, nil
 }
 
-func (m *mockArticlesRepo) GetArticleByID(id string) (*database.Article, *responses.InternalResponse) {
+func (m *mockArticlesRepo) GetArticleByIDForTenant(id, _ string) (*database.Article, *responses.InternalResponse) {
 	if m.getIDErr != nil {
 		return nil, m.getIDErr
 	}
@@ -47,7 +54,7 @@ func (m *mockArticlesRepo) GetArticleByID(id string) (*database.Article, *respon
 	}
 }
 
-func (m *mockArticlesRepo) GetBySku(sku string) (*database.Article, *responses.InternalResponse) {
+func (m *mockArticlesRepo) GetBySkuForTenant(sku, _ string) (*database.Article, *responses.InternalResponse) {
 	if m.bySku != nil {
 		if a, ok := m.bySku[sku]; ok {
 			return a, nil
@@ -60,13 +67,14 @@ func (m *mockArticlesRepo) GetBySku(sku string) (*database.Article, *responses.I
 	}
 }
 
-func (m *mockArticlesRepo) CreateArticle(data *requests.Article) *responses.InternalResponse {
+func (m *mockArticlesRepo) CreateArticleForTenant(tenantID string, data *requests.Article) *responses.InternalResponse {
 	if m.createErr != nil {
 		return m.createErr
 	}
 	id := fmt.Sprintf("art-%d", len(m.articles)+1)
 	a := database.Article{
 		ID:              id,
+		TenantID:        tenantID,
 		SKU:             data.SKU,
 		Name:            data.Name,
 		Description:     data.Description,
@@ -83,49 +91,66 @@ func (m *mockArticlesRepo) CreateArticle(data *requests.Article) *responses.Inte
 	return nil
 }
 
-func (m *mockArticlesRepo) UpdateArticle(id string, data *requests.Article) (*database.Article, *responses.InternalResponse) {
+func (m *mockArticlesRepo) UpdateArticleForTenant(_, _ string, _ *requests.Article) (*database.Article, *responses.InternalResponse) {
 	return nil, nil
 }
 
-func (m *mockArticlesRepo) GetLotsBySKU(sku string) ([]database.Lot, error) {
+func (m *mockArticlesRepo) DeleteArticleForTenant(_, _ string) *responses.InternalResponse {
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	return nil
+}
+
+func (m *mockArticlesRepo) ImportArticlesFromExcelForTenant(_ string, _ []byte) ([]string, []string, []*responses.InternalResponse) {
+	return nil, nil, nil
+}
+
+func (m *mockArticlesRepo) ImportArticlesFromJSONForTenant(_ string, _ []requests.ArticleImportRow) ([]string, []string, []*responses.InternalResponse) {
+	return nil, nil, nil
+}
+
+func (m *mockArticlesRepo) ValidateImportRowsForTenant(_ string, _ []requests.ArticleImportRow) ([]responses.ArticleValidationResult, *responses.InternalResponse) {
+	return nil, nil
+}
+
+func (m *mockArticlesRepo) ExportArticlesToExcelForTenant(_ string) ([]byte, *responses.InternalResponse) {
+	return nil, nil
+}
+
+func (m *mockArticlesRepo) GenerateImportTemplateForTenant(_ string, _ string) ([]byte, *responses.InternalResponse) {
+	return nil, nil
+}
+
+// ── legacy (non-tenant) — used only by GetLotsBySKU / GetSerialsBySKU lookups ─
+
+func (m *mockArticlesRepo) GetAllArticles() ([]database.Article, *responses.InternalResponse) {
+	if m.articles == nil {
+		return nil, nil
+	}
+	return m.articles, nil
+}
+
+func (m *mockArticlesRepo) GetArticleByID(id string) (*database.Article, *responses.InternalResponse) {
+	return m.GetArticleByIDForTenant(id, "")
+}
+
+func (m *mockArticlesRepo) GetBySku(sku string) (*database.Article, *responses.InternalResponse) {
+	return m.GetBySkuForTenant(sku, "")
+}
+
+func (m *mockArticlesRepo) GetLotsBySKU(_ string) ([]database.Lot, error) {
 	if m.lotsBySku != nil {
 		return m.lotsBySku, nil
 	}
 	return nil, nil
 }
 
-func (m *mockArticlesRepo) GetSerialsBySKU(sku string) ([]database.Serial, error) {
+func (m *mockArticlesRepo) GetSerialsBySKU(_ string) ([]database.Serial, error) {
 	if m.serialsBySku != nil {
 		return m.serialsBySku, nil
 	}
 	return nil, nil
-}
-
-func (m *mockArticlesRepo) ImportArticlesFromExcel(fileBytes []byte) ([]string, []string, []*responses.InternalResponse) {
-	return nil, nil, nil
-}
-
-func (m *mockArticlesRepo) ImportArticlesFromJSON(_ []requests.ArticleImportRow) ([]string, []string, []*responses.InternalResponse) {
-	return nil, nil, nil
-}
-
-func (m *mockArticlesRepo) ExportArticlesToExcel() ([]byte, *responses.InternalResponse) {
-	return nil, nil
-}
-
-func (m *mockArticlesRepo) GenerateImportTemplate(_ string) ([]byte, *responses.InternalResponse) {
-	return nil, nil
-}
-
-func (m *mockArticlesRepo) ValidateImportRows(_ []requests.ArticleImportRow) ([]responses.ArticleValidationResult, *responses.InternalResponse) {
-	return nil, nil
-}
-
-func (m *mockArticlesRepo) DeleteArticle(id string) *responses.InternalResponse {
-	if m.deleteErr != nil {
-		return m.deleteErr
-	}
-	return nil
 }
 
 func TestArticlesService_GetAllArticles(t *testing.T) {
@@ -136,7 +161,7 @@ func TestArticlesService_GetAllArticles(t *testing.T) {
 		},
 	}
 	svc := NewArticlesService(repo)
-	list, errResp := svc.GetAllArticles()
+	list, errResp := svc.GetAllArticles(testTenantID)
 	require.Nil(t, errResp)
 	require.Len(t, list, 2)
 	assert.Equal(t, "SKU1", list[0].SKU)
@@ -146,7 +171,7 @@ func TestArticlesService_GetAllArticles(t *testing.T) {
 func TestArticlesService_GetArticleByID_NotFound(t *testing.T) {
 	repo := &mockArticlesRepo{byID: map[string]*database.Article{}}
 	svc := NewArticlesService(repo)
-	art, errResp := svc.GetArticleByID("99")
+	art, errResp := svc.GetArticleByID("99", testTenantID)
 	require.NotNil(t, errResp)
 	assert.True(t, errResp.Handled)
 	assert.Equal(t, responses.StatusNotFound, errResp.StatusCode)
@@ -160,7 +185,7 @@ func TestArticlesService_GetArticleByID_Found(t *testing.T) {
 		},
 	}
 	svc := NewArticlesService(repo)
-	art, errResp := svc.GetArticleByID("1")
+	art, errResp := svc.GetArticleByID("1", testTenantID)
 	require.Nil(t, errResp)
 	require.NotNil(t, art)
 	assert.Equal(t, "SKU1", art.SKU)
@@ -174,7 +199,7 @@ func TestArticlesService_CreateArticle_Success(t *testing.T) {
 		Name:         "New Article",
 		Presentation: "unit",
 	}
-	errResp := svc.CreateArticle(req)
+	errResp := svc.CreateArticle(testTenantID, req)
 	require.Nil(t, errResp)
 	require.Len(t, repo.articles, 1)
 	assert.Equal(t, "NEW-SKU", repo.articles[0].SKU)
@@ -190,7 +215,7 @@ func TestArticlesService_CreateArticle_Conflict(t *testing.T) {
 	}
 	svc := NewArticlesService(repo)
 	req := &requests.Article{SKU: "DUP", Name: "Dup", Presentation: "unit"}
-	errResp := svc.CreateArticle(req)
+	errResp := svc.CreateArticle(testTenantID, req)
 	require.NotNil(t, errResp)
 	assert.Equal(t, responses.StatusConflict, errResp.StatusCode)
 }
@@ -198,7 +223,7 @@ func TestArticlesService_CreateArticle_Conflict(t *testing.T) {
 func TestArticlesService_DeleteArticle_Success(t *testing.T) {
 	repo := &mockArticlesRepo{}
 	svc := NewArticlesService(repo)
-	errResp := svc.DeleteArticle("1")
+	errResp := svc.DeleteArticle("1", testTenantID)
 	require.Nil(t, errResp)
 }
 
@@ -211,7 +236,7 @@ func TestArticlesService_DeleteArticle_Error(t *testing.T) {
 		},
 	}
 	svc := NewArticlesService(repo)
-	errResp := svc.DeleteArticle("1")
+	errResp := svc.DeleteArticle("1", testTenantID)
 	require.NotNil(t, errResp)
 	assert.False(t, errResp.Handled)
 }
@@ -259,7 +284,7 @@ func TestArticlesService_CreateArticle_ExtendedFields(t *testing.T) {
 		DefaultLocationID: &locID,
 	}
 	// No CategoriesRepo/LocationsRepo → validation skipped
-	errResp := svc.CreateArticle(req)
+	errResp := svc.CreateArticle(testTenantID, req)
 	require.Nil(t, errResp)
 }
 
@@ -275,7 +300,7 @@ func TestArticlesService_CreateArticle_InvalidCategoryID(t *testing.T) {
 		Presentation: "unit",
 		CategoryID: &catID,
 	}
-	errResp := svc.CreateArticle(req)
+	errResp := svc.CreateArticle(testTenantID, req)
 	require.NotNil(t, errResp)
 	assert.True(t, errResp.Handled)
 	assert.Equal(t, responses.StatusBadRequest, errResp.StatusCode)
@@ -295,7 +320,7 @@ func TestArticlesService_CreateArticle_ValidCategoryID(t *testing.T) {
 		Presentation: "unit",
 		CategoryID: &catID,
 	}
-	errResp := svc.CreateArticle(req)
+	errResp := svc.CreateArticle(testTenantID, req)
 	require.Nil(t, errResp)
 }
 
@@ -311,7 +336,7 @@ func TestArticlesService_CreateArticle_InvalidDefaultLocationID(t *testing.T) {
 		Presentation:      "unit",
 		DefaultLocationID: &locID,
 	}
-	errResp := svc.CreateArticle(req)
+	errResp := svc.CreateArticle(testTenantID, req)
 	require.NotNil(t, errResp)
 	assert.True(t, errResp.Handled)
 	assert.Equal(t, responses.StatusBadRequest, errResp.StatusCode)
@@ -326,7 +351,7 @@ func TestArticlesService_CreateArticle_NegativeSafetyStock(t *testing.T) {
 		Presentation: "unit",
 		SafetyStock: -1.0,
 	}
-	errResp := svc.CreateArticle(req)
+	errResp := svc.CreateArticle(testTenantID, req)
 	require.NotNil(t, errResp)
 	assert.Equal(t, responses.StatusBadRequest, errResp.StatusCode)
 }
@@ -343,7 +368,7 @@ func TestArticlesService_EnrichArticle_WithCategory(t *testing.T) {
 			"cat-1": {ID: "cat-1", Name: "Electronics"},
 		},
 	})
-	art, _ := svc.GetArticleByID("1")
+	art, _ := svc.GetArticleByID("1", testTenantID)
 	enriched := svc.EnrichArticle(art)
 	require.NotNil(t, enriched)
 	require.NotNil(t, enriched.Category)

--- a/services/lots_service_test.go
+++ b/services/lots_service_test.go
@@ -77,6 +77,10 @@ type mockArticlesRepoForLots struct {
 	rotationStrategy string
 }
 
+// S3.5 W1 — interface bumped to include ForTenant variants. Lots service only
+// reads via GetBySku (legacy non-tenant path; lots/serials still use SKU-only FK
+// resolution until W2 retrofits child tables).
+
 func (m *mockArticlesRepoForLots) GetBySku(sku string) (*database.Article, *responses.InternalResponse) {
 	if m == nil {
 		return nil, &responses.InternalResponse{Message: "no repo"}
@@ -84,45 +88,55 @@ func (m *mockArticlesRepoForLots) GetBySku(sku string) (*database.Article, *resp
 	return &database.Article{SKU: sku, RotationStrategy: m.rotationStrategy}, nil
 }
 
+// ── tenant-scoped (no-op) ───────────────────────────────────────────────────
+
+func (m *mockArticlesRepoForLots) GetAllArticlesForTenant(_ string) ([]database.Article, *responses.InternalResponse) {
+	return nil, nil
+}
+func (m *mockArticlesRepoForLots) GetArticleByIDForTenant(_, _ string) (*database.Article, *responses.InternalResponse) {
+	return nil, nil
+}
+func (m *mockArticlesRepoForLots) GetBySkuForTenant(sku, _ string) (*database.Article, *responses.InternalResponse) {
+	return m.GetBySku(sku)
+}
+func (m *mockArticlesRepoForLots) CreateArticleForTenant(_ string, _ *requests.Article) *responses.InternalResponse {
+	return nil
+}
+func (m *mockArticlesRepoForLots) UpdateArticleForTenant(_, _ string, _ *requests.Article) (*database.Article, *responses.InternalResponse) {
+	return nil, nil
+}
+func (m *mockArticlesRepoForLots) DeleteArticleForTenant(_, _ string) *responses.InternalResponse {
+	return nil
+}
+func (m *mockArticlesRepoForLots) ImportArticlesFromExcelForTenant(_ string, _ []byte) ([]string, []string, []*responses.InternalResponse) {
+	return nil, nil, nil
+}
+func (m *mockArticlesRepoForLots) ImportArticlesFromJSONForTenant(_ string, _ []requests.ArticleImportRow) ([]string, []string, []*responses.InternalResponse) {
+	return nil, nil, nil
+}
+func (m *mockArticlesRepoForLots) ValidateImportRowsForTenant(_ string, _ []requests.ArticleImportRow) ([]responses.ArticleValidationResult, *responses.InternalResponse) {
+	return nil, nil
+}
+func (m *mockArticlesRepoForLots) ExportArticlesToExcelForTenant(_ string) ([]byte, *responses.InternalResponse) {
+	return nil, nil
+}
+func (m *mockArticlesRepoForLots) GenerateImportTemplateForTenant(_, _ string) ([]byte, *responses.InternalResponse) {
+	return nil, nil
+}
+
+// ── legacy non-tenant ───────────────────────────────────────────────────────
+
 func (m *mockArticlesRepoForLots) GetAllArticles() ([]database.Article, *responses.InternalResponse) {
 	return nil, nil
 }
-func (m *mockArticlesRepoForLots) GetArticleByID(id string) (*database.Article, *responses.InternalResponse) {
+func (m *mockArticlesRepoForLots) GetArticleByID(_ string) (*database.Article, *responses.InternalResponse) {
 	return nil, nil
 }
-func (m *mockArticlesRepoForLots) CreateArticle(data *requests.Article) *responses.InternalResponse {
-	return nil
-}
-func (m *mockArticlesRepoForLots) UpdateArticle(id string, data *requests.Article) (*database.Article, *responses.InternalResponse) {
+func (m *mockArticlesRepoForLots) GetLotsBySKU(_ string) ([]database.Lot, error) {
 	return nil, nil
 }
-func (m *mockArticlesRepoForLots) GetLotsBySKU(sku string) ([]database.Lot, error) {
+func (m *mockArticlesRepoForLots) GetSerialsBySKU(_ string) ([]database.Serial, error) {
 	return nil, nil
-}
-func (m *mockArticlesRepoForLots) GetSerialsBySKU(sku string) ([]database.Serial, error) {
-	return nil, nil
-}
-func (m *mockArticlesRepoForLots) ImportArticlesFromExcel(_ []byte) ([]string, []string, []*responses.InternalResponse) {
-	return nil, nil, nil
-}
-
-func (m *mockArticlesRepoForLots) ImportArticlesFromJSON(_ []requests.ArticleImportRow) ([]string, []string, []*responses.InternalResponse) {
-	return nil, nil, nil
-}
-func (m *mockArticlesRepoForLots) ExportArticlesToExcel() ([]byte, *responses.InternalResponse) {
-	return nil, nil
-}
-
-func (m *mockArticlesRepoForLots) GenerateImportTemplate(_ string) ([]byte, *responses.InternalResponse) {
-	return nil, nil
-}
-
-func (m *mockArticlesRepoForLots) ValidateImportRows(_ []requests.ArticleImportRow) ([]responses.ArticleValidationResult, *responses.InternalResponse) {
-	return nil, nil
-}
-
-func (m *mockArticlesRepoForLots) DeleteArticle(id string) *responses.InternalResponse {
-	return nil
 }
 
 func TestLotsService_GetAllLots(t *testing.T) {

--- a/tools/demo_seeder_farma.go
+++ b/tools/demo_seeder_farma.go
@@ -312,13 +312,19 @@ var farmaArticles = []farmaArticle{
 
 // seedArticles inserts articles. locationIDs must be location UUIDs (FK to locations.id).
 //
-// TODO(ARCH BLOCKER — S3.5): articles table has no tenant_id column (global unique on sku).
-// SeedFarma uses WHERE sku=? FirstOrCreate which finds rows from *any* tenant. Tenant 2+ will
-// silently inherit Tenant 1's articles instead of creating their own — data isolation failure.
-// Fix requires: migration adding tenant_id to articles, composite UNIQUE(tenant_id, sku),
-// model update, and all query sites. Tracked as S3.5-articles-tenant-isolation. See:
-// feedback_estock_articles_no_tenant_isolation.md
-func seedArticles(ctx context.Context, tx *gorm.DB, _ string, categoryIDs, locationIDs []string) ([]farmaArticle, error) {
+// S3.5 W1 (HR-S3-W5 C2 fix): articles is now tenant-scoped via composite UNIQUE
+// (tenant_id, sku). FirstOrCreate now scopes by (tenant_id, sku) so each tenant
+// looks up its own row instead of silently inheriting another tenant's article.
+//
+// KNOWN LIMITATION (W1): the legacy global UNIQUE(sku) is still in place to keep
+// 8+ child-table FKs satisfied; this means a SECOND tenant signing up cannot yet
+// register the same demo SKUs — the INSERT will fail. SeedFarma will surface a
+// clear duplicate-key error rather than silently leaking data. The W4 wave will
+// either prefix demo SKUs per-tenant or share a single demo catalog explicitly,
+// once child FKs migrate to composite (tenant_id, sku). For the immediate goal
+// (un-blocking signup for the second G-customer in prod), the operator can pre-
+// migrate them with a custom SKU set OR keep ENABLE_SIGNUP=false until W4 lands.
+func seedArticles(ctx context.Context, tx *gorm.DB, tenantID string, categoryIDs, locationIDs []string) ([]farmaArticle, error) {
 	active := true
 	for _, a := range farmaArticles {
 		shelfDays := a.shelfDays
@@ -328,23 +334,24 @@ func seedArticles(ctx context.Context, tx *gorm.DB, _ string, categoryIDs, locat
 		locID := locationIDs[a.locIndex%len(locationIDs)] // UUID FK — not code
 
 		article := database.Article{
-			ID:              uuid.NewString(),
-			SKU:             a.sku,
-			Name:            a.name,
-			Presentation:    a.pres,
-			UnitPrice:       &price,
-			TrackByLot:      true,
-			TrackExpiration: true,
-			RotationStrategy: "fefo",
-			MinQuantity:     &minQty,
-			IsActive:        &active,
-			CategoryID:      &catID,
+			ID:                uuid.NewString(),
+			TenantID:          tenantID,
+			SKU:               a.sku,
+			Name:              a.name,
+			Presentation:      a.pres,
+			UnitPrice:         &price,
+			TrackByLot:        true,
+			TrackExpiration:   true,
+			RotationStrategy:  "fefo",
+			MinQuantity:       &minQty,
+			IsActive:          &active,
+			CategoryID:        &catID,
 			DefaultLocationID: &locID,
-			ShelfLifeInDays: &shelfDays,
-			SafetyStock:     float64(minQty) / 2,
+			ShelfLifeInDays:   &shelfDays,
+			SafetyStock:       float64(minQty) / 2,
 		}
 		if err := tx.WithContext(ctx).
-			Where("sku = ?", a.sku).
+			Where("tenant_id = ? AND sku = ?", tenantID, a.sku).
 			FirstOrCreate(&article).Error; err != nil {
 			return nil, fmt.Errorf("article %s: %w", a.sku, err)
 		}

--- a/tools/table_configs.go
+++ b/tools/table_configs.go
@@ -1,6 +1,11 @@
 package tools
 
 // ArticlesTableConfig returns the generic table configuration for articles.
+//
+// S3.5 W1 — articles is now tenant-scoped (HR-S3-W5 C2). Use ArticlesTableConfigForTenant
+// from HTTP routes; this no-arg variant is kept for back-compat / single-tenant callers
+// and emits a wide-open SELECT (no tenant filter). It MUST NOT be used by tenant-aware
+// HTTP handlers — they will leak data across tenants.
 func ArticlesTableConfig() TableConfig {
 	return TableConfig{
 		EntityName: "artículos",
@@ -13,14 +18,37 @@ func ArticlesTableConfig() TableConfig {
 			"is_active":    "a.is_active",
 			"created_at":   "a.created_at",
 		},
-		SearchFields: []string{"a.sku", "a.name"},
-		DefaultWhere: "",
-		SelectFields: "a.id, a.sku, a.name, a.presentation, a.is_active, a.created_at",
-		CSVFields:    []string{"id", "sku", "name", "presentation", "is_active", "created_at"},
-		CSVHeaders:   []string{"ID", "SKU", "Nombre", "Presentación", "Activo", "Creado en"},
+		SearchFields:   []string{"a.sku", "a.name"},
+		DefaultWhere:   "",
+		SelectFields:   "a.id, a.sku, a.name, a.presentation, a.is_active, a.created_at",
+		CSVFields:      []string{"id", "sku", "name", "presentation", "is_active", "created_at"},
+		CSVHeaders:     []string{"ID", "SKU", "Nombre", "Presentación", "Activo", "Creado en"},
 		DefaultSortBy:  "created_at",
 		DefaultSortDir: "desc",
 	}
+}
+
+// ArticlesTableConfigForTenant returns ArticlesTableConfig with a tenant-scoped
+// DefaultWhere clause baked in. tenantID must be a UUID — the value is sanitised
+// (only [0-9a-f-] kept) before being inlined into the SQL fragment, so it is safe
+// to interpolate without a placeholder. The generic table handler doesn't expose
+// argument injection for DefaultWhere, hence the inline approach.
+func ArticlesTableConfigForTenant(tenantID string) TableConfig {
+	cfg := ArticlesTableConfig()
+	cfg.DefaultWhere = "a.tenant_id = '" + sanitizeUUID(tenantID) + "'::uuid"
+	return cfg
+}
+
+// sanitizeUUID drops any character that isn't valid in a hex/dash UUID. Defensive.
+func sanitizeUUID(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') || c == '-' {
+			out = append(out, c)
+		}
+	}
+	return string(out)
 }
 
 // LocationsTableConfig returns the generic table configuration for locations.


### PR DESCRIPTION
## Summary

- Adds `tenant_id` to the `articles` master-data table via migration `000029` and threads it through the entire repo / service / controller stack with `*ForTenant` variants. Closes the HR-S3-W5 C2 ARCH BLOCKER that's keeping `ENABLE_SIGNUP=false` in prod.
- Surgical fix to `SeedFarma.seedArticles` so it stamps `tenant_id` and scopes its `FirstOrCreate` by `(tenant_id, sku)` — no more silent inheritance of tenant 1's catalog by tenant 2.
- New regression tests in `repositories/tenant_isolation_test.go` cover GetAll isolation, per-tenant SKU lookup, and the W1 limitation that the legacy global UNIQUE on `sku` is intentionally retained as a FK target.

## Decision: FK strategy

Kept `articles_sku_key` (global UNIQUE on `sku`). 8+ child tables FK to it — dropping it would require composite-FK redesign on each, which expands scope way beyond a hotfix wave. Documented as a known limitation in the migration + `demo_seeder_farma.go`. Until that retrofit happens (separate structural sprint after W2 retrofits child tables with `tenant_id`), two tenants cannot register the same SKU.

This is a deliberate tradeoff: the **data leak** (tenant 2 silently reading tenant 1's articles) is fixed completely. The **shared SKU namespace** limitation persists and surfaces as a clean duplicate-key error rather than a silent leak. Operator workaround until W4: pre-migrate the second tenant with a custom SKU set, or keep `ENABLE_SIGNUP=false`.

## What stays for later waves

- W2 (parallel): `lots`, `inventory_lots`, `locations`, `serials` get the same treatment.
- W3: JWT `tenant_id` claim so multi-tenant signup actually wires through.
- W4: `SeedFarma` query refactor + cross-tenant integration test, plus decision on per-tenant SKU prefixing OR shared demo catalog.
- Future structural: drop `articles_sku_key` and migrate every child FK to composite `(tenant_id, sku)`.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -short -race -count=1 ./...` all green
- [x] `make sqlc` regenerates without drift
- [x] `go test -count=1 -timeout 600s -run "TestArticlesRepositorySQLC|TestArticles_TenantIsolation|TestTenantIsolation_Article" ./repositories/...` passes against testcontainers postgres:16-alpine (3 new isolation tests + existing SQLC integration tests)
- [ ] Manual smoke against dev cluster after merge: provision a fresh tenant, confirm articles list is empty until SeedFarma runs, confirm tenant 1 articles are NOT visible from tenant 2 endpoint
- [ ] Hostile review (S3.5-HR-W1) before W4 deploy

## Refs

- HR-S3-W5 C2 finding (memory: `feedback_estock_articles_no_tenant_isolation`)
- Sprint roadmap: `plans/2026-04-24-sprint-S3.5-roadmap.md`
- Branch: `s3.5-w1-articles-tenant` in worktree `backend-s35-w1`