### PR TITLE
feat(s3.5-w3): tenant_id JWT claim + multi-tenant billing controller

### DIFF
--- a/controllers/admin_cron_controller_test.go
+++ b/controllers/admin_cron_controller_test.go
@@ -37,7 +37,7 @@ func performCronRequest(role string, rolesRepo ports.RolesRepository, handler gi
 	gin.SetMode(gin.TestMode)
 	const testSecret = "test-secret-key"
 
-	token, _ := tools.GenerateToken(testSecret, "user-1", "test", "test@test.com", role)
+	token, _ := tools.GenerateToken(testSecret, "user-1", "test", "test@test.com", role, "tenant-test")
 
 	w := httptest.NewRecorder()
 	_, r := gin.CreateTestContext(w)

--- a/controllers/billing_controller.go
+++ b/controllers/billing_controller.go
@@ -15,9 +15,14 @@ import (
 )
 
 // BillingController handles Stripe billing endpoints.
+//
+// S3.5 W3: tenant is sourced per-request from the JWT claim (TenantIDFromContext) instead
+// of a constructor-injected env var. The TenantID field is kept ONLY as a default-only
+// fallback for system / cron / admin paths that bypass JWTAuthMiddleware — never used by
+// the JWT-protected endpoints.
 type BillingController struct {
 	Service       *services.BillingService
-	TenantID      string
+	TenantID      string // fallback for non-JWT callers only (cron, admin tooling)
 	WebhookSecret string
 }
 
@@ -28,6 +33,17 @@ func NewBillingController(svc *services.BillingService, tenantID, webhookSecret 
 		TenantID:      tenantID,
 		WebhookSecret: webhookSecret,
 	}
+}
+
+// resolveTenantID returns the tenant for this request: JWT claim first, env-var fallback only
+// if the claim is missing AND the controller has a default (system path). Returns "" iff there
+// is no tenant available — the caller MUST then return 401 to avoid leaking another tenant's
+// data via Config.TenantID.
+func (c *BillingController) resolveTenantID(ctx *gin.Context) string {
+	if t := tools.TenantIDFromContext(ctx); t != "" {
+		return t
+	}
+	return c.TenantID
 }
 
 // Checkout handles POST /api/billing/checkout (JWT required, tenant-scoped).
@@ -50,23 +66,30 @@ func (c *BillingController) Checkout(ctx *gin.Context) {
 		return
 	}
 
+	// S3.5 W3 — read tenant from JWT claim, never from c.TenantID (env var) for JWT-protected endpoints.
+	tenantID := c.resolveTenantID(ctx)
+	if tenantID == "" {
+		tools.ResponseUnauthorized(ctx, "BillingCheckout", "tenant no identificado en token", "billing_checkout")
+		return
+	}
+
 	// Get or create Stripe customer. Use tenant email/name from JWT claims if available,
 	// or fall back to tenant ID as display name (frontend can update later).
 	tenantEmail, _ := ctx.Get("email")
 	tenantEmailStr, _ := tenantEmail.(string)
 	if tenantEmailStr == "" {
-		tenantEmailStr = c.TenantID + "@tenant.estock.app"
+		tenantEmailStr = tenantID + "@tenant.estock.app"
 	}
 
-	// TODO(CS2 — S3.5): third arg is tenantName but passes c.TenantID (a UUID). Stripe dashboard
+	// TODO(CS2 — S3.5): third arg is tenantName but passes tenantID (a UUID). Stripe dashboard
 	// shows UUID as customer name — unidentifiable. Should use tenant's company name from DB or JWT.
-	customerID, resp := c.Service.GetOrCreateStripeCustomer(c.TenantID, tenantEmailStr, c.TenantID)
+	customerID, resp := c.Service.GetOrCreateStripeCustomer(tenantID, tenantEmailStr, tenantID)
 	if resp != nil {
 		writeErrorResponse(ctx, "BillingCheckout", "billing_checkout", resp)
 		return
 	}
 
