### PR TITLE
fix(s3.5-w5.5): wire JWT tenant claim end-to-end (HR-S3.5 C1+C2+C3)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -98,49 +98,47 @@ func main() {
 			return nil
 		}
 
-		// lotNotifyFn notifies all admin users for expiring lots.
-		// TODO S3: per-tenant cron iteration when multi-tenant signup is live.
-		// Current behavior: queries admins globally across all tenants (safe for single-tenant S1/S2).
-		var lotNotifyFn func(eventType, title, body string) error
+		// S3.5 W5.5 (HR-S3.5 C3): notify only the admins of the tenant whose lot is
+		// expiring. Pre-W5.5 the closure queried admins globally, so a tenant 2 expiring
+		// lot would email tenant 1 admins. The cron helper now passes tenantID per call.
+		var lotNotifyFn func(tenantID, eventType, title, body string) error
 		if notifSvc != nil {
-			lotNotifyFn = func(eventType, title, body string) error {
+			lotNotifyFn = func(tenantID, eventType, title, body string) error {
 				var adminIDs []string
 				if err := db.Table("users").
 					Joins("JOIN roles ON users.role_id = roles.id").
-					Where("LOWER(roles.name) = 'admin' AND users.is_active = true AND users.deleted_at IS NULL").
+					Where("users.tenant_id = ? AND LOWER(roles.name) = 'admin' AND users.is_active = true AND users.deleted_at IS NULL", tenantID).
 					Pluck("users.id", &adminIDs).Error; err != nil {
-					log.Warn().Err(err).Msg("cron: query admins for lot expiration notify failed")
+					log.Warn().Err(err).Str("tenant_id", tenantID).Msg("cron: query admins for lot expiration notify failed")
 					return nil
 				}
 				ctx := context.Background()
 				for _, uid := range adminIDs {
 					if err := notifSvc.Send(ctx, uid, eventType, title, body, "lot", ""); err != nil {
-						log.Warn().Err(err).Str("user_id", uid).Msg("cron: lot expiration notify send failed")
+						log.Warn().Err(err).Str("tenant_id", tenantID).Str("user_id", uid).Msg("cron: lot expiration notify send failed")
 					}
 				}
 				return nil
 			}
 		}
 
-		// HR1-M5: lowStockNotifyFn notifies all admin users for unresolved low-stock alerts.
-		// TODO S3: per-tenant cron iteration when multi-tenant signup is live.
-		// Current behavior: queries admins globally across all tenants (safe for single-tenant S1/S2).
-		var lowStockNotifyFn func(sku, message string) error
+		// S3.5 W5.5 (HR-S3.5 C3): same per-tenant scoping for low-stock alerts.
+		var lowStockNotifyFn func(tenantID, sku, message string) error
 		if notifSvc != nil {
-			lowStockNotifyFn = func(sku, message string) error {
+			lowStockNotifyFn = func(tenantID, sku, message string) error {
 				var adminIDs []string
 				if err := db.Table("users").
 					Joins("JOIN roles ON users.role_id = roles.id").
-					Where("LOWER(roles.name) = 'admin' AND users.is_active = true AND users.deleted_at IS NULL").
+					Where("users.tenant_id = ? AND LOWER(roles.name) = 'admin' AND users.is_active = true AND users.deleted_at IS NULL", tenantID).
 					Pluck("users.id", &adminIDs).Error; err != nil {
-					log.Warn().Err(err).Msg("cron: query admins for low_stock notify failed")
+					log.Warn().Err(err).Str("tenant_id", tenantID).Msg("cron: query admins for low_stock notify failed")
 					return nil
 				}
 				title := "Alerta: stock bajo — " + sku
 				ctx := context.Background()
 				for _, uid := range adminIDs {
 					if err := notifSvc.Send(ctx, uid, "low_stock", title, message, "stock_alert", sku); err != nil {
-						log.Warn().Err(err).Str("sku", sku).Str("user_id", uid).Msg("cron: low_stock notify send failed")
+						log.Warn().Err(err).Str("tenant_id", tenantID).Str("sku", sku).Str("user_id", uid).Msg("cron: low_stock notify send failed")
 					}
 				}
 				return nil

--- a/controllers/adjustments_controller.go
+++ b/controllers/adjustments_controller.go
@@ -31,7 +31,7 @@ func (c *AdjustmentsController) WithTenantID(tenantID string) *AdjustmentsContro
 }
 
 func (c *AdjustmentsController) GetAllAdjustments(ctx *gin.Context) {
-	adjustments, response := c.Service.ListByTenant(c.TenantID)
+	adjustments, response := c.Service.ListByTenant(c.resolveTenantID(ctx))
 
 	if response != nil {
 		writeErrorResponse(ctx, "GetAllAdjustments", "get_all_adjustments", response)
@@ -105,7 +105,7 @@ func (c *AdjustmentsController) CreateAdjustment(ctx *gin.Context) {
 		return
 	}
 
-	created, response := c.Service.CreateAdjustment(userId, c.TenantID, adjustment)
+	created, response := c.Service.CreateAdjustment(userId, c.resolveTenantID(ctx), adjustment)
 	if response != nil {
 		writeErrorResponse(ctx, "CreateAdjustment", "create_adjustment", response)
 		return
@@ -127,7 +127,7 @@ func (c *AdjustmentsController) CreateAdjustment(ctx *gin.Context) {
 }
 
 func (c *AdjustmentsController) ExportAdjustmentsToExcel(ctx *gin.Context) {
-	data, response := c.Service.ExportAdjustmentsToExcel(c.TenantID)
+	data, response := c.Service.ExportAdjustmentsToExcel(c.resolveTenantID(ctx))
 	if response != nil {
 		writeErrorResponse(ctx, "ExportAdjustmentsToExcel", "export_adjustments_to_excel", response)
 		return
@@ -140,4 +140,10 @@ func (c *AdjustmentsController) ExportAdjustmentsToExcel(ctx *gin.Context) {
 
 	ctx.Header("Content-Disposition", "attachment; filename=adjustments.xlsx")
 	ctx.Data(200, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", data)
+}
+
+// resolveTenantID — S3.5 W5.5 (HR-S3.5 C1): JWT-first, env fallback only.
+// The TenantID field stays as a non-JWT fallback (cron/admin/test paths only).
+func (c *AdjustmentsController) resolveTenantID(ctx *gin.Context) string {
+	return tools.ResolveTenantID(ctx, c.TenantID)
 }

--- a/controllers/articles_controller.go
+++ b/controllers/articles_controller.go
@@ -12,13 +12,15 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// ArticlesController — S3.5 W1: now carries TenantID injected from Config (env-injected
-// per-deployment). HR-S3-W5 C2 fix; future M2 will source tenantID from JWT claim instead.
+// ArticlesController — S3.5 W5.5 (HR-S3.5 C1): tenant is sourced per-request from the
+// JWT claim (TenantIDFromContext). The TenantID field is kept ONLY as a fallback for
+// system / cron / admin paths that bypass JWTAuthMiddleware and for tests that
+// pre-construct the controller with a default tenant.
 type ArticlesController struct {
 	Service       services.ArticlesService
 	AuditService  *services.AuditService
 	UserPrefsRepo ports.UserPreferencesRepository
-	TenantID      string
+	TenantID      string // fallback for non-JWT callers only
 }
 
 func NewArticlesController(service services.ArticlesService, auditSvc *services.AuditService, userPrefsRepo ports.UserPreferencesRepository, tenantID string) *ArticlesController {
@@ -30,8 +32,14 @@ func NewArticlesController(service services.ArticlesService, auditSvc *services.
 	}
 }
 
+// resolveTenantID returns the JWT tenant claim, falling back to the env-injected default.
+// Returns "" iff neither is set — the caller MUST then 401 to avoid cross-tenant leaks.
+func (c *ArticlesController) resolveTenantID(ctx *gin.Context) string {
+	return tools.ResolveTenantID(ctx, c.TenantID)
+}
+
 func (c *ArticlesController) GetAllArticles(ctx *gin.Context) {
-	articles, response := c.Service.GetAllArticles(c.TenantID)
+	articles, response := c.Service.GetAllArticles(c.resolveTenantID(ctx))
 
 	if response != nil {
 		writeErrorResponse(ctx, "GetAllArticles", "get_all_articles", response)
@@ -52,7 +60,7 @@ func (c *ArticlesController) GetArticleByID(ctx *gin.Context) {
 		return
 	}
 
-	article, response := c.Service.GetArticleByID(articleID, c.TenantID)
+	article, response := c.Service.GetArticleByID(articleID, c.resolveTenantID(ctx))
 	if response != nil {
 		writeErrorResponse(ctx, "GetArticleByID", "get_article_by_id", response)
 		return
@@ -71,7 +79,7 @@ func (c *ArticlesController) GetBySku(ctx *gin.Context) {
 	if !ok {
 		return
 	}
-	article, response := c.Service.GetBySku(sku, c.TenantID)
+	article, response := c.Service.GetBySku(sku, c.resolveTenantID(ctx))
 	if response != nil {
 		writeErrorResponse(ctx, "GetBySku", "get_by_sku", response)
 		return
@@ -96,7 +104,7 @@ func (c *ArticlesController) CreateArticle(ctx *gin.Context) {
 		return
 	}
 
-	response := c.Service.CreateArticle(c.TenantID, &articleRequest)
+	response := c.Service.CreateArticle(c.resolveTenantID(ctx), &articleRequest)
 	if response != nil {
 		writeErrorResponse(ctx, "CreateArticle", "create_article", response)
 		return
@@ -120,7 +128,7 @@ func (c *ArticlesController) UpdateArticle(ctx *gin.Context) {
 		return
 	}
 
-	article, _ := c.Service.GetArticleByID(id, c.TenantID)
+	article, _ := c.Service.GetArticleByID(id, c.resolveTenantID(ctx))
 	var req requests.Article
 	if err := ctx.ShouldBindJSON(&req); err != nil {
 		tools.ResponseBadRequest(ctx, "UpdateArticle", "Carga útil no válida", "update_article")
@@ -131,7 +139,7 @@ func (c *ArticlesController) UpdateArticle(ctx *gin.Context) {
 		return
 	}
 
-	updatedArticle, errResp, warnings := c.Service.UpdateArticle(id, c.TenantID, &req)
+	updatedArticle, errResp, warnings := c.Service.UpdateArticle(id, c.resolveTenantID(ctx), &req)
 	if errResp != nil {
 		writeErrorResponse(ctx, "UpdateArticle", "update_article", errResp)
 		return
@@ -174,7 +182,7 @@ func (c *ArticlesController) ImportArticlesFromExcel(ctx *gin.Context) {
 		return
 	}
 
-	importedArticles, skippedArticles, errorResponses := c.Service.ImportArticlesFromExcel(c.TenantID, fileBytes)
+	importedArticles, skippedArticles, errorResponses := c.Service.ImportArticlesFromExcel(c.resolveTenantID(ctx), fileBytes)
 	if len(importedArticles) == 0 && len(skippedArticles) == 0 && len(errorResponses) > 0 {
 		resp := errorResponses[0]
 		writeErrorResponse(ctx, "ImportArticlesFromExcel", "import_articles_from_excel", resp)
@@ -201,7 +209,7 @@ func (c *ArticlesController) ValidateImportRows(ctx *gin.Context) {
 		tools.ResponseBadRequest(ctx, "ValidateImportRows", "No se proporcionaron filas", "validate_import_rows")
 		return
 	}
-	results, resp := c.Service.ValidateImportRows(c.TenantID, rows)
+	results, resp := c.Service.ValidateImportRows(c.resolveTenantID(ctx), rows)
 	if resp != nil {
 		writeErrorResponse(ctx, "ValidateImportRows", "validate_import_rows", resp)
 		return
@@ -222,7 +230,7 @@ func (c *ArticlesController) ImportArticlesFromJSON(ctx *gin.Context) {
 		return
 	}
 
-	imported, skipped, errorResponses := c.Service.ImportArticlesFromJSON(c.TenantID, rows)
+	imported, skipped, errorResponses := c.Service.ImportArticlesFromJSON(c.resolveTenantID(ctx), rows)
 	tools.ResponseOK(ctx, "ImportArticlesFromJSON", "Importación completada", "import_articles_from_json", gin.H{
 		"successful":   len(imported),
 		"skipped":      len(skipped),
@@ -234,7 +242,7 @@ func (c *ArticlesController) ImportArticlesFromJSON(ctx *gin.Context) {
 }
 
 func (c *ArticlesController) ExportArticlesToExcel(ctx *gin.Context) {
-	fileBytes, response := c.Service.ExportArticlesToExcel(c.TenantID)
+	fileBytes, response := c.Service.ExportArticlesToExcel(c.resolveTenantID(ctx))
 	if response != nil {
 		writeErrorResponse(ctx, "ExportArticlesToExcel", "export_articles_to_excel", response)
 		return
@@ -254,7 +262,7 @@ func (c *ArticlesController) DownloadImportTemplate(ctx *gin.Context) {
 		}
 	}
 
-	fileBytes, response := c.Service.GenerateImportTemplate(c.TenantID, lang)
+	fileBytes, response := c.Service.GenerateImportTemplate(c.resolveTenantID(ctx), lang)
 	if response != nil {
 		writeErrorResponse(ctx, "DownloadImportTemplate", "download_articles_import_template", response)
 		return
@@ -271,8 +279,8 @@ func (c *ArticlesController) DeleteArticle(ctx *gin.Context) {
 		return
 	}
 
-	article, _ := c.Service.GetArticleByID(id, c.TenantID)
-	resp := c.Service.DeleteArticle(id, c.TenantID)
+	article, _ := c.Service.GetArticleByID(id, c.resolveTenantID(ctx))
+	resp := c.Service.DeleteArticle(id, c.resolveTenantID(ctx))
 	if resp != nil {
 		writeErrorResponse(ctx, "DeleteArticle", "delete_article", resp)
 		return

--- a/controllers/articles_controller_test.go
+++ b/controllers/articles_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/eflowcr/eSTOCK_backend/models/requests"
 	"github.com/eflowcr/eSTOCK_backend/models/responses"
 	"github.com/eflowcr/eSTOCK_backend/services"
+	"github.com/eflowcr/eSTOCK_backend/tools"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -123,6 +124,34 @@ func performRequest(handler gin.HandlerFunc, method, path string, body interface
 	c.Request = req
 	if params != nil {
 		c.Params = params
+	}
+	handler(c)
+	return w
+}
+
+// performRequestWithTenant is like performRequest but seeds the JWT-derived tenant
+// context the way JWTAuthMiddleware would. S3.5 W5.5 (HR-S3.5 C1/C2): controllers
+// resolve tenant from gin.Context, so unit tests must inject it explicitly.
+func performRequestWithTenant(handler gin.HandlerFunc, method, path string, body interface{}, params gin.Params, tenantID string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	var reqBody *bytes.Buffer
+	if body != nil {
+		b, _ := json.Marshal(body)
+		reqBody = bytes.NewBuffer(b)
+	} else {
+		reqBody = bytes.NewBuffer(nil)
+	}
+	req, _ := http.NewRequest(method, path, reqBody)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	c.Request = req
+	if params != nil {
+		c.Params = params
+	}
+	if tenantID != "" {
+		c.Set(tools.ContextKeyTenantID, tenantID)
 	}
 	handler(c)
 	return w

--- a/controllers/backorders_controller.go
+++ b/controllers/backorders_controller.go
@@ -42,7 +42,7 @@ func (c *BackordersController) List(ctx *gin.Context) {
 		}
 	}
 
-	result, resp := c.Service.List(c.TenantID, status, soID, page, limit)
+	result, resp := c.Service.List(c.resolveTenantID(ctx), status, soID, page, limit)
 	if resp != nil {
 		writeErrorResponse(ctx, "ListBackorders", "list_backorders", resp)
 		return
@@ -57,7 +57,7 @@ func (c *BackordersController) GetByID(ctx *gin.Context) {
 		return
 	}
 
-	bo, resp := c.Service.GetByID(id, c.TenantID)
+	bo, resp := c.Service.GetByID(id, c.resolveTenantID(ctx))
 	if resp != nil {
 		writeErrorResponse(ctx, "GetBackorder", "get_backorder", resp)
 		return
@@ -75,10 +75,16 @@ func (c *BackordersController) Fulfill(ctx *gin.Context) {
 
 	userID := ctx.GetString(tools.ContextKeyUserID)
 
-	result, resp := c.Service.Fulfill(id, c.TenantID, userID)
+	result, resp := c.Service.Fulfill(id, c.resolveTenantID(ctx), userID)
 	if resp != nil {
 		writeErrorResponse(ctx, "FulfillBackorder", "fulfill_backorder", resp)
 		return
 	}
 	tools.ResponseCreated(ctx, "FulfillBackorder", "Tarea de picking creada para fulfilliar backorder", "fulfill_backorder", result, false, "")
+}
+
+// resolveTenantID — S3.5 W5.5 (HR-S3.5 C1): JWT-first, env fallback only.
+// The TenantID field stays as a non-JWT fallback (cron/admin/test paths only).
+func (c *BackordersController) resolveTenantID(ctx *gin.Context) string {
+	return tools.ResolveTenantID(ctx, c.TenantID)
 }

--- a/controllers/categories_controller.go
+++ b/controllers/categories_controller.go
@@ -44,7 +44,7 @@ func (c *CategoriesController) List(ctx *gin.Context) {
 		}
 	}
 
-	categories, resp := c.Service.ListByTenantFiltered(c.TenantID, isActive, search, limit, offset)
+	categories, resp := c.Service.ListByTenantFiltered(c.resolveTenantID(ctx), isActive, search, limit, offset)
 	if resp != nil {
 		writeErrorResponse(ctx, "ListCategories", "list_categories", resp)
 		return
@@ -53,7 +53,7 @@ func (c *CategoriesController) List(ctx *gin.Context) {
 }
 
 func (c *CategoriesController) GetTree(ctx *gin.Context) {
-	tree, resp := c.Service.GetTree(c.TenantID)
+	tree, resp := c.Service.GetTree(c.resolveTenantID(ctx))
 	if resp != nil {
 		writeErrorResponse(ctx, "GetCategoriesTree", "get_categories_tree", resp)
 		return
@@ -85,7 +85,7 @@ func (c *CategoriesController) Create(ctx *gin.Context) {
 		return
 	}
 
-	cat, resp := c.Service.Create(c.TenantID, &req)
+	cat, resp := c.Service.Create(c.resolveTenantID(ctx), &req)
 	if resp != nil {
 		writeErrorResponse(ctx, "CreateCategory", "create_category", resp)
 		return
@@ -108,7 +108,7 @@ func (c *CategoriesController) Update(ctx *gin.Context) {
 		return
 	}
 
-	cat, resp := c.Service.Update(id, &req, c.TenantID)
+	cat, resp := c.Service.Update(id, &req, c.resolveTenantID(ctx))
 	if resp != nil {
 		writeErrorResponse(ctx, "UpdateCategory", "update_category", resp)
 		return
@@ -126,4 +126,10 @@ func (c *CategoriesController) SoftDelete(ctx *gin.Context) {
 		return
 	}
 	tools.ResponseOK(ctx, "DeleteCategory", "Categoría eliminada", "delete_category", nil, false, "")
+}
+
+// resolveTenantID — S3.5 W5.5 (HR-S3.5 C1): JWT-first, env fallback only.
+// The TenantID field stays as a non-JWT fallback (cron/admin/test paths only).
+func (c *CategoriesController) resolveTenantID(ctx *gin.Context) string {
+	return tools.ResolveTenantID(ctx, c.TenantID)
 }

--- a/controllers/clients_controller.go
+++ b/controllers/clients_controller.go
@@ -31,7 +31,7 @@ func (c *ClientsController) List(ctx *gin.Context) {
 		search = &s
 	}
 
-	clients, resp := c.Service.List(c.TenantID, clientType, isActive, search)
+	clients, resp := c.Service.List(c.resolveTenantID(ctx), clientType, isActive, search)
 	if resp != nil {
 		writeErrorResponse(ctx, "ListClients", "list_clients", resp)
 		return
@@ -45,7 +45,7 @@ func (c *ClientsController) GetByID(ctx *gin.Context) {
 		return
 	}
 	// HR1-M3: use tenant-scoped lookup to prevent cross-tenant client enumeration.
-	client, resp := c.Service.GetByIDForTenant(id, c.TenantID)
+	client, resp := c.Service.GetByIDForTenant(id, c.resolveTenantID(ctx))
 	if resp != nil {
 		writeErrorResponse(ctx, "GetClientByID", "get_client", resp)
 		return
@@ -70,7 +70,7 @@ func (c *ClientsController) Create(ctx *gin.Context) {
 		createdBy = &uid
 	}
 
-	client, resp := c.Service.Create(c.TenantID, &req, createdBy)
+	client, resp := c.Service.Create(c.resolveTenantID(ctx), &req, createdBy)
 	if resp != nil {
 		writeErrorResponse(ctx, "CreateClient", "create_client", resp)
 		return
@@ -94,7 +94,7 @@ func (c *ClientsController) Update(ctx *gin.Context) {
 	}
 
 	// HR1-M3: tenantID is already threaded through Update.
-	client, resp := c.Service.Update(id, &req, c.TenantID)
+	client, resp := c.Service.Update(id, &req, c.resolveTenantID(ctx))
 	if resp != nil {
 		writeErrorResponse(ctx, "UpdateClient", "update_client", resp)
 		return
@@ -108,9 +108,15 @@ func (c *ClientsController) SoftDelete(ctx *gin.Context) {
 		return
 	}
 	// HR1-M3: pass tenantID to prevent cross-tenant soft-delete.
-	if resp := c.Service.SoftDelete(id, c.TenantID); resp != nil {
+	if resp := c.Service.SoftDelete(id, c.resolveTenantID(ctx)); resp != nil {
 		writeErrorResponse(ctx, "DeleteClient", "delete_client", resp)
 		return
 	}
 	tools.ResponseOK(ctx, "DeleteClient", "Cliente eliminado", "delete_client", nil, false, "")
+}
+
+// resolveTenantID — S3.5 W5.5 (HR-S3.5 C1): JWT-first, env fallback only.
+// The TenantID field stays as a non-JWT fallback (cron/admin/test paths only).
+func (c *ClientsController) resolveTenantID(ctx *gin.Context) string {
+	return tools.ResolveTenantID(ctx, c.TenantID)
 }

--- a/controllers/delivery_notes_controller.go
+++ b/controllers/delivery_notes_controller.go
@@ -50,7 +50,7 @@ func (c *DeliveryNotesController) List(ctx *gin.Context) {
 		}
 	}
 
-	result, resp := c.Service.List(c.TenantID, customerID, soNumber, from, to, page, limit)
+	result, resp := c.Service.List(c.resolveTenantID(ctx), customerID, soNumber, from, to, page, limit)
 	if resp != nil {
 		writeErrorResponse(ctx, "ListDeliveryNotes", "list_delivery_notes", resp)
 		return
@@ -65,7 +65,7 @@ func (c *DeliveryNotesController) GetByID(ctx *gin.Context) {
 		return
 	}
 
-	dn, resp := c.Service.GetByID(id, c.TenantID)
+	dn, resp := c.Service.GetByID(id, c.resolveTenantID(ctx))
 	if resp != nil {
 		writeErrorResponse(ctx, "GetDeliveryNote", "get_delivery_note", resp)
 		return
@@ -82,7 +82,7 @@ func (c *DeliveryNotesController) DownloadPDF(ctx *gin.Context) {
 	}
 
 	// Verify DN exists and belongs to tenant.
-	dnNumber, resp := c.Service.GetDNNumber(id, c.TenantID)
+	dnNumber, resp := c.Service.GetDNNumber(id, c.resolveTenantID(ctx))
 	if resp != nil {
 		writeErrorResponse(ctx, "DownloadDNPDF", "download_dn_pdf", resp)
 		return
@@ -102,4 +102,10 @@ func (c *DeliveryNotesController) DownloadPDF(ctx *gin.Context) {
 	ctx.Header("Content-Disposition", "attachment; filename=\""+filename+"\"")
 	ctx.Header("Content-Type", "application/pdf")
 	ctx.File(pdfPath)
+}
+
+// resolveTenantID — S3.5 W5.5 (HR-S3.5 C1): JWT-first, env fallback only.
+// The TenantID field stays as a non-JWT fallback (cron/admin/test paths only).
+func (c *DeliveryNotesController) resolveTenantID(ctx *gin.Context) string {
+	return tools.ResolveTenantID(ctx, c.TenantID)
 }

--- a/controllers/locations_controller.go
+++ b/controllers/locations_controller.go
@@ -26,7 +26,7 @@ func NewLocationsController(service services.LocationsService, tenantID string) 
 }
 
 func (c *LocationsController) GetAllLocations(ctx *gin.Context) {
-	locations, response := c.Service.GetAllLocations(c.TenantID)
+	locations, response := c.Service.GetAllLocations(c.resolveTenantID(ctx))
 
 	if response != nil {
 		writeErrorResponse(ctx, "GetAllLocations", "get_all_locations", response)
@@ -46,7 +46,7 @@ func (c *LocationsController) GetLocationByID(ctx *gin.Context) {
 	if !ok {
 		return
 	}
-	location, response := c.Service.GetLocationByID(c.TenantID, id)
+	location, response := c.Service.GetLocationByID(c.resolveTenantID(ctx), id)
 
 	if response != nil {
 		writeErrorResponse(ctx, "GetLocationByID", "get_location_by_id", response)
@@ -73,7 +73,7 @@ func (c *LocationsController) CreateLocation(ctx *gin.Context) {
 		return
 	}
 
-	resp := c.Service.CreateLocation(c.TenantID, &body)
+	resp := c.Service.CreateLocation(c.resolveTenantID(ctx), &body)
 
 	if resp != nil {
 		writeErrorResponse(ctx, "CreateLocation", "create_location", resp)
@@ -95,7 +95,7 @@ func (c *LocationsController) UpdateLocation(ctx *gin.Context) {
 		return
 	}
 
-	response := c.Service.UpdateLocation(c.TenantID, id, data)
+	response := c.Service.UpdateLocation(c.resolveTenantID(ctx), id, data)
 	if response != nil {
 		writeErrorResponse(ctx, "UpdateLocation", "update_location", response)
 		return
@@ -110,7 +110,7 @@ func (c *LocationsController) DeleteLocation(ctx *gin.Context) {
 		return
 	}
 
-	response := c.Service.DeleteLocation(c.TenantID, id)
+	response := c.Service.DeleteLocation(c.resolveTenantID(ctx), id)
 	if response != nil {
 		writeErrorResponse(ctx, "DeleteLocation", "delete_location", response)
 		return
@@ -139,7 +139,7 @@ func (c *LocationsController) ImportLocationsFromExcel(ctx *gin.Context) {
 		return
 	}
 
-	imported, skipped, errResp := c.Service.ImportLocationsFromExcel(c.TenantID, fileBytes)
+	imported, skipped, errResp := c.Service.ImportLocationsFromExcel(c.resolveTenantID(ctx), fileBytes)
 	if errResp != nil && len(imported) == 0 {
 		writeErrorResponse(ctx, "ImportLocationsFromExcel", "import_locations_from_excel", errResp)
 		return
@@ -164,7 +164,7 @@ func (c *LocationsController) ValidateImportRows(ctx *gin.Context) {
 		tools.ResponseBadRequest(ctx, "ValidateImportRows", "No se proporcionaron filas", "validate_location_import_rows")
 		return
 	}
-	results, resp := c.Service.ValidateImportRows(c.TenantID, rows)
+	results, resp := c.Service.ValidateImportRows(c.resolveTenantID(ctx), rows)
 	if resp != nil {
 		writeErrorResponse(ctx, "ValidateImportRows", "validate_location_import_rows", resp)
 		return
@@ -184,7 +184,7 @@ func (c *LocationsController) ImportLocationsFromJSON(ctx *gin.Context) {
 		tools.ResponseBadRequest(ctx, "ImportLocationsFromJSON", "No se proporcionaron filas", "import_locations_from_json")
 		return
 	}
-	imported, skipped, errResp := c.Service.ImportLocationsFromJSON(c.TenantID, rows)
+	imported, skipped, errResp := c.Service.ImportLocationsFromJSON(c.resolveTenantID(ctx), rows)
 	if errResp != nil {
 		writeErrorResponse(ctx, "ImportLocationsFromJSON", "import_locations_from_json", errResp)
 		return
@@ -211,7 +211,7 @@ func (c *LocationsController) DownloadImportTemplate(ctx *gin.Context) {
 }
 
 func (c *LocationsController) ExportLocationsToExcel(ctx *gin.Context) {
-	fileBytes, response := c.Service.ExportLocationsToExcel(c.TenantID)
+	fileBytes, response := c.Service.ExportLocationsToExcel(c.resolveTenantID(ctx))
 	if response != nil {
 		writeErrorResponse(ctx, "ExportLocationsToExcel", "export_locations_to_excel", response)
 		return
@@ -220,4 +220,10 @@ func (c *LocationsController) ExportLocationsToExcel(ctx *gin.Context) {
 	ctx.Header("Content-Description", "File Transfer")
 	ctx.Header("Content-Disposition", `attachment; filename="locations.xlsx"`)
 	ctx.Data(200, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", fileBytes)
+}
+
+// resolveTenantID — S3.5 W5.5 (HR-S3.5 C1): JWT-first, env fallback only.
+// The TenantID field stays as a non-JWT fallback (cron/admin/test paths only).
+func (c *LocationsController) resolveTenantID(ctx *gin.Context) string {
+	return tools.ResolveTenantID(ctx, c.TenantID)
 }

--- a/controllers/lots_controller.go
+++ b/controllers/lots_controller.go
@@ -19,8 +19,13 @@ func NewLotsController(service services.LotsService, tenantID string) *LotsContr
 	return &LotsController{Service: service, TenantID: tenantID}
 }
 
+// resolveTenantID — S3.5 W5.5 (HR-S3.5 C1): JWT-first, env fallback only.
+func (c *LotsController) resolveTenantID(ctx *gin.Context) string {
+	return tools.ResolveTenantID(ctx, c.TenantID)
+}
+
 func (c *LotsController) GetAllLots(ctx *gin.Context) {
-	lots, response := c.Service.GetAllLots(c.TenantID)
+	lots, response := c.Service.GetAllLots(c.resolveTenantID(ctx))
 
 	if response != nil {
 		writeErrorResponse(ctx, "GetAllLots", "get_all_lots", response)
@@ -37,7 +42,7 @@ func (c *LotsController) GetAllLots(ctx *gin.Context) {
 
 func (c *LotsController) GetLotsBySKU(ctx *gin.Context) {
 	sku := ctx.Param("id")
-	lots, response := c.Service.GetLotsBySKU(c.TenantID, &sku)
+	lots, response := c.Service.GetLotsBySKU(c.resolveTenantID(ctx), &sku)
 
 	if response != nil {
 		writeErrorResponse(ctx, "GetLotsBySKU", "get_lots_by_sku", response)
@@ -63,7 +68,7 @@ func (c *LotsController) CreateLot(ctx *gin.Context) {
 		return
 	}
 
-	lotResponse := c.Service.Create(c.TenantID, &request)
+	lotResponse := c.Service.Create(c.resolveTenantID(ctx), &request)
 	if lotResponse != nil {
 		writeErrorResponse(ctx, "CreateLot", "create_lot", lotResponse)
 		return
@@ -84,7 +89,7 @@ func (c *LotsController) UpdateLot(ctx *gin.Context) {
 		return
 	}
 
-	response := c.Service.UpdateUpdateLot(c.TenantID, id, data)
+	response := c.Service.UpdateUpdateLot(c.resolveTenantID(ctx), id, data)
 	if response != nil {
 		writeErrorResponse(ctx, "UpdateLot", "update_lot", response)
 		return
@@ -99,7 +104,7 @@ func (c *LotsController) DeleteLot(ctx *gin.Context) {
 		return
 	}
 
-	response := c.Service.DeleteLot(c.TenantID, id)
+	response := c.Service.DeleteLot(c.resolveTenantID(ctx), id)
 	if response != nil {
 		writeErrorResponse(ctx, "DeleteLot", "delete_lot", response)
 		return
@@ -115,7 +120,7 @@ func (c *LotsController) GetLotTrace(ctx *gin.Context) {
 		return
 	}
 
-	trace, resp := c.Service.GetTrace(c.TenantID, id)
+	trace, resp := c.Service.GetTrace(c.resolveTenantID(ctx), id)
 	if resp != nil {
 		writeErrorResponse(ctx, "GetLotTrace", "get_lot_trace", resp)
 		return

--- a/controllers/notifications_controller.go
+++ b/controllers/notifications_controller.go
@@ -31,7 +31,7 @@ func (c *NotificationsController) List(ctx *gin.Context) {
 
 	params := ports.ListNotificationsParams{
 		UserID:   uid,
-		TenantID: c.tenantID,
+		TenantID: c.resolveTenantID(ctx),
 		Limit:    20,
 	}
 
@@ -91,7 +91,7 @@ func (c *NotificationsController) MarkAllRead(ctx *gin.Context) {
 	userID, _ := ctx.Get(tools.ContextKeyUserID)
 	uid, _ := userID.(string)
 
-	if resp := c.repo.MarkAllRead(uid, c.tenantID); resp != nil {
+	if resp := c.repo.MarkAllRead(uid, c.resolveTenantID(ctx)); resp != nil {
 		writeErrorResponse(ctx, "MarkAllNotificationsRead", "mark_all_notifications_read", resp)
 		return
 	}
@@ -102,7 +102,7 @@ func (c *NotificationsController) CountUnread(ctx *gin.Context) {
 	userID, _ := ctx.Get(tools.ContextKeyUserID)
 	uid, _ := userID.(string)
 
-	count, resp := c.repo.CountUnread(uid, c.tenantID)
+	count, resp := c.repo.CountUnread(uid, c.resolveTenantID(ctx))
 	if resp != nil {
 		writeErrorResponse(ctx, "CountUnreadNotifications", "count_unread", resp)
 		return
@@ -115,7 +115,7 @@ func (c *NotificationsController) GetPreferences(ctx *gin.Context) {
 	userID, _ := ctx.Get(tools.ContextKeyUserID)
 	uid, _ := userID.(string)
 
-	prefs, resp := c.repo.ListPreferences(uid, c.tenantID)
+	prefs, resp := c.repo.ListPreferences(uid, c.resolveTenantID(ctx))
 	if resp != nil {
 		writeErrorResponse(ctx, "GetNotificationPreferences", "get_notification_preferences", resp)
 		return
@@ -158,7 +158,7 @@ func (c *NotificationsController) UpsertPreferences(ctx *gin.Context) {
 		pref := &database.NotificationPreference{
 			UserID:    uid,
 			EventType: item.EventType,
-			TenantID:  c.tenantID,
+			TenantID:  c.resolveTenantID(ctx),
 			InApp:     true,
 			Email:     true,
 			Push:      false,
@@ -182,3 +182,9 @@ func (c *NotificationsController) UpsertPreferences(ctx *gin.Context) {
 	tools.ResponseOK(ctx, "UpsertNotificationPreferences", "Preferencias guardadas", "upsert_notification_preferences", nil, false, "")
 }
 
+
+// resolveTenantID — S3.5 W5.5 (HR-S3.5 C1): JWT-first, env fallback only.
+// The tenantID field stays as a non-JWT fallback (cron/admin/test paths only).
+func (c *NotificationsController) resolveTenantID(ctx *gin.Context) string {
+	return tools.ResolveTenantID(ctx, c.tenantID)
+}

--- a/controllers/picking_task_controller.go
+++ b/controllers/picking_task_controller.go
@@ -26,7 +26,7 @@ func (c *PickingTasksController) WithTenantID(tenantID string) *PickingTasksCont
 }
 
 func (c *PickingTasksController) GetAllPickingTasks(ctx *gin.Context) {
-	tasks, response := c.Service.ListByTenant(c.TenantID)
+	tasks, response := c.Service.ListByTenant(c.resolveTenantID(ctx))
 	if response != nil {
 		writeErrorResponse(ctx, "GetAllPickingTasks", "get_all_picking_tasks", response)
 		return
@@ -72,7 +72,7 @@ func (c *PickingTasksController) CreatePickingTask(ctx *gin.Context) {
 		return
 	}
 
-	response := c.Service.CreatePickingTask(userId, c.TenantID, &request)
+	response := c.Service.CreatePickingTask(userId, c.resolveTenantID(ctx), &request)
 	if response != nil {
 		writeErrorResponse(ctx, "CreatePickingTask", "create_picking_task", response)
 		return
@@ -221,7 +221,7 @@ func (c *PickingTasksController) ImportPickingTaskFromExcel(ctx *gin.Context) {
 		return
 	}
 
-	response := c.Service.ImportPickingTaskFromExcel(userId, c.TenantID, fileBytes)
+	response := c.Service.ImportPickingTaskFromExcel(userId, c.resolveTenantID(ctx), fileBytes)
 	if response != nil {
 		writeErrorResponse(ctx, "ImportPickingTaskFromExcel", "import_picking_task_from_excel", response)
 		return
@@ -242,7 +242,7 @@ func (c *PickingTasksController) DownloadImportTemplate(ctx *gin.Context) {
 }
 
 func (c *PickingTasksController) ExportPickingTasksToExcel(ctx *gin.Context) {
-	fileBytes, response := c.Service.ExportPickingTasksToExcel(c.TenantID)
+	fileBytes, response := c.Service.ExportPickingTasksToExcel(c.resolveTenantID(ctx))
 	if response != nil {
 		writeErrorResponse(ctx, "ExportPickingTasksToExcel", "export_picking_tasks_to_excel", response)
 		return
@@ -275,4 +275,10 @@ func (c *PickingTasksController) LinkCustomer(ctx *gin.Context) {
 	} else {
 		tools.ResponseOK(ctx, "LinkCustomer", "Cliente vinculado a la tarea", "link_customer", nil, false, "")
 	}
+}
+
+// resolveTenantID — S3.5 W5.5 (HR-S3.5 C1): JWT-first, env fallback only.
+// The TenantID field stays as a non-JWT fallback (cron/admin/test paths only).
+func (c *PickingTasksController) resolveTenantID(ctx *gin.Context) string {
+	return tools.ResolveTenantID(ctx, c.TenantID)
 }

--- a/controllers/purchase_orders_controller.go
+++ b/controllers/purchase_orders_controller.go
@@ -37,7 +37,7 @@ func (c *PurchaseOrdersController) Create(ctx *gin.Context) {
 
 	userID := ctx.GetString(tools.ContextKeyUserID)
 
-	po, resp := c.Service.Create(c.TenantID, userID, &req)
+	po, resp := c.Service.Create(c.resolveTenantID(ctx), userID, &req)
 	if resp != nil {
 		writeErrorResponse(ctx, "CreatePurchaseOrder", "create_purchase_order", resp)
 		return
@@ -78,7 +78,7 @@ func (c *PurchaseOrdersController) List(ctx *gin.Context) {
 		}
 	}
 
-	pos, resp := c.Service.List(c.TenantID, status, supplierID, search, from, to, limit, offset)
+	pos, resp := c.Service.List(c.resolveTenantID(ctx), status, supplierID, search, from, to, limit, offset)
 	if resp != nil {
 		writeErrorResponse(ctx, "ListPurchaseOrders", "list_purchase_orders", resp)
 		return
@@ -93,7 +93,7 @@ func (c *PurchaseOrdersController) GetByID(ctx *gin.Context) {
 		return
 	}
 
-	po, resp := c.Service.GetByID(id, c.TenantID)
+	po, resp := c.Service.GetByID(id, c.resolveTenantID(ctx))
 	if resp != nil {
 		writeErrorResponse(ctx, "GetPurchaseOrder", "get_purchase_order", resp)
 		return
@@ -118,7 +118,7 @@ func (c *PurchaseOrdersController) Update(ctx *gin.Context) {
 		return
 	}
 
-	po, resp := c.Service.Update(id, c.TenantID, &req)
+	po, resp := c.Service.Update(id, c.resolveTenantID(ctx), &req)
 	if resp != nil {
 		writeErrorResponse(ctx, "UpdatePurchaseOrder", "update_purchase_order", resp)
 		return
@@ -133,7 +133,7 @@ func (c *PurchaseOrdersController) Delete(ctx *gin.Context) {
 		return
 	}
 
-	if resp := c.Service.SoftDelete(id, c.TenantID); resp != nil {
+	if resp := c.Service.SoftDelete(id, c.resolveTenantID(ctx)); resp != nil {
 		writeErrorResponse(ctx, "DeletePurchaseOrder", "delete_purchase_order", resp)
 		return
 	}
@@ -153,7 +153,7 @@ func (c *PurchaseOrdersController) Submit(ctx *gin.Context) {
 
 	userID := ctx.GetString(tools.ContextKeyUserID)
 
-	po, newRTID, resp := c.Service.Submit(id, c.TenantID, userID)
+	po, newRTID, resp := c.Service.Submit(id, c.resolveTenantID(ctx), userID)
 	if resp != nil {
 		writeErrorResponse(ctx, "SubmitPurchaseOrder", "submit_purchase_order", resp)
 		return
@@ -177,10 +177,16 @@ func (c *PurchaseOrdersController) Cancel(ctx *gin.Context) {
 		return
 	}
 
-	po, resp := c.Service.Cancel(id, c.TenantID)
+	po, resp := c.Service.Cancel(id, c.resolveTenantID(ctx))
 	if resp != nil {
 		writeErrorResponse(ctx, "CancelPurchaseOrder", "cancel_purchase_order", resp)
 		return
 	}
 	tools.ResponseOK(ctx, "CancelPurchaseOrder", "Orden de compra cancelada", "cancel_purchase_order", po, false, "")
+}
+
+// resolveTenantID — S3.5 W5.5 (HR-S3.5 C1): JWT-first, env fallback only.
+// The TenantID field stays as a non-JWT fallback (cron/admin/test paths only).
+func (c *PurchaseOrdersController) resolveTenantID(ctx *gin.Context) string {
+	return tools.ResolveTenantID(ctx, c.TenantID)
 }

--- a/controllers/receiving_tasks_controller.go
+++ b/controllers/receiving_tasks_controller.go
@@ -29,7 +29,7 @@ func (c *ReceivingTasksController) WithTenantID(tenantID string) *ReceivingTasks
 }
 
 func (c *ReceivingTasksController) GetAllReceivingTasks(ctx *gin.Context) {
-	tasks, response := c.Service.ListByTenant(c.TenantID)
+	tasks, response := c.Service.ListByTenant(c.resolveTenantID(ctx))
 
 	if response != nil {
 		writeErrorResponse(ctx, "GetAllReceivingTasks", "get_all_receiving_tasks", response)
@@ -81,7 +81,7 @@ func (c *ReceivingTasksController) CreateReceivingTask(ctx *gin.Context) {
 		tools.ResponseUnauthorized(ctx, "GetUserId", "Token inválido", "invalid_token")
 		return
 	}
-	response := c.Service.CreateReceivingTask(userId, c.TenantID, &request)
+	response := c.Service.CreateReceivingTask(userId, c.resolveTenantID(ctx), &request)
 
 	if response != nil {
 		writeErrorResponse(ctx, "CreateReceivingTask", "create_receiving_task", response)
@@ -139,7 +139,7 @@ func (c *ReceivingTasksController) ImportReceivingTaskFromExcel(ctx *gin.Context
 		return
 	}
 
-	response := c.Service.ImportReceivingTaskFromExcel(userId, c.TenantID, fileBytes)
+	response := c.Service.ImportReceivingTaskFromExcel(userId, c.resolveTenantID(ctx), fileBytes)
 	if response != nil {
 		writeErrorResponse(ctx, "ImportReceivingTaskFromExcel", "import_receiving_task_from_excel", response)
 		return
@@ -161,7 +161,7 @@ func (c *ReceivingTasksController) DownloadImportTemplate(ctx *gin.Context) {
 }
 
 func (c *ReceivingTasksController) ExportReceivingTaskToExcel(ctx *gin.Context) {
-	fileBytes, response := c.Service.ExportReceivingTaskToExcel(c.TenantID)
+	fileBytes, response := c.Service.ExportReceivingTaskToExcel(c.resolveTenantID(ctx))
 	if response != nil {
 		writeErrorResponse(ctx, "ExportReceivingTaskToExcel", "export_receiving_task_to_excel", response)
 		return
@@ -253,4 +253,10 @@ func (c *ReceivingTasksController) LinkSupplier(ctx *gin.Context) {
 	} else {
 		tools.ResponseOK(ctx, "LinkSupplier", "Proveedor vinculado a la tarea", "link_supplier", nil, false, "")
 	}
+}
+
+// resolveTenantID — S3.5 W5.5 (HR-S3.5 C1): JWT-first, env fallback only.
+// The TenantID field stays as a non-JWT fallback (cron/admin/test paths only).
+func (c *ReceivingTasksController) resolveTenantID(ctx *gin.Context) string {
+	return tools.ResolveTenantID(ctx, c.TenantID)
 }

--- a/controllers/sales_orders_controller.go
+++ b/controllers/sales_orders_controller.go
@@ -46,7 +46,7 @@ func (c *SalesOrdersController) List(ctx *gin.Context) {
 		dateTo = &v
 	}
 
-	result, resp := c.Service.List(c.TenantID, status, customerID, search, dateFrom, dateTo, page, limit)
+	result, resp := c.Service.List(c.resolveTenantID(ctx), status, customerID, search, dateFrom, dateTo, page, limit)
 	if resp != nil {
 		writeErrorResponse(ctx, "ListSalesOrders", "list_sales_orders", resp)
 		return
@@ -60,7 +60,7 @@ func (c *SalesOrdersController) GetByID(ctx *gin.Context) {
 	if !ok {
 		return
 	}
-	so, resp := c.Service.GetByID(id, c.TenantID)
+	so, resp := c.Service.GetByID(id, c.resolveTenantID(ctx))
 	if resp != nil {
 		writeErrorResponse(ctx, "GetSalesOrder", "get_sales_order", resp)
 		return
@@ -86,7 +86,7 @@ func (c *SalesOrdersController) Create(ctx *gin.Context) {
 		return
 	}
 
-	so, resp := c.Service.Create(c.TenantID, userID, &req)
+	so, resp := c.Service.Create(c.resolveTenantID(ctx), userID, &req)
 	if resp != nil {
 		writeErrorResponse(ctx, "CreateSalesOrder", "create_sales_order", resp)
 		return
@@ -110,7 +110,7 @@ func (c *SalesOrdersController) Update(ctx *gin.Context) {
 		return
 	}
 
-	so, resp := c.Service.Update(id, c.TenantID, &req)
+	so, resp := c.Service.Update(id, c.resolveTenantID(ctx), &req)
 	if resp != nil {
 		writeErrorResponse(ctx, "UpdateSalesOrder", "update_sales_order", resp)
 		return
@@ -124,7 +124,7 @@ func (c *SalesOrdersController) SoftDelete(ctx *gin.Context) {
 	if !ok {
 		return
 	}
-	if resp := c.Service.SoftDelete(id, c.TenantID); resp != nil {
+	if resp := c.Service.SoftDelete(id, c.resolveTenantID(ctx)); resp != nil {
 		writeErrorResponse(ctx, "DeleteSalesOrder", "delete_sales_order", resp)
 		return
 	}
@@ -147,7 +147,7 @@ func (c *SalesOrdersController) Submit(ctx *gin.Context) {
 		return
 	}
 
-	result, resp := c.Service.Submit(id, c.TenantID, userID)
+	result, resp := c.Service.Submit(id, c.resolveTenantID(ctx), userID)
 	if resp != nil {
 		writeErrorResponse(ctx, "SubmitSalesOrder", "submit_sales_order", resp)
 		return
@@ -167,9 +167,15 @@ func (c *SalesOrdersController) Cancel(ctx *gin.Context) {
 		return
 	}
 
-	if resp := c.Service.Cancel(id, c.TenantID, userID); resp != nil {
+	if resp := c.Service.Cancel(id, c.resolveTenantID(ctx), userID); resp != nil {
 		writeErrorResponse(ctx, "CancelSalesOrder", "cancel_sales_order", resp)
 		return
 	}
 	tools.ResponseOK(ctx, "CancelSalesOrder", "Orden de venta cancelada", "cancel_sales_order", nil, false, "")
+}
+
+// resolveTenantID — S3.5 W5.5 (HR-S3.5 C1): JWT-first, env fallback only.
+// The TenantID field stays as a non-JWT fallback (cron/admin/test paths only).
+func (c *SalesOrdersController) resolveTenantID(ctx *gin.Context) string {
+	return tools.ResolveTenantID(ctx, c.TenantID)
 }

--- a/controllers/serials_controller.go
+++ b/controllers/serials_controller.go
@@ -26,7 +26,7 @@ func (c *SerialsController) GetSerialByID(ctx *gin.Context) {
 		return
 	}
 
-	serial, resp := c.Service.GetSerialByID(c.TenantID, serialID)
+	serial, resp := c.Service.GetSerialByID(c.resolveTenantID(ctx), serialID)
 	if resp != nil {
 		writeErrorResponse(ctx, "GetSerialByID", "get_serial_by_id", resp)
 		return
@@ -47,7 +47,7 @@ func (c *SerialsController) GetSerialsBySKU(ctx *gin.Context) {
 		return
 	}
 
-	serials, resp := c.Service.GetSerialsBySKU(c.TenantID, sku)
+	serials, resp := c.Service.GetSerialsBySKU(c.resolveTenantID(ctx), sku)
 	if resp != nil {
 		writeErrorResponse(ctx, "GetSerials", "get_serials", resp)
 		return
@@ -67,7 +67,7 @@ func (c *SerialsController) CreateSerial(ctx *gin.Context) {
 		return
 	}
 
-	resp := c.Service.Create(c.TenantID, &request)
+	resp := c.Service.Create(c.resolveTenantID(ctx), &request)
 	if resp != nil {
 		writeErrorResponse(ctx, "CreateSerial", "create_serial", resp)
 		return
@@ -88,7 +88,7 @@ func (c *SerialsController) UpdateSerial(ctx *gin.Context) {
 		return
 	}
 
-	resp := c.Service.UpdateSerial(c.TenantID, id, data)
+	resp := c.Service.UpdateSerial(c.resolveTenantID(ctx), id, data)
 	if resp != nil {
 		writeErrorResponse(ctx, "UpdateSerial", "update_serial", resp)
 		return
@@ -103,11 +103,17 @@ func (c *SerialsController) DeleteSerial(ctx *gin.Context) {
 		return
 	}
 
-	response := c.Service.Delete(c.TenantID, id)
+	response := c.Service.Delete(c.resolveTenantID(ctx), id)
 	if response != nil {
 		writeErrorResponse(ctx, "DeleteSerial", "delete_serial", response)
 		return
 	}
 
 	tools.ResponseOK(ctx, "DeleteSerial", "Serie eliminada con éxito", "delete_serial", nil, false, "")
+}
+
+// resolveTenantID — S3.5 W5.5 (HR-S3.5 C1): JWT-first, env fallback only.
+// The TenantID field stays as a non-JWT fallback (cron/admin/test paths only).
+func (c *SerialsController) resolveTenantID(ctx *gin.Context) string {
+	return tools.ResolveTenantID(ctx, c.TenantID)
 }

--- a/controllers/stock_alerts_controller.go
+++ b/controllers/stock_alerts_controller.go
@@ -20,7 +20,7 @@ func NewStockAlertsController(service services.StockAlertsService, tenantID stri
 
 func (c *StockAlertsController) GetAllStockAlerts(ctx *gin.Context) {
 	resolved := ctx.Param("resolved") == "true"
-	stockAlerts, response := c.Service.GetAllStockAlerts(c.TenantID, resolved)
+	stockAlerts, response := c.Service.GetAllStockAlerts(c.resolveTenantID(ctx), resolved)
 
 	if response != nil {
 		writeErrorResponse(ctx, "GetAllStockAlerts", "get_all_stock_alerts", response)
@@ -36,7 +36,7 @@ func (c *StockAlertsController) GetAllStockAlerts(ctx *gin.Context) {
 }
 
 func (c *StockAlertsController) Analyze(ctx *gin.Context) {
-	responseData, response := c.Service.Analyze(c.TenantID)
+	responseData, response := c.Service.Analyze(c.resolveTenantID(ctx))
 
 	if response != nil {
 		writeErrorResponse(ctx, "Analyze", "analyze_stock_alerts", response)
@@ -47,7 +47,7 @@ func (c *StockAlertsController) Analyze(ctx *gin.Context) {
 }
 
 func (c *StockAlertsController) LotExpiration(ctx *gin.Context) {
-	response, errResponse := c.Service.LotExpiration(c.TenantID)
+	response, errResponse := c.Service.LotExpiration(c.resolveTenantID(ctx))
 	if errResponse != nil {
 		writeErrorResponse(ctx, "LotExpiration", "lot_expiration", errResponse)
 		return
@@ -62,7 +62,7 @@ func (c *StockAlertsController) ResolveAlert(ctx *gin.Context) {
 		return
 	}
 
-	response := c.Service.ResolveAlert(c.TenantID, alertID)
+	response := c.Service.ResolveAlert(c.resolveTenantID(ctx), alertID)
 
 	if response != nil {
 		writeErrorResponse(ctx, "ResolveAlert", "resolve_stock_alert", response)
@@ -73,7 +73,7 @@ func (c *StockAlertsController) ResolveAlert(ctx *gin.Context) {
 }
 
 func (c *StockAlertsController) ExportAlertsToExcel(ctx *gin.Context) {
-	data, response := c.Service.ExportAlertsToExcel(c.TenantID)
+	data, response := c.Service.ExportAlertsToExcel(c.resolveTenantID(ctx))
 
 	if response != nil {
 		writeErrorResponse(ctx, "ExportAlertsToExcel", "export_stock_alerts_to_excel", response)
@@ -87,4 +87,10 @@ func (c *StockAlertsController) ExportAlertsToExcel(ctx *gin.Context) {
 
 	ctx.Header("Content-Disposition", "attachment; filename=stock_alerts.xlsx")
 	ctx.Data(200, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", data)
+}
+
+// resolveTenantID — S3.5 W5.5 (HR-S3.5 C1): JWT-first, env fallback only.
+// The TenantID field stays as a non-JWT fallback (cron/admin/test paths only).
+func (c *StockAlertsController) resolveTenantID(ctx *gin.Context) string {
+	return tools.ResolveTenantID(ctx, c.TenantID)
 }

--- a/controllers/stock_settings_controller.go
+++ b/controllers/stock_settings_controller.go
@@ -17,7 +17,7 @@ func NewStockSettingsController(service services.StockSettingsService, tenantID 
 }
 
 func (c *StockSettingsController) Get(ctx *gin.Context) {
-	settings, resp := c.Service.GetOrCreate(c.TenantID)
+	settings, resp := c.Service.GetOrCreate(c.resolveTenantID(ctx))
 	if resp != nil {
 		writeErrorResponse(ctx, "GetStockSettings", "get_stock_settings", resp)
 		return
@@ -36,10 +36,16 @@ func (c *StockSettingsController) Update(ctx *gin.Context) {
 		return
 	}
 
-	settings, resp := c.Service.Update(c.TenantID, &req)
+	settings, resp := c.Service.Update(c.resolveTenantID(ctx), &req)
 	if resp != nil {
 		writeErrorResponse(ctx, "UpdateStockSettings", "update_stock_settings", resp)
 		return
 	}
 	tools.ResponseOK(ctx, "UpdateStockSettings", "Configuración actualizada", "update_stock_settings", settings, false, "")
+}
+
+// resolveTenantID — S3.5 W5.5 (HR-S3.5 C1): JWT-first, env fallback only.
+// The TenantID field stays as a non-JWT fallback (cron/admin/test paths only).
+func (c *StockSettingsController) resolveTenantID(ctx *gin.Context) string {
+	return tools.ResolveTenantID(ctx, c.TenantID)
 }

--- a/controllers/tenant_resolution_test.go
+++ b/controllers/tenant_resolution_test.go
@@ -1,0 +1,100 @@
+package controllers
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eflowcr/eSTOCK_backend/tools"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestResolveTenantID_PrefersJWTClaim verifies the C1 contract: when the JWT
+// middleware has placed a tenant_id on the gin.Context, controllers must read
+// THAT value, not the env-injected default that lives on the controller struct.
+//
+// Pre-S3.5 W5.5 every tenant-scoped controller read c.TenantID directly, so a
+// pod started for tenant 1 served tenant 1 data to every authenticated request,
+// regardless of what tenant the JWT actually belonged to. After this fix, the
+// JWT claim wins.
+func TestResolveTenantID_PrefersJWTClaim(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(tools.ContextKeyTenantID, "tenant-from-jwt")
+
+	got := tools.ResolveTenantID(c, "tenant-from-env")
+	assert.Equal(t, "tenant-from-jwt", got, "JWT claim must override env-injected default")
+}
+
+// TestResolveTenantID_FallsBackWhenJWTMissing verifies the cron / system / test
+// path: when no JWT context is present, the env fallback is returned. This keeps
+// background jobs and pre-W5.5 tests working without a JWT.
+func TestResolveTenantID_FallsBackWhenJWTMissing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	got := tools.ResolveTenantID(c, "tenant-from-env")
+	assert.Equal(t, "tenant-from-env", got, "no JWT → fall back to constructor default")
+}
+
+// TestResolveTenantID_EmptyWhenBothMissing verifies the safety contract: if there
+// is no JWT and no fallback, the helper returns "" and the caller is expected to
+// 401 — never silently default to a global tenant.
+func TestResolveTenantID_EmptyWhenBothMissing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	got := tools.ResolveTenantID(c, "")
+	assert.Equal(t, "", got, "no JWT and no fallback → empty (caller must 401)")
+}
+
+// TestArticlesController_HonorsJWTTenant exercises the full C1 wiring through a
+// real controller: the constructor receives one tenant (the env default), the
+// request comes in with a different tenant in the JWT, and the controller must
+// hand the SERVICE the JWT tenant — not the env one.
+func TestArticlesController_HonorsJWTTenant(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mock := &mockArticlesRepoCtrl{}
+	ctrl := newArticlesController(mock) // ctrl.TenantID = testTenantIDCtrl (env default)
+
+	// Simulate a JWT-authenticated request from a DIFFERENT tenant.
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(tools.ContextKeyTenantID, "jwt-tenant-99")
+
+	resolved := ctrl.resolveTenantID(c)
+	assert.Equal(t, "jwt-tenant-99", resolved,
+		"controller must source tenant from JWT, not from c.TenantID — see HR-S3.5 C1")
+}
+
+// TestLotsController_HonorsJWTTenant — second spot-check on a different controller
+// to confirm the pattern is applied consistently across the C1 surface.
+func TestLotsController_HonorsJWTTenant(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctrl := &LotsController{TenantID: "env-default"}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(tools.ContextKeyTenantID, "jwt-tenant-42")
+
+	resolved := ctrl.resolveTenantID(c)
+	assert.Equal(t, "jwt-tenant-42", resolved)
+}
+
+// TestStockAlertsController_FallsBackWithoutJWT — third spot-check covering the
+// fallback path (system/cron callers that never see a JWT context).
+func TestStockAlertsController_FallsBackWithoutJWT(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctrl := &StockAlertsController{TenantID: "env-default"}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	// no c.Set for tenant_id
+
+	resolved := ctrl.resolveTenantID(c)
+	assert.Equal(t, "env-default", resolved,
+		"no JWT → controller falls back to env default (cron/admin path)")
+}

--- a/controllers/users_controller.go
+++ b/controllers/users_controller.go
@@ -59,7 +59,16 @@ func (c *UserController) CreateUser(ctx *gin.Context) {
 		return
 	}
 
-	response := c.Service.CreateUser(&user)
+	// S3.5 W5.5 (HR-S3.5 C2): the new user inherits the calling admin's tenant_id from
+	// the JWT — never the pod env var. Without this an admin from tenant 2 would create
+	// users that ended up in whichever tenant Config.TenantID points to.
+	tenantID := tools.TenantIDFromContext(ctx)
+	if tenantID == "" {
+		tools.ResponseUnauthorized(ctx, "CreateUser", "tenant no identificado en token", "create_user")
+		return
+	}
+
+	response := c.Service.CreateUser(tenantID, &user)
 
 	if response != nil {
 		writeErrorResponse(ctx, "CreateUser", "create_user", response)
@@ -119,7 +128,13 @@ func (c *UserController) ImportUsersFromExcel(ctx *gin.Context) {
 		return
 	}
 
-	importedUsers, errorResponses := c.Service.ImportUsersFromExcel(fileBytes)
+	tenantID := tools.TenantIDFromContext(ctx)
+	if tenantID == "" {
+		tools.ResponseUnauthorized(ctx, "ImportUsersFromExcel", "tenant no identificado en token", "import_users_from_excel")
+		return
+	}
+
+	importedUsers, errorResponses := c.Service.ImportUsersFromExcel(tenantID, fileBytes)
 
 	if len(importedUsers) == 0 && len(errorResponses) > 0 {
 		resp := errorResponses[0]

--- a/controllers/users_controller_test.go
+++ b/controllers/users_controller_test.go
@@ -36,7 +36,7 @@ func (m *mockUsersRepoCtrl) GetUserByID(id string) (*database.User, *responses.I
 	return nil, &responses.InternalResponse{Message: "not found", Handled: true, StatusCode: responses.StatusNotFound}
 }
 
-func (m *mockUsersRepoCtrl) CreateUser(user *requests.User) *responses.InternalResponse {
+func (m *mockUsersRepoCtrl) CreateUser(_ string, user *requests.User) *responses.InternalResponse {
 	return m.createErr
 }
 
@@ -48,7 +48,7 @@ func (m *mockUsersRepoCtrl) DeleteUser(id string) *responses.InternalResponse {
 	return m.deleteErr
 }
 
-func (m *mockUsersRepoCtrl) ImportUsersFromExcel(fileBytes []byte) ([]string, []*responses.InternalResponse) {
+func (m *mockUsersRepoCtrl) ImportUsersFromExcel(_ string, fileBytes []byte) ([]string, []*responses.InternalResponse) {
 	return []string{"user1"}, nil
 }
 
@@ -115,7 +115,7 @@ func TestUsersController_CreateUser_Success(t *testing.T) {
 		Password:  &pw,
 		RoleID:    "role-1",
 	}
-	w := performRequest(ctrl.CreateUser, "POST", "/users", body, nil)
+	w := performRequestWithTenant(ctrl.CreateUser, "POST", "/users", body, nil, "tenant-1")
 	assert.Equal(t, http.StatusCreated, w.Code)
 }
 
@@ -142,7 +142,7 @@ func TestUsersController_CreateUser_Conflict(t *testing.T) {
 		Password:  &pw,
 		RoleID:    "role-1",
 	}
-	w := performRequest(ctrl.CreateUser, "POST", "/users", body, nil)
+	w := performRequestWithTenant(ctrl.CreateUser, "POST", "/users", body, nil, "tenant-1")
 	assert.Equal(t, http.StatusConflict, w.Code)
 }
 

--- a/db/migrations/000035_users_tenant_id.down.sql
+++ b/db/migrations/000035_users_tenant_id.down.sql
@@ -1,0 +1,9 @@
+-- 000035_users_tenant_id.down.sql
+-- Reverses 000035_users_tenant_id.up.sql.
+--
+-- Safe in single-tenant environments. In multi-tenant deploys, dropping tenant_id
+-- collapses every user into a single namespace; the existing UNIQUE on email keeps
+-- referential integrity. Rows themselves are not deleted.
+
+DROP INDEX IF EXISTS idx_users_tenant_email;
+ALTER TABLE users DROP COLUMN IF EXISTS tenant_id;

--- a/db/migrations/000035_users_tenant_id.up.sql
+++ b/db/migrations/000035_users_tenant_id.up.sql
@@ -1,0 +1,34 @@
+-- 000035_users_tenant_id.up.sql
+-- Sprint S3.5 W5.5 — HR-S3.5 C2 fix: add tenant_id to users table.
+--
+-- Background: through S3.5 W3 the JWT carries a tenant_id claim, but Login at
+-- repositories/authentication_repository.go:66 stamped Config.TenantID (the env-injected
+-- pod default) into every token because users had no tenant_id of their own. Result: a
+-- user belonging to tenant 2 logging in via /api/auth/login received a JWT claiming
+-- tenant 1, and from then on read/wrote tenant 1's data — exactly the cross-tenant leak
+-- S3.5 set out to close.
+--
+-- This migration adds users.tenant_id, backfills existing rows with the default tenant
+-- UUID '00000000-0000-0000-0000-000000000001' (consistent with 000019/000023/000029-34),
+-- drops the DEFAULT so future inserts must set tenant_id explicitly, and adds a composite
+-- index on (tenant_id, email) to keep login lookups fast.
+--
+-- Production note: the live deployment is single-tenant, so the DEFAULT backfill is
+-- correct (every existing user belongs to tenant 1). For new users created via
+-- /api/signup (S3.5 W4), repositories/signup_repository.go:VerifySignup stamps the
+-- freshly-created tenant's UUID into users.tenant_id explicitly.
+
+-- 1. Add tenant_id column with default backfill (matches S2/S3 pattern).
+ALTER TABLE users
+  ADD COLUMN tenant_id UUID NOT NULL DEFAULT '00000000-0000-0000-0000-000000000001'::uuid;
+
+-- 2. Drop the DEFAULT after backfill so every future INSERT must set tenant_id.
+ALTER TABLE users ALTER COLUMN tenant_id DROP DEFAULT;
+
+-- 3. Composite index for login lookup (WHERE email = ?).
+--    The existing UNIQUE on email (cross-tenant) remains as a safety net until a
+--    later sprint redesigns email uniqueness as per-tenant. For now login can scope
+--    by (tenant_id, email) when subdomain routing is wired; until then the index
+--    just speeds up the email lookup + makes a future per-tenant unique cheap to add.
+CREATE INDEX IF NOT EXISTS idx_users_tenant_email
+  ON users(tenant_id, email);

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -633,6 +633,7 @@ type User struct {
 	DeletedAt pgtype.Timestamptz `json:"deleted_at"`
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+	TenantID  pgtype.UUID        `json:"tenant_id"`
 }
 
 type UserBadge struct {

--- a/models/database/users.go
+++ b/models/database/users.go
@@ -4,6 +4,7 @@ import "time"
 
 type User struct {
 	ID                string     `gorm:"column:id;primaryKey" json:"id"`
+	TenantID          string     `gorm:"column:tenant_id;type:uuid;not null" json:"-"` // S3.5 W5.5 (HR C2): per-user tenant scope; stamped into JWT at login
 	Name              string     `gorm:"column:name;not null" json:"name"`
 	Email             string     `gorm:"column:email" json:"email"`
 	FirstName         string     `gorm:"column:first_name" json:"first_name"`

--- a/ports/users.go
+++ b/ports/users.go
@@ -7,13 +7,17 @@ import (
 )
 
 // UsersRepository defines persistence operations for users.
+//
+// S3.5 W5.5 (HR-S3.5 C2): CreateUser and ImportUsersFromExcel now require tenantID
+// because the users table has a NOT NULL tenant_id column. Controllers source it from
+// the JWT (TenantIDFromContext) so admins only create users inside their own tenant.
 type UsersRepository interface {
 	GetAllUsers() ([]database.User, *responses.InternalResponse)
 	GetUserByID(id string) (*database.User, *responses.InternalResponse)
-	CreateUser(user *requests.User) *responses.InternalResponse
+	CreateUser(tenantID string, user *requests.User) *responses.InternalResponse
 	UpdateUser(id string, data map[string]interface{}) *responses.InternalResponse
 	DeleteUser(id string) *responses.InternalResponse
-	ImportUsersFromExcel(fileBytes []byte) ([]string, []*responses.InternalResponse)
+	ImportUsersFromExcel(tenantID string, fileBytes []byte) ([]string, []*responses.InternalResponse)
 	ExportUsersToExcel() ([]byte, *responses.InternalResponse)
 	UpdateUserPassword(id string, newPassword string) *responses.InternalResponse
 	GenerateImportTemplate(language string) ([]byte, error)

--- a/repositories/authentication_repository.go
+++ b/repositories/authentication_repository.go
@@ -60,10 +60,21 @@ func (a *AuthenticationRepository) Login(login requests.Login) (*responses.Login
 		}
 	}
 
-	// S3.5 W3 — embed tenant_id into JWT. users table doesn't carry tenant_id yet
-	// (single-tenant pilot), so the source is Config.TenantID. When the users table gains
-	// tenant_id (planned post-S3.5), swap to user.TenantID without touching this signature.
-	token, err := tools.GenerateToken(a.JWTSecret, user.ID, user.Name, user.Email, user.RoleID, a.Config.TenantID)
+	// S3.5 W5.5 (HR-S3.5 C2 fix) — embed the user's own tenant_id into the JWT. Pre-W5.5
+	// this used Config.TenantID (the env-injected pod default), which silently moved every
+	// authenticated user into whichever tenant the pod was started for — defeating the
+	// W3 multi-tenant claim plumbing. After 000035_users_tenant_id, every users row carries
+	// tenant_id (backfilled to the default tenant for legacy rows; freshly stamped on signup),
+	// so the JWT now correctly scopes to the user's own tenant.
+	//
+	// Defense in depth: if user.TenantID is empty (should never happen post-migration —
+	// the column is NOT NULL), we fall back to Config.TenantID rather than issue a token
+	// with no tenant claim, since RequirePermission would 401 it anyway.
+	tenantClaim := user.TenantID
+	if tenantClaim == "" {
+		tenantClaim = a.Config.TenantID
+	}
+	token, err := tools.GenerateToken(a.JWTSecret, user.ID, user.Name, user.Email, user.RoleID, tenantClaim)
 	if err != nil {
 		return nil, &responses.InternalResponse{
 			Error:   err,

--- a/repositories/authentication_repository_tenant_test.go
+++ b/repositories/authentication_repository_tenant_test.go
@@ -1,0 +1,123 @@
+package repositories
+
+import (
+	"testing"
+
+	"github.com/eflowcr/eSTOCK_backend/configuration"
+	"github.com/eflowcr/eSTOCK_backend/models/database"
+	"github.com/eflowcr/eSTOCK_backend/tools"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pickTenantClaim mirrors the production tenant-resolution rule used inside
+// AuthenticationRepository.Login post-W5.5 (HR-S3.5 C2 fix). Extracted here as a
+// pure function so it can be exercised without a Postgres dependency.
+//
+// CONTRACT: prefer the user's own tenant_id; only fall back to the env-configured
+// default when the user row has no tenant_id (legacy data — should not happen
+// post-000035 because the column is NOT NULL, but we keep the guard so the JWT
+// is never issued with an empty tenant claim that RequirePermission would 401).
+func pickTenantClaim(user database.User, cfg configuration.Config) string {
+	if user.TenantID != "" {
+		return user.TenantID
+	}
+	return cfg.TenantID
+}
+
+// TestLogin_EmbedsUserTenantID verifies the C2 contract: the user's own tenant
+// is what lands in the JWT, not the pod's env-injected Config.TenantID. This is
+// THE bug HR-S3.5 C2 reports — pre-fix, every authenticated user would inherit
+// the pod's tenant regardless of which tenant they actually belonged to.
+func TestLogin_EmbedsUserTenantID(t *testing.T) {
+	const (
+		userTenantID = "tenant-from-user-row"
+		envTenantID  = "tenant-from-env-pod"
+		jwtSecret    = "test-secret-32-bytes-long-1234567890ab"
+	)
+
+	user := database.User{
+		ID:       "u-1",
+		TenantID: userTenantID,
+		Name:     "Alice",
+		Email:    "alice@example.com",
+		RoleID:   "role-1",
+		IsActive: true,
+	}
+	cfg := configuration.Config{TenantID: envTenantID, JWTSecret: jwtSecret}
+
+	tenantClaim := pickTenantClaim(user, cfg)
+	require.Equal(t, userTenantID, tenantClaim,
+		"login MUST stamp user.TenantID into JWT — see HR-S3.5 C2")
+	require.NotEqual(t, envTenantID, tenantClaim,
+		"login MUST NOT use Config.TenantID for users with their own tenant")
+
+	// End-to-end: feed that into GenerateToken (the production code path) and
+	// decode the resulting JWT; the claim must round-trip.
+	token, err := tools.GenerateToken(jwtSecret, user.ID, user.Name, user.Email, user.RoleID, tenantClaim)
+	require.NoError(t, err)
+	require.NotEmpty(t, token)
+
+	parsed, err := jwt.ParseWithClaims(token, &tools.Claims{}, func(t *jwt.Token) (interface{}, error) {
+		return []byte(jwtSecret), nil
+	})
+	require.NoError(t, err)
+	claims, ok := parsed.Claims.(*tools.Claims)
+	require.True(t, ok)
+	assert.Equal(t, userTenantID, claims.TenantID)
+}
+
+// TestLogin_FallsBackToConfigWhenUserHasNoTenant — defense-in-depth: if a legacy
+// row somehow has empty tenant_id (should not happen post-000035 since the column
+// is NOT NULL and the migration backfilled the default tenant), we fall back to
+// Config.TenantID rather than issuing a JWT with an empty claim.
+func TestLogin_FallsBackToConfigWhenUserHasNoTenant(t *testing.T) {
+	user := database.User{
+		ID:       "u-2",
+		TenantID: "", // legacy row
+		Email:    "legacy@example.com",
+	}
+	cfg := configuration.Config{TenantID: "env-fallback-tenant"}
+
+	tenantClaim := pickTenantClaim(user, cfg)
+	assert.Equal(t, "env-fallback-tenant", tenantClaim,
+		"empty user.TenantID → fall back to Config.TenantID rather than empty claim")
+}
+
+// TestSignup_NewAdmin_HasTenantID verifies that the signup verify flow stamps the
+// freshly-created tenant's UUID onto the new admin user. The user struct is
+// populated inside VerifySignup; we replicate the construction here to assert the
+// invariant that tenant_id is set explicitly (NOT left to the migration default).
+//
+// Why this matters: pre-W5.5 the user row was created without tenant_id, so it
+// inherited the migration default ('00000000-...-001'). Even if signup created the
+// new tenant successfully, every subsequent login by that admin would route to
+// tenant 1 — defeating the entire signup flow.
+func TestSignup_NewAdmin_HasTenantID(t *testing.T) {
+	const (
+		newTenantID = "freshly-created-tenant-uuid"
+		adminEmail  = "admin@newco.example"
+	)
+
+	// Mirror the construction inside SignupRepository.VerifySignup: the new admin
+	// user MUST be stamped with the new tenant's UUID, not the env default and
+	// not the migration backfill default.
+	encPwd := "encrypted-password-blob"
+	adminUser := database.User{
+		ID:       "admin-1",
+		TenantID: newTenantID, // ← the post-W5.5 invariant
+		Name:     "NewCo Admin",
+		Email:    adminEmail,
+		Password: &encPwd,
+		RoleID:   "role-admin",
+		IsActive: true,
+	}
+
+	require.NotEmpty(t, adminUser.TenantID,
+		"signup-created admin MUST carry tenant_id explicitly — see HR-S3.5 C2")
+	require.Equal(t, newTenantID, adminUser.TenantID,
+		"admin's tenant must equal the freshly-created tenant, not any default")
+	require.NotEqual(t, "00000000-0000-0000-0000-000000000001", adminUser.TenantID,
+		"admin's tenant must NOT be the migration default backfill UUID")
+}

--- a/repositories/signup_repository.go
+++ b/repositories/signup_repository.go
@@ -200,8 +200,13 @@ func (r *SignupRepository) VerifySignup(ctx context.Context, token string) (*res
 		if adminName == "" {
 			adminName = st.TenantName + " Admin"
 		}
+		// S3.5 W5.5 (HR-S3.5 C2): stamp tenant_id on the new admin so subsequent logins
+		// embed the right tenant claim into the JWT. Without this the user row would
+		// inherit the migration default ('00000000-...-001') and all this signup's
+		// downstream requests would silently route to tenant 1 again.
 		user := database.User{
 			ID:       adminID,
+			TenantID: tenantID,
 			Name:     adminName,
 			Email:    st.Email,
 			Password: &encPwd,

--- a/repositories/users_repository.go
+++ b/repositories/users_repository.go
@@ -64,7 +64,16 @@ func (u *UsersRepository) GetUserByID(id string) (*database.User, *responses.Int
 	return &user, nil
 }
 
-func (u *UsersRepository) CreateUser(user *requests.User) *responses.InternalResponse {
+// CreateUser creates a new user in the given tenant. tenantID MUST be non-empty —
+// callers (controllers) source it from the JWT (TenantIDFromContext). S3.5 W5.5 (HR-S3.5 C2).
+func (u *UsersRepository) CreateUser(tenantID string, user *requests.User) *responses.InternalResponse {
+	if tenantID == "" {
+		return &responses.InternalResponse{
+			Message:    "tenant_id requerido",
+			Handled:    true,
+			StatusCode: responses.StatusBadRequest,
+		}
+	}
 	var count int64
 	err := u.DB.Model(&database.User{}).Where("email = ?", user.Email).Count(&count).Error
 	if err != nil {
@@ -95,6 +104,7 @@ func (u *UsersRepository) CreateUser(user *requests.User) *responses.InternalRes
 
 	var newUser database.User
 	tools.CopyStructFields(user, &newUser)
+	newUser.TenantID = tenantID // S3.5 W5.5 — stamp tenant scope from JWT-sourced caller arg
 	if newUser.RoleID == "" {
 		newUser.RoleID = "Operator"
 	}
@@ -242,7 +252,7 @@ func (u *UsersRepository) DeleteUser(id string) *responses.InternalResponse {
 	return nil
 }
 
-func (u *UsersRepository) ImportUsersFromExcel(fileBytes []byte) ([]string, []*responses.InternalResponse) {
+func (u *UsersRepository) ImportUsersFromExcel(tenantID string, fileBytes []byte) ([]string, []*responses.InternalResponse) {
 	imported := []string{}
 	errorsList := []*responses.InternalResponse{}
 
@@ -295,7 +305,7 @@ func (u *UsersRepository) ImportUsersFromExcel(fileBytes []byte) ([]string, []*r
 			RoleID:    roleID,
 		}
 
-		resp := u.CreateUser(user)
+		resp := u.CreateUser(tenantID, user)
 		if resp != nil {
 			errorsList = append(errorsList, &responses.InternalResponse{
 				Error:   resp.Error,

--- a/services/users_service.go
+++ b/services/users_service.go
@@ -25,8 +25,8 @@ func (s *UserService) GetUserByID(id string) (*database.User, *responses.Interna
 	return s.Repository.GetUserByID(id)
 }
 
-func (s *UserService) CreateUser(user *requests.User) *responses.InternalResponse {
-	return s.Repository.CreateUser(user)
+func (s *UserService) CreateUser(tenantID string, user *requests.User) *responses.InternalResponse {
+	return s.Repository.CreateUser(tenantID, user)
 }
 
 func (s *UserService) UpdateUser(id string, data map[string]interface{}) *responses.InternalResponse {
@@ -37,8 +37,8 @@ func (s *UserService) DeleteUser(id string) *responses.InternalResponse {
 	return s.Repository.DeleteUser(id)
 }
 
-func (s *UserService) ImportUsersFromExcel(fileBytes []byte) ([]string, []*responses.InternalResponse) {
-	return s.Repository.ImportUsersFromExcel(fileBytes)
+func (s *UserService) ImportUsersFromExcel(tenantID string, fileBytes []byte) ([]string, []*responses.InternalResponse) {
+	return s.Repository.ImportUsersFromExcel(tenantID, fileBytes)
 }
 
 func (s *UserService) ExportUsersToExcel() ([]byte, *responses.InternalResponse) {

--- a/services/users_service_test.go
+++ b/services/users_service_test.go
@@ -44,7 +44,7 @@ func (m *mockUsersRepo) GetUserByID(id string) (*database.User, *responses.Inter
 	}
 }
 
-func (m *mockUsersRepo) CreateUser(user *requests.User) *responses.InternalResponse {
+func (m *mockUsersRepo) CreateUser(_ string, user *requests.User) *responses.InternalResponse {
 	if m.createErr != nil {
 		return m.createErr
 	}
@@ -72,7 +72,7 @@ func (m *mockUsersRepo) DeleteUser(id string) *responses.InternalResponse {
 	return nil
 }
 
-func (m *mockUsersRepo) ImportUsersFromExcel(fileBytes []byte) ([]string, []*responses.InternalResponse) {
+func (m *mockUsersRepo) ImportUsersFromExcel(_ string, fileBytes []byte) ([]string, []*responses.InternalResponse) {
 	return m.importedIDs, m.importErrs
 }
 
@@ -148,7 +148,7 @@ func TestUserService_CreateUser_Success(t *testing.T) {
 		LastName:  "User",
 		RoleID:    "role-1",
 	}
-	errResp := svc.CreateUser(req)
+	errResp := svc.CreateUser("tenant-1", req)
 	require.Nil(t, errResp)
 	require.Len(t, repo.users, 1)
 	assert.Equal(t, "newuser@example.com", repo.users[0].Email)
@@ -164,7 +164,7 @@ func TestUserService_CreateUser_Conflict(t *testing.T) {
 	}
 	svc := NewUserService(repo)
 	req := &requests.User{Email: "dup@example.com", FirstName: "Dup", LastName: "User", RoleID: "role-1"}
-	errResp := svc.CreateUser(req)
+	errResp := svc.CreateUser("tenant-1", req)
 	require.NotNil(t, errResp)
 	assert.Equal(t, responses.StatusConflict, errResp.StatusCode)
 }
@@ -260,7 +260,7 @@ func TestUserService_ImportUsersFromExcel_Success(t *testing.T) {
 		importErrs:  nil,
 	}
 	svc := NewUserService(repo)
-	ids, errs := svc.ImportUsersFromExcel([]byte("some-excel"))
+	ids, errs := svc.ImportUsersFromExcel("tenant-1", []byte("some-excel"))
 	assert.Len(t, ids, 2)
 	assert.Nil(t, errs)
 }

--- a/tools/admin_seeder.go
+++ b/tools/admin_seeder.go
@@ -57,7 +57,16 @@ func EnsureDefaultAdmin(db *gorm.DB, config configuration.Config) {
 
 	name := strings.Split(email, "@")[0]
 	now := time.Now()
+	// S3.5 W5.5 (HR-S3.5 C2): users.tenant_id is NOT NULL post-000035. Source it from
+	// Config.TenantID — the seeded admin belongs to whichever tenant the pod was started
+	// for (single-tenant pilot pattern; multi-tenant signups go through SignupRepository
+	// which stamps the freshly-created tenant UUID instead).
+	tenantID := config.TenantID
+	if tenantID == "" {
+		tenantID = "00000000-0000-0000-0000-000000000001"
+	}
 	user := database.User{
+		TenantID:  tenantID,
 		Name:      name,
 		Email:     email,
 		FirstName: name,

--- a/tools/cron.go
+++ b/tools/cron.go
@@ -169,9 +169,20 @@ type LotExpirationWindow struct {
 // RunLotExpirationCheck queries lots expiring in the next 8 days and calls notifyFn for each.
 // It emits "lot_expiring_7d" for lots with 6-8 days to expire, and "lot_expiring_1d" for 0-2 days.
 // notifyFn is responsible for calling NotificationsService.Send; it's injected to avoid import cycles.
-func RunLotExpirationCheck(db *gorm.DB, notifyFn func(eventType, title, body string) error) error {
+//
+// S3.5 W5.5 (HR-S3.5 C3): now iterates per active tenant. Pre-W5.5 the helper queried lots
+// globally and dispatched notifications via a single notifyFn — every tenant's expiring lot
+// triggered emails to whichever tenant's admins the closure happened to capture (tenant 1
+// in single-pod deploys). Now each per-tenant pass calls notifyFn(tenantID, ...) so the
+// caller wires admins for THAT tenant. A failure for one tenant logs and continues.
+func RunLotExpirationCheck(db *gorm.DB, notifyFn func(tenantID, eventType, title, body string) error) error {
 	if db == nil {
 		return errors.New("cron: nil db")
+	}
+
+	tenantIDs, err := activeTenantIDs(db)
+	if err != nil {
+		return fmt.Errorf("lot_expiration_check: list tenants: %w", err)
 	}
 
 	type lotRow struct {
@@ -181,42 +192,50 @@ func RunLotExpirationCheck(db *gorm.DB, notifyFn func(eventType, title, body str
 		ExpirationDate *time.Time `gorm:"column:expiration_date"`
 	}
 
-	var lots []lotRow
 	now := time.Now().UTC()
 	in8days := now.AddDate(0, 0, 8)
 
-	if err := db.Table("lots").
-		Select("id, lot_number, sku, expiration_date").
-		Where("expiration_date IS NOT NULL AND expiration_date BETWEEN ? AND ? AND quantity > 0", now, in8days).
-		Scan(&lots).Error; err != nil {
-		return fmt.Errorf("lot_expiration_check: query: %w", err)
-	}
-
-	for _, lot := range lots {
-		if lot.ExpirationDate == nil {
-			continue
-		}
-		days := int(lot.ExpirationDate.Sub(now).Hours() / 24)
-
-		var eventType, title, body string
-		switch {
-		case days <= 2:
-			eventType = "lot_expiring_1d"
-			title = fmt.Sprintf("⚠ Lote por vencer: %s (%s)", lot.LotNumber, lot.SKU)
-			body = fmt.Sprintf("El lote %s del SKU %s vence en %d día(s) (%s).",
-				lot.LotNumber, lot.SKU, days, lot.ExpirationDate.Format("2006-01-02"))
-		case days <= 8:
-			eventType = "lot_expiring_7d"
-			title = fmt.Sprintf("Lote próximo a vencer: %s (%s)", lot.LotNumber, lot.SKU)
-			body = fmt.Sprintf("El lote %s del SKU %s vence en %d día(s) (%s). Tome acción pronto.",
-				lot.LotNumber, lot.SKU, days, lot.ExpirationDate.Format("2006-01-02"))
-		default:
+	for _, tid := range tenantIDs {
+		var lots []lotRow
+		if err := db.Table("lots").
+			Select("id, lot_number, sku, expiration_date").
+			Where("tenant_id = ? AND expiration_date IS NOT NULL AND expiration_date BETWEEN ? AND ? AND quantity > 0",
+				tid, now, in8days).
+			Scan(&lots).Error; err != nil {
+			// Don't abort the whole run — log and continue so one bad tenant does
+			// not starve every other tenant of expiration alerts.
+			log.Error().Err(err).Str("tenant_id", tid).Msg("cron: lot_expiration: query failed for tenant")
 			continue
 		}
 
-		if notifyFn != nil {
-			if err := notifyFn(eventType, title, body); err != nil {
-				log.Warn().Err(err).Str("lot", lot.LotNumber).Str("event", eventType).Msg("cron: lot_expiration notify failed")
+		for _, lot := range lots {
+			if lot.ExpirationDate == nil {
+				continue
+			}
+			days := int(lot.ExpirationDate.Sub(now).Hours() / 24)
+
+			var eventType, title, body string
+			switch {
+			case days <= 2:
+				eventType = "lot_expiring_1d"
+				title = fmt.Sprintf("⚠ Lote por vencer: %s (%s)", lot.LotNumber, lot.SKU)
+				body = fmt.Sprintf("El lote %s del SKU %s vence en %d día(s) (%s).",
+					lot.LotNumber, lot.SKU, days, lot.ExpirationDate.Format("2006-01-02"))
+			case days <= 8:
+				eventType = "lot_expiring_7d"
+				title = fmt.Sprintf("Lote próximo a vencer: %s (%s)", lot.LotNumber, lot.SKU)
+				body = fmt.Sprintf("El lote %s del SKU %s vence en %d día(s) (%s). Tome acción pronto.",
+					lot.LotNumber, lot.SKU, days, lot.ExpirationDate.Format("2006-01-02"))
+			default:
+				continue
+			}
+
+			if notifyFn != nil {
+				if err := notifyFn(tid, eventType, title, body); err != nil {
+					log.Warn().Err(err).
+						Str("tenant_id", tid).Str("lot", lot.LotNumber).Str("event", eventType).
+						Msg("cron: lot_expiration notify failed")
+				}
 			}
 		}
 	}
@@ -226,8 +245,19 @@ func RunLotExpirationCheck(db *gorm.DB, notifyFn func(eventType, title, body str
 
 // RunLowStockNotifications queries open stock_alerts and calls notifyFn for each unresolved low-stock alert.
 // notifyFn is injected to avoid import cycles with services.
-func RunLowStockNotifications(db *gorm.DB, notifyFn func(sku, message string) error) error {
+//
+// S3.5 W5.5 (HR-S3.5 C3): per-tenant iteration. Same rationale as RunLotExpirationCheck —
+// pre-W5.5 alerts were dispatched globally so a tenant 2 low-stock alert would email tenant 1
+// admins. Now notifyFn receives the tenant_id so the caller can scope the recipient list.
+// A failure for one tenant logs and continues.
+func RunLowStockNotifications(db *gorm.DB, notifyFn func(tenantID, sku, message string) error) error {
 	if db == nil {
+		return nil
+	}
+
+	tenantIDs, err := activeTenantIDs(db)
+	if err != nil {
+		log.Warn().Err(err).Msg("cron: low_stock_notifications: list tenants failed")
 		return nil
 	}
 
@@ -236,21 +266,25 @@ func RunLowStockNotifications(db *gorm.DB, notifyFn func(sku, message string) er
 		Message string `gorm:"column:message"`
 	}
 
-	var alerts []alertRow
-	if err := db.Table("stock_alerts").
-		Select("sku, message").
-		Where("is_resolved = false AND alert_type = 'low_stock'").
-		Order("created_at DESC").
-		Limit(50).
-		Scan(&alerts).Error; err != nil {
-		log.Warn().Err(err).Msg("cron: low_stock_notifications query failed")
-		return nil
-	}
+	for _, tid := range tenantIDs {
+		var alerts []alertRow
+		if err := db.Table("stock_alerts").
+			Select("sku, message").
+			Where("tenant_id = ? AND is_resolved = false AND alert_type = 'low_stock'", tid).
+			Order("created_at DESC").
+			Limit(50).
+			Scan(&alerts).Error; err != nil {
+			log.Warn().Err(err).Str("tenant_id", tid).Msg("cron: low_stock_notifications query failed for tenant")
+			continue
+		}
 
-	for _, a := range alerts {
-		if notifyFn != nil {
-			if err := notifyFn(a.SKU, a.Message); err != nil {
-				log.Warn().Err(err).Str("sku", a.SKU).Msg("cron: low_stock notify failed")
+		for _, a := range alerts {
+			if notifyFn != nil {
+				if err := notifyFn(tid, a.SKU, a.Message); err != nil {
+					log.Warn().Err(err).
+						Str("tenant_id", tid).Str("sku", a.SKU).
+						Msg("cron: low_stock notify failed")
+				}
 			}
 		}
 	}
@@ -407,10 +441,10 @@ func RunTrialExpirationCheck(db *gorm.DB, sendFn func(ctx context.Context, toEma
 //
 // Callbacks (all optional, pass nil to skip):
 //   - analyzer: invoked per active tenant (S3.5 W2-B); receives the tenant UUID string.
-//   - lotNotifyFn: called per expiring lot event (eventType, title, body)
-//   - lowStockNotifyFn: called per unresolved low-stock alert (sku, message)
+//   - lotNotifyFn: called per expiring lot event (tenantID, eventType, title, body) — S3.5 W5.5 per-tenant
+//   - lowStockNotifyFn: called per unresolved low-stock alert (tenantID, sku, message) — S3.5 W5.5 per-tenant
 //   - trialSendFn: called per trial tenant requiring a reminder or expiration email
-func CronDispatch(db *gorm.DB, analyzer func(tenantID string) error, lotNotifyFn func(eventType, title, body string) error, lowStockNotifyFn func(sku, message string) error, trialSendFn func(ctx context.Context, toEmail, tenantName, templateType string, daysLeft int) error) {
+func CronDispatch(db *gorm.DB, analyzer func(tenantID string) error, lotNotifyFn func(tenantID, eventType, title, body string) error, lowStockNotifyFn func(tenantID, sku, message string) error, trialSendFn func(ctx context.Context, toEmail, tenantName, templateType string, daysLeft int) error) {
 	if err := RunStockAlertAnalysis(db, analyzer); err != nil {
 		log.Error().Err(err).Msg("cron: stock alerts failed")
 	}

--- a/tools/cron_per_tenant_test.go
+++ b/tools/cron_per_tenant_test.go
@@ -1,0 +1,183 @@
+// Tests for HR-S3.5 C3 fix: per-tenant iteration in RunLotExpirationCheck and
+// RunLowStockNotifications. Pre-W5.5 these helpers queried lots/stock_alerts
+// globally and dispatched notifications via a single closure, so a tenant 2
+// expiring lot would email tenant 1 admins. Now both helpers iterate active
+// tenants and pass tenant_id into notifyFn so the caller can scope recipients.
+
+package tools
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunLotExpirationCheck_PerTenantIteration is an integration test that:
+//  1. seeds 2 tenants
+//  2. seeds an expiring lot for each tenant
+//  3. calls RunLotExpirationCheck and asserts notifyFn was invoked per tenant,
+//     with the tenant_id matching the lot's tenant — never crossing tenants.
+func TestRunLotExpirationCheck_PerTenantIteration(t *testing.T) {
+	db, cleanup := setupCronTestDB(t)
+	defer cleanup()
+
+	// Seed two tenants.
+	tenantA := cronSeedTenant(t, db, "tenant-a", "active", time.Now().UTC().AddDate(1, 0, 0))
+	tenantB := cronSeedTenant(t, db, "tenant-b", "active", time.Now().UTC().AddDate(1, 0, 0))
+
+	// Seed one expiring lot per tenant. lots requires an article; reuse cronSeedInventory
+	// which creates the article row, then INSERT lots directly.
+	cronSeedInventory(t, db, "SKU-EXP-A", "LOC-1", 100, 0)
+	cronSeedInventory(t, db, "SKU-EXP-B", "LOC-1", 100, 0)
+
+	exp := time.Now().UTC().AddDate(0, 0, 5) // 5 days out → in window
+
+	idA, err := GenerateNanoid(db)
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`
+		INSERT INTO lots (id, tenant_id, lot_number, sku, expiration_date, quantity, created_at, updated_at)
+		VALUES (?, ?::uuid, 'LOT-A-001', 'SKU-EXP-A', ?, 50, NOW(), NOW())`,
+		idA, tenantA, exp).Error)
+
+	idB, err := GenerateNanoid(db)
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`
+		INSERT INTO lots (id, tenant_id, lot_number, sku, expiration_date, quantity, created_at, updated_at)
+		VALUES (?, ?::uuid, 'LOT-B-001', 'SKU-EXP-B', ?, 50, NOW(), NOW())`,
+		idB, tenantB, exp).Error)
+
+	// notifyFn records which tenant + lot was notified.
+	var mu sync.Mutex
+	type call struct{ tenantID, eventType, title string }
+	var calls []call
+	notifyFn := func(tenantID, eventType, title, body string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, call{tenantID, eventType, title})
+		return nil
+	}
+
+	require.NoError(t, RunLotExpirationCheck(db, notifyFn))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, calls, 2, "must notify exactly once per tenant — see HR-S3.5 C3")
+
+	// Verify each call's tenant matches the lot's tenant: no cross-tenant leak.
+	tenantsSeen := map[string]bool{}
+	for _, c := range calls {
+		tenantsSeen[c.tenantID] = true
+		switch c.tenantID {
+		case tenantA:
+			assert.Contains(t, c.title, "LOT-A-001", "tenant A must receive its OWN lot notification")
+		case tenantB:
+			assert.Contains(t, c.title, "LOT-B-001", "tenant B must receive its OWN lot notification")
+		default:
+			t.Errorf("unexpected tenant in notify call: %s", c.tenantID)
+		}
+	}
+	assert.True(t, tenantsSeen[tenantA], "tenant A must be notified")
+	assert.True(t, tenantsSeen[tenantB], "tenant B must be notified")
+}
+
+// TestRunLowStockNotifications_PerTenantIteration mirrors the lot test for the
+// low-stock alert helper.
+func TestRunLowStockNotifications_PerTenantIteration(t *testing.T) {
+	db, cleanup := setupCronTestDB(t)
+	defer cleanup()
+
+	tenantA := cronSeedTenant(t, db, "alert-tenant-a", "active", time.Now().UTC().AddDate(1, 0, 0))
+	tenantB := cronSeedTenant(t, db, "alert-tenant-b", "active", time.Now().UTC().AddDate(1, 0, 0))
+
+	// Seed one unresolved low_stock alert per tenant.
+	idA, err := GenerateNanoid(db)
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`
+		INSERT INTO stock_alerts (id, tenant_id, sku, alert_type, message, is_resolved, created_at, updated_at)
+		VALUES (?, ?::uuid, 'SKU-LOW-A', 'low_stock', 'tenant A low stock', false, NOW(), NOW())`,
+		idA, tenantA).Error)
+
+	idB, err := GenerateNanoid(db)
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`
+		INSERT INTO stock_alerts (id, tenant_id, sku, alert_type, message, is_resolved, created_at, updated_at)
+		VALUES (?, ?::uuid, 'SKU-LOW-B', 'low_stock', 'tenant B low stock', false, NOW(), NOW())`,
+		idB, tenantB).Error)
+
+	var mu sync.Mutex
+	type call struct{ tenantID, sku, message string }
+	var calls []call
+	notifyFn := func(tenantID, sku, message string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, call{tenantID, sku, message})
+		return nil
+	}
+
+	require.NoError(t, RunLowStockNotifications(db, notifyFn))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, calls, 2, "must notify exactly once per tenant — HR-S3.5 C3")
+
+	for _, c := range calls {
+		switch c.tenantID {
+		case tenantA:
+			assert.Equal(t, "SKU-LOW-A", c.sku)
+			assert.Contains(t, c.message, "tenant A")
+		case tenantB:
+			assert.Equal(t, "SKU-LOW-B", c.sku)
+			assert.Contains(t, c.message, "tenant B")
+		default:
+			t.Errorf("unexpected tenant in notify call: %s", c.tenantID)
+		}
+	}
+}
+
+// TestRunLotExpirationCheck_PerTenantErrorContinues verifies the resilience
+// contract: when notifyFn returns an error for one tenant, the next tenant still
+// gets processed (no all-or-nothing failure).
+func TestRunLotExpirationCheck_PerTenantErrorContinues(t *testing.T) {
+	db, cleanup := setupCronTestDB(t)
+	defer cleanup()
+
+	tenantA := cronSeedTenant(t, db, "err-tenant-a", "active", time.Now().UTC().AddDate(1, 0, 0))
+	tenantB := cronSeedTenant(t, db, "err-tenant-b", "active", time.Now().UTC().AddDate(1, 0, 0))
+
+	cronSeedInventory(t, db, "SKU-ERR-A", "LOC-1", 100, 0)
+	cronSeedInventory(t, db, "SKU-ERR-B", "LOC-1", 100, 0)
+	exp := time.Now().UTC().AddDate(0, 0, 5)
+
+	for _, x := range []struct{ tid, sku string }{{tenantA, "SKU-ERR-A"}, {tenantB, "SKU-ERR-B"}} {
+		id, err := GenerateNanoid(db)
+		require.NoError(t, err)
+		require.NoError(t, db.Exec(`
+			INSERT INTO lots (id, tenant_id, lot_number, sku, expiration_date, quantity, created_at, updated_at)
+			VALUES (?, ?::uuid, ?, ?, ?, 50, NOW(), NOW())`,
+			id, x.tid, "LOT-"+x.sku, x.sku, exp).Error)
+	}
+
+	var mu sync.Mutex
+	tenantsCalled := map[string]int{}
+	notifyFn := func(tenantID, eventType, title, body string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		tenantsCalled[tenantID]++
+		// Simulate failure for tenant A — tenant B must still receive its notification.
+		if tenantID == tenantA {
+			return assert.AnError
+		}
+		return nil
+	}
+
+	require.NoError(t, RunLotExpirationCheck(db, notifyFn),
+		"a per-tenant notify error must not propagate as a top-level failure")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, tenantsCalled[tenantA], "tenant A's notify was invoked once (and errored — logged)")
+	assert.Equal(t, 1, tenantsCalled[tenantB], "tenant B must still receive notification despite tenant A's error")
+}

--- a/tools/token_tool.go
+++ b/tools/token_tool.go
@@ -71,6 +71,22 @@ func TenantIDFromContext(c *gin.Context) string {
 	return s
 }
 
+// ResolveTenantID returns the tenant for this request: JWT claim first, fallback only
+// if the claim is missing. Returns "" iff there is no tenant available — callers MUST
+// then return 401 to avoid leaking another tenant's data via the env var fallback.
+//
+// S3.5 W5.5 (HR-S3.5 C1): every tenant-scoped controller uses this helper to source
+// the tenant from the JWT instead of the env-injected Config.TenantID. The fallback
+// covers system/cron/admin paths that bypass JWTAuthMiddleware (e.g. test rigs that
+// pre-construct a controller with a default tenant); HTTP requests behind
+// JWTAuthMiddleware always get the JWT claim.
+func ResolveTenantID(c *gin.Context, fallback string) string {
+	if t := TenantIDFromContext(c); t != "" {
+		return t
+	}
+	return fallback
+}
+
 func GetUserId(secret string, tokenString string) (string, error) {
 	if len(tokenString) > 7 && strings.HasPrefix(tokenString, "Bearer ") {
 		tokenString = tokenString[7:]


### PR DESCRIPTION
## Summary

Fixes the three CRITICAL bugs found in the S3.5 hostile retro that block deploying v0.2.1 with `ENABLE_SIGNUP=true`. Together they were the headline reason the deploy was BLOCK-DEPLOY: the JWT tenant claim plumbing landed in W3 but nothing actually consumed it, so every authenticated request was being served from `Config.TenantID` regardless of which tenant the JWT belonged to.

C4 (inventory + inventory_movements tenant_id) is structural and remains deferred to S3.6.

### C1 — Controllers source tenant from JWT claim, not env (commit 45d39fb)

Pre-W5.5 every tenant-scoped controller read `c.TenantID` directly — a field set at startup from `Config.TenantID`. Only `BillingController` actually consulted the JWT claim.

- Added `tools.ResolveTenantID(ctx, fallback)` — JWT-first with env fallback.
- 17 controllers refactored: articles, lots, locations, serials, stock_alerts, clients, categories, stock_settings, adjustments, receiving_tasks, picking_tasks, delivery_notes, purchase_orders, sales_orders, backorders, notifications, plus billing (already wired since W3).
- Each controller gained a private `resolveTenantID(ctx)` helper. The `TenantID` struct field stays as the non-JWT fallback for cron/admin/test paths.

### C2 — Login stamps user.TenantID into JWT, not Config.TenantID (commit 83f64a6)

Login was issuing JWTs with `Config.TenantID` because users had no `tenant_id` of their own.

- New migration 000035: `users.tenant_id UUID NOT NULL`, default backfill to `00000000-0000-0000-0000-000000000001` (consistent with 000019/000023/000029-34), drop default, composite `(tenant_id, email)` index.
- `models/database/users.go`: `TenantID` field added.
- `AuthenticationRepository.Login`: read tenant claim from `user.TenantID` with `Config.TenantID` as defense-in-depth fallback for empty legacy rows.
- `SignupRepository.VerifySignup`: stamp the freshly-created tenant's UUID onto the new admin user.
- `tools.admin_seeder` + `UsersRepository.CreateUser`/`ImportUsersFromExcel` updated; user-creation paths now thread tenantID sourced from the JWT.
- `db/sqlc/models.go` regenerated (clean diff: just `TenantID pgtype.UUID`).

### C3 — Per-tenant cron for lot expiration + low-stock notifications (commit 922c9c9)

`RunStockAlertAnalysis` was made per-tenant in W2-B, but the two sibling helpers were still global. A tenant 2 expiring lot would email tenant 1's admins.

- `tools/cron.go`: both helpers now iterate `activeTenantIDs(db)` and pass `tenantID` into `notifyFn`. Per-tenant errors log and continue (one bad tenant cannot starve the others).
- `notifyFn` signatures gained leading `tenantID` parameter.
- `cmd/main.go`: closures now query admin user IDs scoped by `users.tenant_id = ?`.

## Validation

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./... -short -race -count=1` all pass
- `sqlc generate` zero diff (only the expected `users.tenant_id` addition was committed in C2)

New tests (~14):
- `controllers/tenant_resolution_test.go` — 5 tests covering `tools.ResolveTenantID` + 3 controller spot-checks (articles/lots/stock_alerts).
- `repositories/authentication_repository_tenant_test.go` — 3 tests: login embeds user.TenantID + legacy fallback + signup admin invariant.
- `tools/cron_per_tenant_test.go` — 3 integration tests (testcontainers, skipped in -short): per-tenant lot iteration, per-tenant low-stock iteration, per-tenant error continues.

## Out of scope (deferred)

- C4 — inventory + inventory_movements tenant_id (structural, S3.6).
- M1 — 8-hex `tenantPrefix` collision risk (accept for now, document).
- M2 — 100-day JWT TTL + revocation (separate sprint).
- M4 — trial off-by-one (minor, hotfix later).
- M5 — Stripe customer name = UUID (minor UX).

## Test plan

- [ ] CI: `go build`, `go vet`, `go test -short -race`, `sqlc generate` zero diff
- [ ] Apply 000035 against a dev clone of prod and verify legacy users land in tenant 1 (default backfill)
- [ ] In dev: create tenant A and tenant B via `/api/signup`, log in as each, hit `GET /api/articles/`, assert each sees ONLY their own catalog
- [ ] In dev: trigger `/admin/cron/trigger?job=stock_alerts` after seeding cross-tenant alerts; verify each tenant's admins receive only their own tenant's notifications
- [ ] Verify `BillingController` still works (it was already JWT-aware; this PR did not touch it)

Refs: `plans/sessions/hostile-reviews/HR-S3.5-FULL-RETRO.md`