### PR TITLE
feat(s3.5-w4): SeedFarma per-tenant SKU prefix + multi-tenant test

### DIFF
--- a/repositories/seedfarma_multitenant_integration_test.go
+++ b/repositories/seedfarma_multitenant_integration_test.go
@@ -1,0 +1,128 @@
+// Multi-tenant integration test for tools.SeedFarma — S3.5 W4.
+//
+// Requires Docker (testcontainers). Skipped automatically in `-short` mode by
+// setupGORMTestDB. The unit-level helper coverage (tenantPrefix / prefixedSKU
+// / prefixedTaskID) lives in tools/demo_seeder_farma_multitenant_test.go and
+// runs without Docker.
+//
+// What this test PROVES end-to-end against real Postgres + every migration:
+//
+//  1. SeedFarma can be invoked for two distinct tenants in the same DB
+//     without hitting articles_sku_key, receiving_tasks_task_id_key or
+//     picking_tasks_task_id_key UNIQUE violations (the symptom that
+//     motivated the W4 fix — see feedback_estock_articles_no_tenant_isolation.md).
+//  2. Each tenant ends up with the same N-card demo dataset, but those
+//     datasets are isolated rows (no shared article ids).
+//  3. Cross-tenant SKU lookup returns NotFound (regression guard for the
+//     SeedFarma data-leak that the prefixing scheme is designed to prevent).
+//  4. demo_data_seeds carries one row per tenant (idempotency key is
+//     (tenant_id, seed_name), set by migration 000023).
+
+package repositories
+
+import (
+	"context"
+	"testing"
+
+	"github.com/eflowcr/eSTOCK_backend/models/database"
+	"github.com/eflowcr/eSTOCK_backend/models/responses"
+	"github.com/eflowcr/eSTOCK_backend/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// seedTenantRow inserts a row in tenants(id, …) so demo_data_seeds.tenant_id
+// (FK → tenants.id) is satisfied. The default tenant from migration 000023 is
+// already present; this is for the second tenant only.
+func seedTenantRow(t *testing.T, db *gorm.DB, tenantID, slug, email string) {
+	t.Helper()
+	require.NoError(t, db.Exec(`
+		INSERT INTO tenants (id, name, slug, email, status, trial_ends_at, is_active)
+		VALUES (?::uuid, ?, ?, ?, 'trial', NOW() + interval '14 days', true)
+		ON CONFLICT (id) DO NOTHING`,
+		tenantID, slug, slug, email).Error)
+}
+
+// TestSeedFarma_MultiTenantIsolation is the end-to-end W4 regression guard.
+func TestSeedFarma_MultiTenantIsolation(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	const (
+		tenantA = "00000000-0000-0000-0000-000000000001" // default tenant from 000023
+		tenantB = "22222222-2222-2222-2222-222222222222"
+	)
+
+	// Tenant A is already present in the tenants table (default seed); only B
+	// needs a row before SeedFarma touches FK-bound demo_data_seeds.
+	seedTenantRow(t, db, tenantB, "tenantb-seedtest", "b@seedtest.com")
+
+	// ── Seed both tenants ────────────────────────────────────────────────────
+	require.NoError(t, tools.SeedFarma(ctx, db, tenantA), "seed for tenant A")
+	require.NoError(t, tools.SeedFarma(ctx, db, tenantB), "seed for tenant B (must NOT collide on global UNIQUE indexes)")
+
+	// ── Per-tenant article counts ────────────────────────────────────────────
+	repo := &ArticlesRepository{DB: db}
+
+	rowsA, errA := repo.GetAllArticlesForTenant(tenantA)
+	require.Nil(t, errA)
+	require.Len(t, rowsA, 50, "tenant A should see exactly its own 50 demo articles")
+
+	rowsB, errB := repo.GetAllArticlesForTenant(tenantB)
+	require.Nil(t, errB)
+	require.Len(t, rowsB, 50, "tenant B should see exactly its own 50 demo articles (separate dataset)")
+
+	// Every row returned by GetAllArticlesForTenant(X) must have TenantID == X.
+	for _, r := range rowsA {
+		assert.Equal(t, tenantA, r.TenantID, "tenant A leaks tenant B row %s", r.ID)
+	}
+	for _, r := range rowsB {
+		assert.Equal(t, tenantB, r.TenantID, "tenant B leaks tenant A row %s", r.ID)
+	}
+
+	// Article IDs are disjoint — proves no FirstOrCreate-induced row sharing.
+	idSetA := make(map[string]struct{}, len(rowsA))
+	for _, r := range rowsA {
+		idSetA[r.ID] = struct{}{}
+	}
+	for _, r := range rowsB {
+		if _, leaked := idSetA[r.ID]; leaked {
+			t.Fatalf("tenant B inherited tenant A's article id %s — multi-tenant data leak", r.ID)
+		}
+	}
+
+	// ── Cross-tenant SKU lookup must return NotFound ─────────────────────────
+	// Pick one SKU from tenant A's catalog and try to fetch it from tenant B.
+	someSkuA := rowsA[0].SKU
+	gotCross, errCross := repo.GetBySkuForTenant(someSkuA, tenantB)
+	require.NotNil(t, errCross, "tenant B must not see tenant A's prefixed SKU %s", someSkuA)
+	assert.Equal(t, responses.StatusNotFound, errCross.StatusCode)
+	assert.Nil(t, gotCross)
+
+	// Inverse direction.
+	someSkuB := rowsB[0].SKU
+	gotCross2, errCross2 := repo.GetBySkuForTenant(someSkuB, tenantA)
+	require.NotNil(t, errCross2, "tenant A must not see tenant B's prefixed SKU %s", someSkuB)
+	assert.Equal(t, responses.StatusNotFound, errCross2.StatusCode)
+	assert.Nil(t, gotCross2)
+
+	// ── demo_data_seeds tracks both tenants ──────────────────────────────────
+	var seedCount int64
+	require.NoError(t, db.Model(&database.DemoDataSeed{}).
+		Where("seed_name = ?", tools.FarmaSeedName).Count(&seedCount).Error)
+	assert.EqualValues(t, 2, seedCount, "demo_data_seeds should carry exactly one row per tenant")
+
+	// ── Re-running SeedFarma for either tenant is a no-op (idempotency) ──────
+	require.NoError(t, tools.SeedFarma(ctx, db, tenantA), "second seed call for tenant A must be idempotent")
+	require.NoError(t, tools.SeedFarma(ctx, db, tenantB), "second seed call for tenant B must be idempotent")
+
+	// Counts unchanged after re-run.
+	var countA, countB int64
+	require.NoError(t, db.Model(&database.Article{}).Where("tenant_id = ?", tenantA).Count(&countA).Error)
+	require.NoError(t, db.Model(&database.Article{}).Where("tenant_id = ?", tenantB).Count(&countB).Error)
+	assert.EqualValues(t, 50, countA, "re-run of SeedFarma for tenant A must NOT duplicate articles")
+	assert.EqualValues(t, 50, countB, "re-run of SeedFarma for tenant B must NOT duplicate articles")
+}

--- a/repositories/signup_integration_test.go
+++ b/repositories/signup_integration_test.go
@@ -275,11 +275,13 @@ func TestSeedFarma_Idempotent(t *testing.T) {
 	err2 := tools.SeedFarma(ctx, db, tenantID)
 	require.NoError(t, err2, "second SeedFarma should be idempotent (no error)")
 
-	// Verify articles count is not doubled.
+	// Verify articles count is not doubled. S3.5 W4: SKUs are now tenant-prefixed
+	// ("T00000000-RX-001"), so we filter on the prefixed pattern for this tenant
+	// instead of bare "RX-%".
 	var count int64
 	require.NoError(t, db.Model(&database.Article{}).
-		Where("sku LIKE 'RX-%'").Count(&count).Error)
-	assert.EqualValues(t, 50, count, "exactly 50 farma articles should exist")
+		Where("tenant_id = ? AND sku LIKE '%RX-%'", tenantID).Count(&count).Error)
+	assert.EqualValues(t, 50, count, "exactly 50 farma articles should exist for tenant")
 }
 
 // ─── Test: Rate-limit middleware integration (route-level) ───────────────────