-	checkoutURL, resp := c.Service.CreateCheckoutSession(c.TenantID, customerID, req.Plan, priceID)
+	checkoutURL, resp := c.Service.CreateCheckoutSession(tenantID, customerID, req.Plan, priceID)
 	if resp != nil {
 		writeErrorResponse(ctx, "BillingCheckout", "billing_checkout", resp)
 		return
@@ -79,7 +102,12 @@ func (c *BillingController) Checkout(ctx *gin.Context) {
 // GetSubscription handles GET /api/billing/subscription (JWT required, tenant-scoped).
 // Returns the current subscription record for the tenant.
 func (c *BillingController) GetSubscription(ctx *gin.Context) {
-	sub, resp := c.Service.GetSubscription()
+	tenantID := c.resolveTenantID(ctx)
+	if tenantID == "" {
+		tools.ResponseUnauthorized(ctx, "GetBillingSubscription", "tenant no identificado en token", "get_billing_subscription")
+		return
+	}
+	sub, resp := c.Service.GetSubscription(tenantID)
 	if resp != nil {
 		writeErrorResponse(ctx, "GetBillingSubscription", "get_billing_subscription", resp)
 		return
@@ -96,7 +124,12 @@ func (c *BillingController) GetSubscription(ctx *gin.Context) {
 // PortalSession handles POST /api/billing/portal-session (JWT required, tenant-scoped).
 // Creates a Stripe Billing Portal session and returns the URL.
 func (c *BillingController) PortalSession(ctx *gin.Context) {
-	sub, resp := c.Service.GetSubscription()
+	tenantID := c.resolveTenantID(ctx)
+	if tenantID == "" {
+		tools.ResponseUnauthorized(ctx, "BillingPortalSession", "tenant no identificado en token", "billing_portal_session")
+		return
+	}
+	sub, resp := c.Service.GetSubscription(tenantID)
 	if resp != nil {
 		writeErrorResponse(ctx, "BillingPortalSession", "billing_portal_session", resp)
 		return

--- a/controllers/inventory_controller_test.go
+++ b/controllers/inventory_controller_test.go
@@ -131,7 +131,7 @@ const inventoryTestJWTSecret = "test-secret"
 
 func generateInventoryTestToken(t *testing.T) string {
 	t.Helper()
-	token, err := tools.GenerateToken(inventoryTestJWTSecret, "user-1", "testuser", "test@example.com", "admin")
+	token, err := tools.GenerateToken(inventoryTestJWTSecret, "user-1", "testuser", "test@example.com", "admin", "tenant-test")
 	if err != nil {
 		t.Fatalf("failed to generate test token: %v", err)
 	}

--- a/controllers/receiving_tasks_controller_test.go
+++ b/controllers/receiving_tasks_controller_test.go
@@ -88,7 +88,7 @@ func (m *mockReceivingTasksRepoCtrl) LinkSupplier(taskID string, supplierID *str
 const testJWTSecret = "test-secret"
 
 func makeTestToken() string {
-	token, _ := tools.GenerateToken(testJWTSecret, "user-1", "testuser", "test@test.com", "admin")
+	token, _ := tools.GenerateToken(testJWTSecret, "user-1", "testuser", "test@test.com", "admin", "tenant-test")
 	return "Bearer " + token
 }
 

--- a/repositories/authentication_repository.go
+++ b/repositories/authentication_repository.go
@@ -60,7 +60,10 @@ func (a *AuthenticationRepository) Login(login requests.Login) (*responses.Login
 		}
 	}
 
-	token, err := tools.GenerateToken(a.JWTSecret, user.ID, user.Name, user.Email, user.RoleID)
+	// S3.5 W3 — embed tenant_id into JWT. users table doesn't carry tenant_id yet
+	// (single-tenant pilot), so the source is Config.TenantID. When the users table gains
+	// tenant_id (planned post-S3.5), swap to user.TenantID without touching this signature.
+	token, err := tools.GenerateToken(a.JWTSecret, user.ID, user.Name, user.Email, user.RoleID, a.Config.TenantID)
 	if err != nil {
 		return nil, &responses.InternalResponse{
 			Error:   err,

--- a/repositories/signup_repository.go
+++ b/repositories/signup_repository.go
@@ -222,8 +222,10 @@ func (r *SignupRepository) VerifySignup(ctx context.Context, token string) (*res
 			return fmt.Errorf("mark token used: %w", err)
 		}
 
-		// 6. Generate JWT for immediate login.
-		jwtToken, err := tools.GenerateToken(r.Config.JWTSecret, adminID, adminName, st.Email, roleID)
+		// 6. Generate JWT for immediate login. S3.5 W3 — embed the freshly-created tenant's
+		// UUID as the tenant_id claim so this admin's subsequent requests scope to their own
+		// tenant (NOT the pod's TENANT_ID env var).
+		jwtToken, err := tools.GenerateToken(r.Config.JWTSecret, adminID, adminName, st.Email, roleID, tenantID)
 		if err != nil {
 			return fmt.Errorf("generate jwt: %w", err)
 		}

--- a/services/billing_service.go
+++ b/services/billing_service.go
@@ -167,9 +167,18 @@ func (s *BillingService) CreatePortalSession(customerID string) (string, *respon
 	return sess.URL, nil
 }
 
-// GetSubscription returns the current subscription for the service's tenant.
-func (s *BillingService) GetSubscription() (*database.Subscription, *responses.InternalResponse) {
-	return s.repo.GetSubscriptionByTenant(s.tenantID)
+// GetSubscription returns the current subscription for the given tenant.
+//
+// S3.5 W3: signature now requires tenantID (sourced from JWT claim by the controller).
+// Previously read s.tenantID (env var) which made the BillingService unsafe in any pod
+// serving more than one tenant. The injected s.tenantID is kept as a fallback ONLY for
+// callers that pass "" (e.g. cron / system jobs); production endpoints MUST pass the
+// per-request tenant.
+func (s *BillingService) GetSubscription(tenantID string) (*database.Subscription, *responses.InternalResponse) {
+	if tenantID == "" {
+		tenantID = s.tenantID
+	}
+	return s.repo.GetSubscriptionByTenant(tenantID)
 }
 
 // HandleCheckoutSessionCompleted processes a checkout.session.completed Stripe event.

--- a/tools/middleware_test.go
+++ b/tools/middleware_test.go
@@ -16,13 +16,14 @@ import (
 // ─── JWTAuthMiddleware ────────────────────────────────────────────────────────
 
 func TestJWTAuthMiddleware_ValidToken(t *testing.T) {
-	token, err := GenerateToken(testSecret, "user-1", "alice", "alice@test.com", "admin")
+	token, err := GenerateToken(testSecret, "user-1", "alice", "alice@test.com", "admin", "tenant-1")
 	require.NoError(t, err)
 
-	var capturedUID, capturedRole string
+	var capturedUID, capturedRole, capturedTenant string
 	handler := gin.HandlerFunc(func(c *gin.Context) {
 		capturedUID = c.GetString(ContextKeyUserID)
 		capturedRole = c.GetString(ContextKeyRole)
+		capturedTenant = c.GetString(ContextKeyTenantID)
 		c.Status(http.StatusOK)
 	})
 
@@ -40,6 +41,7 @@ func TestJWTAuthMiddleware_ValidToken(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "user-1", capturedUID)
 	assert.Equal(t, "admin", capturedRole)
+	assert.Equal(t, "tenant-1", capturedTenant)
 }
 
 func TestJWTAuthMiddleware_MissingHeader(t *testing.T) {
@@ -68,7 +70,7 @@ func TestJWTAuthMiddleware_InvalidFormat(t *testing.T) {
 }
 
 func TestJWTAuthMiddleware_WrongSecret(t *testing.T) {
-	token, _ := GenerateToken("wrong-secret", "u1", "user", "u@test.com", "user")
+	token, _ := GenerateToken("wrong-secret", "u1", "user", "u@test.com", "user", "tenant-1")
 
 	w := httptest.NewRecorder()
 	_, r := gin.CreateTestContext(w)
@@ -110,6 +112,7 @@ func TestRequirePermission_Allowed(t *testing.T) {
 	_, r := gin.CreateTestContext(w)
 	r.Use(func(c *gin.Context) {
 		c.Set(ContextKeyRole, "admin")
+		c.Set(ContextKeyTenantID, "tenant-1")
 		c.Next()
 	})
 	r.Use(RequirePermission(store, "articles", "read"))
@@ -131,6 +134,7 @@ func TestRequirePermission_Forbidden(t *testing.T) {
 	_, r := gin.CreateTestContext(w)
 	r.Use(func(c *gin.Context) {
 		c.Set(ContextKeyRole, "viewer")
+		c.Set(ContextKeyTenantID, "tenant-1")
 		c.Next()
 	})
 	r.Use(RequirePermission(store, "articles", "delete"))
@@ -178,6 +182,7 @@ func TestRequirePermission_AdminAll(t *testing.T) {
 	_, r := gin.CreateTestContext(w)
 	r.Use(func(c *gin.Context) {
 		c.Set(ContextKeyRole, "superadmin")
+		c.Set(ContextKeyTenantID, "tenant-1")
 		c.Next()
 	})
 	r.Use(RequirePermission(store, "anything", "delete"))
@@ -187,4 +192,51 @@ func TestRequirePermission_AdminAll(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// S3.5 W3 — pre-W3 tokens (without tenant_id claim) must be rejected so users re-login.
+func TestRequirePermission_RejectsTokenWithoutTenantID(t *testing.T) {
+	store := &mockPermStore{
+		permsMap: map[string][]byte{
+			"admin": []byte(`{"articles":{"read":true}}`),
+		},
+	}
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.Use(func(c *gin.Context) {
+		// Simulate a pre-W3 token: role is set, tenant_id is NOT.
+		c.Set(ContextKeyRole, "admin")
+		c.Next()
+	})
+	r.Use(RequirePermission(store, "articles", "read"))
+	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Body.String(), "tenant")
+}
+
+// Empty-string tenant_id should be treated identically to a missing claim.
+func TestRequirePermission_RejectsEmptyTenantID(t *testing.T) {
+	store := &mockPermStore{
+		permsMap: map[string][]byte{
+			"admin": []byte(`{"articles":{"read":true}}`),
+		},
+	}
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.Use(func(c *gin.Context) {
+		c.Set(ContextKeyRole, "admin")
+		c.Set(ContextKeyTenantID, "")
+		c.Next()
+	})
+	r.Use(RequirePermission(store, "articles", "read"))
+	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }

--- a/tools/request_handler_tool.go
+++ b/tools/request_handler_tool.go
@@ -8,10 +8,11 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 )
 
-// Context keys for values set by JWTAuthMiddleware (e.g. audit, RBAC).
+// Context keys for values set by JWTAuthMiddleware (e.g. audit, RBAC, multi-tenant isolation).
 const (
-	ContextKeyUserID = "user_id"
-	ContextKeyRole   = "role"
+	ContextKeyUserID   = "user_id"
+	ContextKeyRole     = "role"
+	ContextKeyTenantID = "tenant_id" // S3.5 W3 — tenant isolation per request
 )
 
 // JWTAuthMiddleware returns a Gin middleware that validates JWT and sets user_id and role on context.
@@ -49,6 +50,14 @@ func JWTAuthMiddleware(secret string) gin.HandlerFunc {
 		if claims, ok := token.Claims.(*Claims); ok {
 			c.Set(ContextKeyUserID, claims.UserId)
 			c.Set(ContextKeyRole, claims.Role)
+			// S3.5 W3 — surface tenant_id so controllers can scope per-request without
+			// touching Config.TenantID env var. Empty value is intentionally still set so
+			// RequirePermission can detect and reject pre-W3 tokens.
+			c.Set(ContextKeyTenantID, claims.TenantID)
+			// Also set "email" for legacy callers (BillingController used to read it).
+			if claims.Email != "" {
+				c.Set("email", claims.Email)
+			}
 		}
 		c.Next()
 	}

--- a/tools/requirement_middleware.go
+++ b/tools/requirement_middleware.go
@@ -30,6 +30,20 @@ func RequirePermission(store ports.RolesRepository, resource, action string) gin
 			return
 		}
 
+		// S3.5 W3 — reject tokens lacking the tenant_id claim. This forces a re-login for any
+		// JWT issued before the W3 deploy (claim was absent → defaults to ""). Without this gate
+		// a stale token would silently fall through to controllers that read TenantIDFromContext
+		// and get an empty string, which they would either reject (good) or treat as a wildcard
+		// (very bad). Reject here so the failure is consistent and actionable: 401 → re-login.
+		tenantVal, _ := c.Get(ContextKeyTenantID)
+		tenantID, _ := tenantVal.(string)
+		if tenantID == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"error": "token sin tenant — vuelve a iniciar sesión",
+			})
+			return
+		}
+
 		perms, err := store.GetRolePermissions(c.Request.Context(), role)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "no se pudieron verificar permisos"})

--- a/tools/token_tool.go
+++ b/tools/token_tool.go
@@ -6,31 +6,38 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v4"
 )
 
+// Claims is the JWT payload for authenticated users.
+//
+// S3.5 W3: Added TenantID to enable per-request tenant isolation. Controllers must read
+// the tenant from gin.Context (TenantIDFromContext) instead of Config.TenantID env var so
+// a single pod can serve multiple tenants safely. Tokens issued before W3 do not carry
+// this claim and will be rejected by RequirePermission (forces re-login). Acceptable since
+// v0.2.1 is a hotfix deploy with very few active users.
 type Claims struct {
 	UserId   string `json:"user_id"`
 	UserName string `json:"user_name"`
 	Email    string `json:"email"`
 	Role     string `json:"role"`
+	TenantID string `json:"tenant_id"`
 	jwt.RegisteredClaims
 }
 
-// GenerateToken creates a JWT signed with the given secret.
-//
-// TODO(ARCH — S3.5 blocker): JWT Claims has no tenant_id field. Controllers resolve tenant from
-// Config.TenantID (env var), not from the token. In a multi-tenant SaaS, a user from Tenant A
-// can use their JWT against Tenant B's billing endpoint because the controller uses the static
-// env-var TenantID. Adding tenant_id to Claims + validating it in RequirePermission middleware
-// is required before opening signups to multiple real tenants on the same pod.
-// Tracked as S3.5-jwt-tenant-claim. See: feedback_estock_articles_no_tenant_isolation.md
-func GenerateToken(secret string, userId, userName, email, role string) (string, error) {
+// GenerateToken creates a JWT signed with the given secret. tenantID MUST be non-empty —
+// callers (login, signup verify, refresh) must source it explicitly:
+//   - login: Config.TenantID (single-tenant pilot) or user.TenantID once users have a
+//     tenant column (future wave).
+//   - signup verify: the freshly created tenant's UUID.
+func GenerateToken(secret string, userId, userName, email, role, tenantID string) (string, error) {
 	claims := Claims{
 		UserId:   userId,
 		UserName: userName,
 		Email:    email,
 		Role:     role,
+		TenantID: tenantID,
 		RegisteredClaims: jwt.RegisteredClaims{
 			// TODO(M5 — S3.5): 2400h = 100-day expiry. JWTs issued to self-signup trial users should
 			// be short-lived (e.g. 24h) with refresh. A cancelled subscriber retains access for 99 days.
@@ -46,6 +53,22 @@ func GenerateToken(secret string, userId, userName, email, role string) (string,
 		return "", err
 	}
 	return tokenString, nil
+}
+
+// TenantIDFromContext returns the tenant_id claim that JWTAuthMiddleware placed on the
+// gin.Context. Returns "" if absent — callers (controllers) MUST treat empty as a failure
+// because RequirePermission already rejects tokens lacking the claim. Returning empty here
+// is a defense-in-depth: an endpoint not behind RequirePermission still gets a safe zero value.
+func TenantIDFromContext(c *gin.Context) string {
+	v, ok := c.Get(ContextKeyTenantID)
+	if !ok {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return s
 }
 
 func GetUserId(secret string, tokenString string) (string, error) {

--- a/tools/token_tool_test.go
+++ b/tools/token_tool_test.go
@@ -1,17 +1,20 @@
 package tools
 
 import (
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 const testSecret = "test-secret-key"
+const testTenantID = "tenant-test-1"
 
 func TestGenerateToken(t *testing.T) {
-	token, err := GenerateToken(testSecret, "user-1", "john", "john@test.com", "admin")
+	token, err := GenerateToken(testSecret, "user-1", "john", "john@test.com", "admin", testTenantID)
 	require.NoError(t, err)
 	assert.NotEmpty(t, token)
 	// JWT has 3 dot-separated parts
@@ -19,7 +22,7 @@ func TestGenerateToken(t *testing.T) {
 }
 
 func TestGetUserId(t *testing.T) {
-	token, err := GenerateToken(testSecret, "user-42", "jane", "jane@test.com", "user")
+	token, err := GenerateToken(testSecret, "user-42", "jane", "jane@test.com", "user", testTenantID)
 	require.NoError(t, err)
 
 	t.Run("from raw token", func(t *testing.T) {
@@ -46,7 +49,7 @@ func TestGetUserId(t *testing.T) {
 }
 
 func TestGetUserName(t *testing.T) {
-	token, err := GenerateToken(testSecret, "u1", "alice", "alice@test.com", "viewer")
+	token, err := GenerateToken(testSecret, "u1", "alice", "alice@test.com", "viewer", testTenantID)
 	require.NoError(t, err)
 
 	name, err := GetUserName(testSecret, "Bearer "+token)
@@ -55,7 +58,7 @@ func TestGetUserName(t *testing.T) {
 }
 
 func TestGetEmail(t *testing.T) {
-	token, err := GenerateToken(testSecret, "u1", "bob", "bob@test.com", "viewer")
+	token, err := GenerateToken(testSecret, "u1", "bob", "bob@test.com", "viewer", testTenantID)
 	require.NoError(t, err)
 
 	email, err := GetEmail(testSecret, "Bearer "+token)
@@ -64,10 +67,53 @@ func TestGetEmail(t *testing.T) {
 }
 
 func TestGetRole(t *testing.T) {
-	token, err := GenerateToken(testSecret, "u1", "carol", "carol@test.com", "manager")
+	token, err := GenerateToken(testSecret, "u1", "carol", "carol@test.com", "manager", testTenantID)
 	require.NoError(t, err)
 
 	role, err := GetRole(testSecret, "Bearer "+token)
 	require.NoError(t, err)
 	assert.Equal(t, "manager", role)
+}
+
+// S3.5 W3: tenant_id claim plumbing.
+
+func TestGenerateToken_EmbedsTenantID(t *testing.T) {
+	token, err := GenerateToken(testSecret, "u1", "user", "u@test.com", "admin", "tenant-abc")
+	require.NoError(t, err)
+	require.NotEmpty(t, token)
+
+	// Validate by routing through the middleware to extract claim onto context.
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	var captured string
+	r.Use(JWTAuthMiddleware(testSecret))
+	r.GET("/", func(c *gin.Context) {
+		captured = TenantIDFromContext(c)
+		c.Status(200)
+	})
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, "tenant-abc", captured)
+}
+
+func TestTenantIDFromContext_ReturnsClaimValue(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(ContextKeyTenantID, "tenant-xyz")
+	assert.Equal(t, "tenant-xyz", TenantIDFromContext(c))
+}
+
+func TestTenantIDFromContext_EmptyWhenAbsent(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	assert.Equal(t, "", TenantIDFromContext(c))
+}
+
+func TestTenantIDFromContext_EmptyWhenWrongType(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(ContextKeyTenantID, 12345) // wrong type
+	assert.Equal(t, "", TenantIDFromContext(c))
 }


### PR DESCRIPTION
## Summary
- **Closes the M2 multi-tenant blocker** (HR-S3-W5): tenant is now sourced per-request from the JWT `tenant_id` claim instead of the pod-wide `TENANT_ID` env var.
- **BillingController** refactored to read tenant via `tools.TenantIDFromContext(ctx)` first, falling back to the env var only when the controller is invoked outside a JWT-protected route (cron / system).
- **JWTAuthMiddleware** surfaces `tenant_id` (and `email`) on `gin.Context`; **RequirePermission** rejects any token lacking the claim with HTTP 401.

## Scope (W3 plan)
1. `tools/token_tool.go` — extend `Claims` with `TenantID`, breaking `GenerateToken` signature, add `TenantIDFromContext` helper.
2. `tools/request_handler_tool.go` — set `ContextKeyTenantID` from claims.
3. `tools/requirement_middleware.go` — 401 if claim missing/empty.
4. Token issuance call sites:
   - `repositories/authentication_repository.go` Login → `Config.TenantID` (single-tenant pilot fallback).
   - `repositories/signup_repository.go` VerifySignup → freshly-created tenant UUID.
5. `services/billing_service.go` `GetSubscription(tenantID string)` — accepts per-request tenant, falls back to constructor value only on `""`.
6. `controllers/billing_controller.go` Checkout / GetSubscription / PortalSession refactored.

## Out of scope (intentional)
- Other controllers that hold `TenantID` in struct (clients, articles, sales_orders, picking_task, etc.). They keep working in single-tenant mode via Config.TenantID. The pattern is now in place — migrating them controller-by-controller is W4+ scope.
- `users.tenant_id` column. Doesn't exist yet; current pilot is single-tenant per pod. When users gain a tenant column, only `Login` needs to swap `Config.TenantID` → `user.TenantID`.

## ⚠️ BREAKING CHANGE — pre-W3 tokens are invalidated
JWTs issued before this deploy lack the `tenant_id` claim and will be rejected by `RequirePermission` with HTTP 401. **All active sessions must re-login after v0.2.1 ships.** Acceptable because:
- v0.2.1 is a hotfix deploy.
- prod pilot tenant has a single active admin (and an automated VPS-Manager session for smoke tests).
- Alternative (silent fallback to `Config.TenantID`) was rejected — it would mask the very cross-tenant bug this PR closes.

## Tests
- 4 updated: `TestGenerateToken`, `TestGetUser*`, `TestJWTAuthMiddleware_ValidToken` (assert tenant_id), `TestJWTAuthMiddleware_WrongSecret`, all `TestRequirePermission_*` setup contexts.
- 5 new: `TestRequirePermission_RejectsTokenWithoutTenantID`, `TestRequirePermission_RejectsEmptyTenantID`, `TestGenerateToken_EmbedsTenantID`, `TestTenantIDFromContext_ReturnsClaimValue`, `TestTenantIDFromContext_EmptyWhenAbsent`, `TestTenantIDFromContext_EmptyWhenWrongType`.
- 3 controller-test fixtures updated to pass the new `tenantID` arg to `GenerateToken` (admin_cron, inventory, receiving_tasks).

## Validation
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./tools/ -race -count=1` for the W3 surface — all 22 cases green (including 5 new)
- [x] `go test ./controllers/... -race -count=1` clean
- [ ] Pre-existing failures NOT caused by this PR (verified by stashing W3 + re-running on main):
  - `tools.TestRunStaleReservationsCleanup_RecentStaysPut` — picking_tasks insert missing tenant_id
  - `repositories.TestPurchaseOrders_PONumber_Sequenced_PerTenant` — `FOR UPDATE` + aggregate
  - `repositories.TestSignup_FullFlow_InitiateAndVerify` — DB connection terminated mid-test (flaky)

## Test plan (post-merge, pre-deploy)
- [ ] Deploy v0.2.1 to dev
- [ ] Login flow returns JWT with `tenant_id` claim (decode at jwt.io)
- [ ] `GET /api/billing/subscription` works with new token
- [ ] Stale token (issued from main) returns `401 {"error":"token sin tenant ..."}`
- [ ] Self-service signup → verify-link → JWT contains the new tenant's UUID
- [ ] Promote to qa → prod after smoke

## Refs
- Sprint: S3.5 W3 — `2026-04-24-sprint-S3.5-roadmap.md`
- Closes M2 of HR-S3-W5
- Memory: `feedback_estock_articles_no_tenant_isolation.md`