--- a/tools/demo_seeder_farma.go
+++ b/tools/demo_seeder_farma.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/eflowcr/eSTOCK_backend/models/database"
@@ -14,8 +15,61 @@ import (
 
 const FarmaSeedName = "farma-50skus"
 
+// tenantPrefix builds a short, deterministic prefix from a tenant UUID so demo
+// data inserted for two different tenants does not collide on still-global
+// UNIQUE constraints (e.g. articles_sku_key, receiving_tasks_task_id_key,
+// picking_tasks_task_id_key, sales/purchase order numbers).
+//
+// S3.5 W4 (HR-S3-W5 C2 follow-up): articles got tenant_id in W1 but the legacy
+// global UNIQUE(sku) is intentionally retained because 8+ child tables FK on
+// articles.sku without tenant_id (see migration 000029). Without prefixing,
+// tenant 2 signing up + auto-running SeedFarma would hit a UNIQUE violation on
+// "PARA-500" and end up with an empty WMS. The prefix scopes all demo
+// identifiers per tenant; user-visible NAMES are left clean ("Paracetamol
+// 500mg…") so the UI still reads naturally.
+//
+// Format: "T<first 8 hex chars of tenantID, uppercase, no dashes>-".
+// Examples:
+//
+//	tenantPrefix("00000000-0000-0000-0000-000000000001") -> "T00000000-"
+//	tenantPrefix("a1b2c3d4-...")                          -> "TA1B2C3D4-"
+//
+// Empty / malformed tenantID falls back to the literal "TANON-" so the seeder
+// still produces a valid (albeit collision-prone) prefix instead of panicking.
+func tenantPrefix(tenantID string) string {
+	clean := strings.ReplaceAll(tenantID, "-", "")
+	if len(clean) < 8 {
+		return "TANON-"
+	}
+	return "T" + strings.ToUpper(clean[:8]) + "-"
+}
+
+// prefixedSKU applies tenantPrefix to a base SKU. Centralised so the rest of
+// the seeder reads naturally and any future change to the prefix scheme lives
+// in one place.
+func prefixedSKU(tenantID, baseSKU string) string {
+	return tenantPrefix(tenantID) + baseSKU
+}
+
+// prefixedTaskID applies the tenant prefix to demo task identifiers
+// (RT-DEMO-0001, PK-DEMO-0001, IN-DEMO-0001, ORD-DEMO-0001, etc.).
+// receiving_tasks.task_id and picking_tasks.task_id still carry global UNIQUE
+// indexes from migration 000002, so a second tenant re-running the seeder
+// would otherwise collide.
+func prefixedTaskID(tenantID, baseID string) string {
+	return tenantPrefix(tenantID) + baseID
+}
+
 // SeedFarma seeds ~50 pharmaceutical SKUs plus tasks and movements for the given tenant.
 // It is idempotent: if demo_data_seeds already has a row for (tenantID, farma-50skus), it returns nil immediately.
+//
+// S3.5 W4 — multi-tenant safe: every demo identifier that lives behind a still-global
+// UNIQUE constraint (articles.sku, receiving_tasks.task_id, picking_tasks.task_id) is
+// stamped with a per-tenant prefix derived from the first 8 hex chars of tenantID.
+// Two tenants signing up via SaaS self-service therefore each get their own clean
+// demo dataset instead of the second tenant hitting a duplicate-key error or
+// silently inheriting tenant 1's rows. See tenantPrefix and migration 000029 for
+// the full structural-debt context.
 func SeedFarma(ctx context.Context, db *gorm.DB, tenantID string) error {
 	// ── Idempotency check ────────────────────────────────────────────────────────
 	var existing database.DemoDataSeed
@@ -106,10 +160,14 @@ func SeedFarma(ctx context.Context, db *gorm.DB, tenantID string) error {
 // locationIDs are used for FK references in articles.default_location_id.
 // locationCodes are used for inventory.location and task item location fields
 // (which store codes, not IDs — known S2 debt, see feedback_estock_location_storage_inconsistency).
-// TODO(M3 — S3.5): tenantID is dropped (blank identifier _). Locations have no tenant_id column
-// (global table) so this is currently correct. But once articles and inventory_movements gain
-// tenant_id columns (see C2/ARCH BLOCKER), this function signature should accept and use tenantID.
-func seedLocations(ctx context.Context, tx *gorm.DB, _ string) (ids []string, codes []string, err error) {
+//
+// S3.5 W4: locations now have tenant_id (migration 000032) with composite
+// UNIQUE (tenant_id, location_code), so two tenants can both have "RX-A1"
+// without collision. We DO NOT prefix location_code — it stays human-readable
+// per tenant and the per-tenant unique index handles isolation. We DO scope
+// the FirstOrCreate by tenant so a second tenant gets its own row instead of
+// adopting tenant 1's location id.
+func seedLocations(ctx context.Context, tx *gorm.DB, tenantID string) (ids []string, codes []string, err error) {
 	locs := []struct {
 		code string
 		zone string
@@ -131,15 +189,17 @@ func seedLocations(ctx context.Context, tx *gorm.DB, _ string) (ids []string, co
 		desc := l.desc
 		loc := database.Location{
 			ID:           uuid.NewString(),
+			TenantID:     tenantID,
 			LocationCode: l.code,
 			Description:  &desc,
 			Zone:         &l.zone,
 			Type:         "shelf",
 			IsActive:     true,
 		}
-		// FirstOrCreate so idempotent if locations already exist from a prior partial run.
+		// FirstOrCreate scoped by (tenant_id, location_code) so each tenant
+		// owns its own location rows. Idempotent for partial-run recovery too.
 		if err := tx.WithContext(ctx).
-			Where("location_code = ?", l.code).
+			Where("tenant_id = ? AND location_code = ?", tenantID, l.code).
 			FirstOrCreate(&loc).Error; err != nil {
 			return nil, nil, fmt.Errorf("location %s: %w", l.code, err)
 		}
@@ -316,17 +376,23 @@ var farmaArticles = []farmaArticle{
 // (tenant_id, sku). FirstOrCreate now scopes by (tenant_id, sku) so each tenant
 // looks up its own row instead of silently inheriting another tenant's article.
 //
-// KNOWN LIMITATION (W1): the legacy global UNIQUE(sku) is still in place to keep
-// 8+ child-table FKs satisfied; this means a SECOND tenant signing up cannot yet
-// register the same demo SKUs — the INSERT will fail. SeedFarma will surface a
-// clear duplicate-key error rather than silently leaking data. The W4 wave will
-// either prefix demo SKUs per-tenant or share a single demo catalog explicitly,
-// once child FKs migrate to composite (tenant_id, sku). For the immediate goal
-// (un-blocking signup for the second G-customer in prod), the operator can pre-
-// migrate them with a custom SKU set OR keep ENABLE_SIGNUP=false until W4 lands.
+// S3.5 W4: SKUs are now prefixed with the tenant's short hash (see
+// tenantPrefix) before insert. The legacy global UNIQUE(sku) — retained because
+// 8+ child tables FK on articles.sku without tenant_id (see migration 000029) —
+// would otherwise reject the second tenant's "PARA-500" / "RX-001" / etc. The
+// prefix uniqueifies the SKU value across tenants while keeping the per-tenant
+// composite (tenant_id, sku) intact. User-visible NAMES ("Paracetamol 500mg…")
+// are kept clean so the catalog UI reads naturally.
+//
+// Returns the list of articles AS WRITTEN (with prefixed SKUs) so downstream
+// seed steps (inventory, tasks, movements) reference the SAME prefixed SKUs.
 func seedArticles(ctx context.Context, tx *gorm.DB, tenantID string, categoryIDs, locationIDs []string) ([]farmaArticle, error) {
 	active := true
-	for _, a := range farmaArticles {
+	written := make([]farmaArticle, 0, len(farmaArticles))
+	for _, base := range farmaArticles {
+		a := base                            // copy so we can mutate the SKU per-tenant
+		a.sku = prefixedSKU(tenantID, base.sku)
+
 		shelfDays := a.shelfDays
 		minQty := a.minQty
 		price := a.unitPrice
@@ -355,8 +421,9 @@ func seedArticles(ctx context.Context, tx *gorm.DB, tenantID string, categoryIDs
 			FirstOrCreate(&article).Error; err != nil {
 			return nil, fmt.Errorf("article %s: %w", a.sku, err)
 		}
+		written = append(written, a)
 	}
-	return farmaArticles, nil
+	return written, nil
 }
 
 // ─── inventory ───────────────────────────────────────────────────────────────
@@ -443,8 +510,13 @@ func seedReceivingTasks(ctx context.Context, tx *gorm.DB, tenantID string, artic
 		}
 
 		supplierID := supplierIDs[i%len(supplierIDs)]
-		taskID := fmt.Sprintf("RT-DEMO-%04d", i+1)
-		inboundNum := fmt.Sprintf("IN-DEMO-%04d", i+1)
+		// S3.5 W4: receiving_tasks.task_id still has a global UNIQUE index
+		// (receiving_tasks_task_id_key from migration 000002), so demo task IDs
+		// must be tenant-prefixed to avoid collision when a second tenant runs
+		// SeedFarma. inbound_number's UNIQUE was made per-tenant in 000019 but
+		// we prefix it too for visual consistency in the UI.
+		taskID := prefixedTaskID(tenantID, fmt.Sprintf("RT-DEMO-%04d", i+1))
+		inboundNum := prefixedTaskID(tenantID, fmt.Sprintf("IN-DEMO-%04d", i+1))
 
 		task := database.ReceivingTask{
 			ID:          uuid.NewString(),
@@ -524,8 +596,11 @@ func seedPickingTasks(ctx context.Context, tx *gorm.DB, tenantID string, article
 		}
 
 		customerID := customerIDs[i%len(customerIDs)]
-		taskID := fmt.Sprintf("PK-DEMO-%04d", i+1)
-		orderNum := fmt.Sprintf("ORD-DEMO-%04d", i+1)
+		// S3.5 W4: picking_tasks.task_id has a global UNIQUE index
+		// (picking_tasks_task_id_key from migration 000002). Tenant-prefix to
+		// keep demo IDs unique across tenants.
+		taskID := prefixedTaskID(tenantID, fmt.Sprintf("PK-DEMO-%04d", i+1))
+		orderNum := prefixedTaskID(tenantID, fmt.Sprintf("ORD-DEMO-%04d", i+1))
 
 		task := database.PickingTask{
 			ID:          uuid.NewString(),

--- a/tools/demo_seeder_farma_multitenant_test.go
+++ b/tools/demo_seeder_farma_multitenant_test.go
@@ -1,0 +1,118 @@
+// Package-level multi-tenant integration test for SeedFarma.
+//
+// S3.5 W4 (HR-S3-W5 C2 follow-up): proves that SeedFarma can be invoked for
+// two distinct tenants without colliding on the still-global UNIQUE
+// constraints (articles_sku_key, receiving_tasks_task_id_key,
+// picking_tasks_task_id_key) and that each tenant ends up with its own
+// isolated demo dataset (no cross-tenant data leak).
+//
+// The test piggybacks on the tenantPrefix helper rather than spinning up
+// testcontainers, because:
+//
+//   - The full integration path is already covered by
+//     repositories/signup_integration_test.go (TestSeedFarma_Idempotent +
+//     TestSignup_FullFlow_InitiateAndVerify), which exercise the real DB.
+//   - This package-level test belongs next to the helper it validates and
+//     runs in `-short` mode (no Docker), so CI gets fast regression coverage
+//     of the prefix scheme.
+//
+// For end-to-end multi-tenant behaviour against a real Postgres + all
+// migrations, see TestSeedFarma_MultiTenantIsolation in
+// repositories/signup_integration_test.go (added by the same wave).
+
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTenantPrefix_DeterministicAndScoped checks that the prefix is stable for
+// a given tenant UUID and differs across tenants — the property that prevents
+// SKU collisions when two tenants run SeedFarma against the still-global
+// UNIQUE(sku) index.
+func TestTenantPrefix_DeterministicAndScoped(t *testing.T) {
+	const (
+		tenantA = "00000000-0000-0000-0000-000000000001"
+		tenantB = "abcdef12-3456-7890-abcd-ef1234567890"
+	)
+
+	pA1 := tenantPrefix(tenantA)
+	pA2 := tenantPrefix(tenantA)
+	pB := tenantPrefix(tenantB)
+
+	if pA1 != pA2 {
+		t.Fatalf("tenantPrefix not deterministic for tenant A: %q vs %q", pA1, pA2)
+	}
+	if pA1 == pB {
+		t.Fatalf("tenantPrefix collision between distinct tenants: A=%q B=%q", pA1, pB)
+	}
+	if !strings.HasPrefix(pA1, "T") || !strings.HasSuffix(pA1, "-") {
+		t.Fatalf("tenantPrefix shape unexpected: %q", pA1)
+	}
+	if got, want := pA1, "T00000000-"; got != want {
+		t.Fatalf("default tenant prefix want %q got %q", want, got)
+	}
+	if got, want := pB, "TABCDEF12-"; got != want {
+		t.Fatalf("tenant B prefix want %q got %q", want, got)
+	}
+}
+
+// TestTenantPrefix_FallbackOnMalformed makes sure malformed/empty tenant IDs
+// don't panic; they get a sentinel prefix instead. Real callers should never
+// hit this branch (signup creates a UUID) but the seeder is defensive.
+func TestTenantPrefix_FallbackOnMalformed(t *testing.T) {
+	cases := []string{"", "abc", "----", "x"}
+	for _, in := range cases {
+		got := tenantPrefix(in)
+		if got != "TANON-" {
+			t.Errorf("tenantPrefix(%q) = %q, want %q", in, got, "TANON-")
+		}
+	}
+}
+
+// TestPrefixedSKU_AppliesPrefix is a sanity check on the helper used in the
+// articles seed loop.
+func TestPrefixedSKU_AppliesPrefix(t *testing.T) {
+	const tenant = "11111111-2222-3333-4444-555555555555"
+	got := prefixedSKU(tenant, "RX-001")
+	want := "T11111111-RX-001"
+	if got != want {
+		t.Fatalf("prefixedSKU = %q, want %q", got, want)
+	}
+}
+
+// TestPrefixedSKU_DistinctAcrossTenants is the core regression guard for the
+// W4 fix: feeding the same base SKU to two different tenants must yield two
+// distinct prefixed SKUs so the global UNIQUE(sku) index is satisfied.
+func TestPrefixedSKU_DistinctAcrossTenants(t *testing.T) {
+	const (
+		tenantA = "00000000-0000-0000-0000-000000000001"
+		tenantB = "ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb"
+		baseSKU = "PARA-500"
+	)
+	skuA := prefixedSKU(tenantA, baseSKU)
+	skuB := prefixedSKU(tenantB, baseSKU)
+	if skuA == skuB {
+		t.Fatalf("two tenants should produce distinct SKUs from same base; got both = %q", skuA)
+	}
+	if !strings.HasSuffix(skuA, baseSKU) || !strings.HasSuffix(skuB, baseSKU) {
+		t.Fatalf("prefixed SKUs lost their base: A=%q B=%q", skuA, skuB)
+	}
+}
+
+// TestPrefixedTaskID_DistinctAcrossTenants — same regression guard, but for the
+// still-global UNIQUE indexes on receiving_tasks.task_id and
+// picking_tasks.task_id.
+func TestPrefixedTaskID_DistinctAcrossTenants(t *testing.T) {
+	const (
+		tenantA = "00000000-0000-0000-0000-000000000001"
+		tenantB = "ffffffff-eeee-dddd-cccc-bbbbbbbbbbbb"
+		baseID  = "RT-DEMO-0001"
+	)
+	idA := prefixedTaskID(tenantA, baseID)
+	idB := prefixedTaskID(tenantB, baseID)
+	if idA == idB {
+		t.Fatalf("two tenants should produce distinct task IDs; got both = %q", idA)
+	}
+}


### PR DESCRIPTION
## Summary

- **Strategy: Option A — per-tenant SKU prefix** for SeedFarma demo data so two tenants signing up via SaaS self-service get isolated demo datasets without colliding on still-global UNIQUE constraints.
- New `tenantPrefix(tenantID) -> "T<8hex>-"` helper applied to **articles.sku**, **receiving_tasks.task_id**, **picking_tasks.task_id**, plus inbound/order numbers. User-visible NAMES stay clean (\"Paracetamol 500mg…\") so the catalog UI still reads naturally.
- `seedLocations` now stamps `tenant_id` and scopes `FirstOrCreate` by `(tenant_id, location_code)` — fixes a latent bug introduced when migration 000032 added composite UNIQUE on locations.
- Added a real Postgres + testcontainers integration test (`TestSeedFarma_MultiTenantIsolation`) that seeds two tenants in the same DB and asserts: no UNIQUE violations, disjoint article rows, cross-tenant SKU lookup → NotFound, `demo_data_seeds` carries one row per tenant, idempotent re-runs do not duplicate.
- Added unit-level coverage of the prefix scheme (`tools/demo_seeder_farma_multitenant_test.go`) that runs in `-short` mode.

## Why this exists

S3.5 W1 added `tenant_id` to articles via composite `UNIQUE(tenant_id, sku)` but had to retain the legacy `articles_sku_key` (global UNIQUE on sku) because 8+ child tables FK on `articles.sku` without `tenant_id` (see migration 000029 + `feedback_estock_articles_no_tenant_isolation.md`). That left a real-world hole: a second tenant's SeedFarma run would hit `articles_sku_key` on PARA-500 / RX-001 / etc.

The structural fix (composite FKs across all 8 child tables) is deferred to a future sprint. **W4 unblocks SaaS self-service multi-tenant signup right now** by giving each tenant a unique SKU namespace.

## Backwards compat

Tenant 1 in prod already has un-prefixed SKUs from a prior seed run. SeedFarma's idempotency guard (`demo_data_seeds` UNIQUE(tenant_id, seed_name) from migration 000023) skips re-seeding that tenant, so existing data is untouched. Only NEW seeding events get prefixed SKUs.

## Files changed (4)

- `tools/demo_seeder_farma.go` — prefix helpers + applied across articles, locations, receiving/picking tasks
- `tools/demo_seeder_farma_multitenant_test.go` (new, unit, runs in `-short`)
- `repositories/seedfarma_multitenant_integration_test.go` (new, testcontainers)
- `repositories/signup_integration_test.go` — `TestSeedFarma_Idempotent` updated to filter by tenant_id + LIKE '%RX-%' for prefixed SKUs

## Validation

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./... -short -race -count=1\` — all pass
- [x] New \`TestSeedFarma_MultiTenantIsolation\` compiles + skips correctly under \`-short\`

## Test plan

- [ ] Run integration tests with Docker: \`go test -v -race -count=1 -run TestSeedFarma_MultiTenantIsolation ./repositories/\` (requires Docker, not run in CI \`-short\`)
- [ ] In dev with `ENABLE_SIGNUP=true`, complete SaaS signup for two tenants back-to-back; verify both land on their own populated WMS with disjoint article catalogs
- [ ] Spot-check: tenant 2's articles UI shows SKUs like \`T<hex>-RX-001\` but names stay \"Paracetamol 500mg Tab 20s\"

## Refs

- [plans/2026-04-24-sprint-S3.5-roadmap.md](.) (W4 section)
- \`feedback_estock_articles_no_tenant_isolation.md\` (root cause)
- migration 000029 (FK retention rationale)