### PR TITLE
fix(s3.5.1): CORS allowlist + rate-limit headers (M1+M2 QA E2E findings)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,3 +94,14 @@ STRIPE_WEBHOOK_SECRET=whsec_...
 STRIPE_PRICE_STARTER=price_...
 STRIPE_PRICE_PRO=price_...
 STRIPE_PRICE_ENTERPRISE=price_...
+
+# =============================================================================
+# CORS (S3.5.1 hotfix)
+# =============================================================================
+# Comma-separated allowlist of origins that may call the API with credentials.
+# When unset, falls back to a safe default:
+#   https://estock.eflowsuite.com, https://estock-qa.eflowsuite.com,
+#   https://estock-dev.eflowsuite.com, http://localhost:4200, http://localhost:5173
+# The middleware reflects the request Origin only when it matches this list;
+# Access-Control-Allow-Origin is NEVER "*" (browsers reject "*" with credentials).
+# ALLOWED_ORIGINS=https://estock.eflowsuite.com,http://localhost:4200

--- a/tools/cors_tool.go
+++ b/tools/cors_tool.go
@@ -1,16 +1,104 @@
 package tools
 
-import "github.com/gin-gonic/gin"
+import (
+	"net/http"
+	"os"
+	"strings"
+	"sync"
 
+	"github.com/gin-gonic/gin"
+)
+
+// defaultAllowedOrigins is the conservative allowlist used when the
+// ALLOWED_ORIGINS env var is empty. Covers prod/qa/dev hosted envs and
+// common local dev servers (Angular CLI 4200, Vite 5173).
+var defaultAllowedOrigins = []string{
+	"https://estock.eflowsuite.com",
+	"https://estock-qa.eflowsuite.com",
+	"https://estock-dev.eflowsuite.com",
+	"http://localhost:4200",
+	"http://localhost:5173",
+}
+
+var (
+	allowedOriginsOnce sync.Once
+	allowedOriginsSet  map[string]struct{}
+)
+
+// loadAllowedOrigins reads ALLOWED_ORIGINS once (comma-separated). Trims spaces
+// and skips empty entries. Falls back to defaultAllowedOrigins when unset/empty.
+func loadAllowedOrigins() map[string]struct{} {
+	allowedOriginsOnce.Do(func() {
+		raw := strings.TrimSpace(os.Getenv("ALLOWED_ORIGINS"))
+		set := make(map[string]struct{})
+		if raw == "" {
+			for _, o := range defaultAllowedOrigins {
+				set[o] = struct{}{}
+			}
+		} else {
+			for _, part := range strings.Split(raw, ",") {
+				origin := strings.TrimSpace(part)
+				if origin != "" {
+					set[origin] = struct{}{}
+				}
+			}
+		}
+		allowedOriginsSet = set
+	})
+	return allowedOriginsSet
+}
+
+// resetAllowedOriginsForTest is a test-only hook to reset the once-initialized
+// allowlist. It MUST NOT be called outside *_test.go files.
+func resetAllowedOriginsForTest() {
+	allowedOriginsOnce = sync.Once{}
+	allowedOriginsSet = nil
+}
+
+// isOriginAllowed returns true when the request Origin is in the allowlist.
+func isOriginAllowed(origin string) bool {
+	if origin == "" {
+		return false
+	}
+	_, ok := loadAllowedOrigins()[origin]
+	return ok
+}
+
+// CORSMiddleware enforces CORS with an explicit allowlist. It reflects the
+// request Origin header back when allowed (never `*`) so it can be safely
+// combined with Allow-Credentials: true (browsers reject `*` + credentials).
+//
+// Allowlist source: ALLOWED_ORIGINS env var (comma-separated). When unset,
+// uses the safe default list (prod/qa/dev/localhost).
+//
+// Behavior:
+//   - Allowed Origin: reflects Origin in Allow-Origin, sets Allow-Credentials,
+//     Allow-Headers, Allow-Methods, and Vary: Origin.
+//   - Disallowed/missing Origin on non-preflight: passes through with no CORS
+//     headers (browser will block the response, which is the correct CORS reject).
+//   - OPTIONS preflight from disallowed Origin: 403.
+//   - OPTIONS preflight from allowed Origin: 204 with full CORS headers.
 func CORSMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		c.Header("Access-Control-Allow-Origin", "*")
-		c.Header("Access-Control-Allow-Credentials", "true")
-		c.Header("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With")
-		c.Header("Access-Control-Allow-Methods", "POST, HEAD, PATCH, OPTIONS, GET, PUT, DELETE")
+		origin := c.GetHeader("Origin")
+		allowed := isOriginAllowed(origin)
 
-		if c.Request.Method == "OPTIONS" {
-			c.AbortWithStatus(204)
+		// Vary: Origin so caches don't serve a CORS response for the wrong origin.
+		c.Header("Vary", "Origin")
+
+		if allowed {
+			c.Header("Access-Control-Allow-Origin", origin)
+			c.Header("Access-Control-Allow-Credentials", "true")
+			c.Header("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With")
+			c.Header("Access-Control-Allow-Methods", "POST, HEAD, PATCH, OPTIONS, GET, PUT, DELETE")
+		}
+
+		if c.Request.Method == http.MethodOptions {
+			if !allowed {
+				c.AbortWithStatus(http.StatusForbidden)
+				return
+			}
+			c.AbortWithStatus(http.StatusNoContent)
 			return
 		}
 

--- a/tools/cors_tool_test.go
+++ b/tools/cors_tool_test.go
@@ -1,0 +1,156 @@
+package tools
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// newCORSTestRouter builds a minimal Gin router with the CORS middleware and
+// a single GET /ping handler that returns 200 OK.
+func newCORSTestRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+	resetAllowedOriginsForTest()
+	t.Setenv("ALLOWED_ORIGINS", "https://estock.eflowsuite.com,http://localhost:4200")
+	r := gin.New()
+	r.Use(CORSMiddleware())
+	r.GET("/ping", func(c *gin.Context) { c.String(http.StatusOK, "pong") })
+	r.OPTIONS("/ping", func(c *gin.Context) { c.Status(http.StatusNoContent) })
+	return r
+}
+
+func TestCORS_ReflectsAllowedOrigin(t *testing.T) {
+	r := newCORSTestRouter(t)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	req.Header.Set("Origin", "https://estock.eflowsuite.com")
+	r.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://estock.eflowsuite.com" {
+		t.Fatalf("expected Allow-Origin to reflect request Origin, got %q", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Fatalf("expected Allow-Credentials=true, got %q", got)
+	}
+	if got := w.Header().Get("Vary"); got != "Origin" {
+		t.Fatalf("expected Vary: Origin, got %q", got)
+	}
+}
+
+func TestCORS_RejectsUnknownOrigin(t *testing.T) {
+	r := newCORSTestRouter(t)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	r.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("expected no Allow-Origin for unknown origin, got %q", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "" {
+		t.Fatalf("expected no Allow-Credentials for unknown origin, got %q", got)
+	}
+	// Non-preflight passes through to handler (browser will reject the response).
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected handler to run for non-preflight unknown origin, got status %d", w.Code)
+	}
+}
+
+func TestCORS_AllowsCredentialsOnlyWithSpecificOrigin(t *testing.T) {
+	r := newCORSTestRouter(t)
+	// Sweep several origins (allowed + denied) and assert: when Allow-Credentials
+	// is present, Allow-Origin MUST be a specific origin, never "*".
+	cases := []struct {
+		origin     string
+		shouldPass bool
+	}{
+		{"https://estock.eflowsuite.com", true},
+		{"http://localhost:4200", true},
+		{"https://attacker.example.com", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+		if c.origin != "" {
+			req.Header.Set("Origin", c.origin)
+		}
+		r.ServeHTTP(w, req)
+
+		ao := w.Header().Get("Access-Control-Allow-Origin")
+		if ao == "*" {
+			t.Fatalf("origin %q: Allow-Origin must NEVER be \"*\" when credentials are in play", c.origin)
+		}
+		creds := w.Header().Get("Access-Control-Allow-Credentials")
+		if creds == "true" && ao == "" {
+			t.Fatalf("origin %q: Allow-Credentials=true without Allow-Origin (spec violation)", c.origin)
+		}
+		if c.shouldPass {
+			if ao != c.origin {
+				t.Fatalf("origin %q: expected reflected, got %q", c.origin, ao)
+			}
+		} else {
+			if ao != "" {
+				t.Fatalf("origin %q: expected no Allow-Origin, got %q", c.origin, ao)
+			}
+		}
+	}
+}
+
+func TestCORS_PreflightRejectsUnknownOrigin(t *testing.T) {
+	r := newCORSTestRouter(t)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/ping", nil)
+	req.Header.Set("Origin", "https://attacker.example.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for unknown-origin preflight, got %d", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("expected no Allow-Origin on rejected preflight, got %q", got)
+	}
+}
+
+func TestCORS_PreflightAllowsKnownOrigin(t *testing.T) {
+	r := newCORSTestRouter(t)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/ping", nil)
+	req.Header.Set("Origin", "https://estock.eflowsuite.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 for allowed-origin preflight, got %d", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://estock.eflowsuite.com" {
+		t.Fatalf("expected reflected Allow-Origin, got %q", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Methods"); got == "" {
+		t.Fatalf("expected Allow-Methods on preflight, got empty")
+	}
+}
+
+func TestCORS_DefaultAllowlistWhenEnvUnset(t *testing.T) {
+	resetAllowedOriginsForTest()
+	t.Setenv("ALLOWED_ORIGINS", "")
+	r := gin.New()
+	r.Use(CORSMiddleware())
+	r.GET("/ping", func(c *gin.Context) { c.String(http.StatusOK, "pong") })
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	req.Header.Set("Origin", "https://estock.eflowsuite.com")
+	r.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://estock.eflowsuite.com" {
+		t.Fatalf("expected default allowlist to permit prod origin, got %q", got)
+	}
+}

--- a/tools/rate_limit_middleware.go
+++ b/tools/rate_limit_middleware.go
@@ -1,7 +1,9 @@
 package tools
 
 import (
+	"math"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -61,17 +63,83 @@ func (rl *IPRateLimiter) cleanupLoop() {
 	}
 }
 
+// secondsPerToken returns the time (seconds) it takes to refill one token.
+// Returns 0 if the rate is non-positive (degenerate config).
+func (rl *IPRateLimiter) secondsPerToken() float64 {
+	if rl.r <= 0 {
+		return 0
+	}
+	return 1.0 / float64(rl.r)
+}
+
+// computeHeaders derives the X-RateLimit-* values for a given limiter snapshot.
+// Returns (remaining, resetUnix, retryAfterSeconds). retryAfterSeconds is >= 1
+// when remaining == 0, otherwise 0 (caller decides whether to emit it).
+func (rl *IPRateLimiter) computeHeaders(lim *rate.Limiter, now time.Time) (int, int64, int) {
+	tokens := lim.TokensAt(now)
+	if tokens < 0 {
+		tokens = 0
+	}
+	remaining := int(math.Floor(tokens))
+	if remaining > rl.b {
+		remaining = rl.b
+	}
+
+	spt := rl.secondsPerToken()
+	// Reset = time when bucket is fully refilled to burst capacity.
+	missing := float64(rl.b) - tokens
+	if missing < 0 {
+		missing = 0
+	}
+	resetSeconds := missing * spt
+	resetAt := now.Add(time.Duration(resetSeconds * float64(time.Second))).Unix()
+
+	retryAfter := 0
+	if remaining == 0 {
+		// Time until next single token is available.
+		secsUntilNext := (1.0 - tokens) * spt
+		if secsUntilNext < 1 {
+			secsUntilNext = 1
+		}
+		retryAfter = int(math.Ceil(secsUntilNext))
+	}
+	return remaining, resetAt, retryAfter
+}
+
 // NewIPRateLimiter returns a Gin middleware that limits each client IP to r requests
 // per second with a burst of b. Excess requests receive HTTP 429.
+//
+// Every response (allowed or 429) carries:
+//   - X-RateLimit-Limit:     burst capacity
+//   - X-RateLimit-Remaining: tokens left after this request
+//   - X-RateLimit-Reset:     unix timestamp when bucket is fully refilled
+//
+// On 429 only, the response also carries:
+//   - Retry-After: seconds until the next token is available (RFC 6585, integer)
 //
 // Example — 5 requests per minute with burst of 5:
 //
 //	tools.NewIPRateLimiter(rate.Every(time.Minute/5), 5)
 func NewIPRateLimiter(r rate.Limit, b int) gin.HandlerFunc {
 	rl := newIPRateLimiter(r, b)
+	limitStr := strconv.Itoa(b)
 	return func(ctx *gin.Context) {
 		ip := ctx.ClientIP()
-		if !rl.get(ip).Allow() {
+		lim := rl.get(ip)
+		now := time.Now()
+		allowed := lim.AllowN(now, 1)
+
+		remaining, resetAt, retryAfter := rl.computeHeaders(lim, now)
+
+		ctx.Header("X-RateLimit-Limit", limitStr)
+		ctx.Header("X-RateLimit-Remaining", strconv.Itoa(remaining))
+		ctx.Header("X-RateLimit-Reset", strconv.FormatInt(resetAt, 10))
+
+		if !allowed {
+			if retryAfter < 1 {
+				retryAfter = 1
+			}
+			ctx.Header("Retry-After", strconv.Itoa(retryAfter))
 			ctx.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
 				"error":   "too_many_requests",
 				"message": "Rate limit exceeded. Please wait before retrying.",

--- a/tools/rate_limit_middleware_test.go
+++ b/tools/rate_limit_middleware_test.go
@@ -1,0 +1,113 @@
+package tools
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
+)
+
+// newRateLimitTestRouter wires the rate limit middleware to a /ping handler
+// from a fixed client IP (set via X-Forwarded-For requires TrustedProxies setup,
+// so we just rely on Gin's RemoteAddr-based ClientIP).
+func newRateLimitTestRouter(t *testing.T, r rate.Limit, b int) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(NewIPRateLimiter(r, b))
+	router.GET("/ping", func(c *gin.Context) { c.String(http.StatusOK, "pong") })
+	return router
+}
+
+func doRateLimitedReq(router *gin.Engine) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestRateLimit_ResponseIncludesXRateLimitHeaders(t *testing.T) {
+	// 5 tokens burst, very slow refill so token count stays predictable.
+	router := newRateLimitTestRouter(t, rate.Every(time.Hour), 5)
+
+	w := doRateLimitedReq(router)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 on first request, got %d", w.Code)
+	}
+	if got := w.Header().Get("X-RateLimit-Limit"); got != "5" {
+		t.Fatalf("expected X-RateLimit-Limit=5, got %q", got)
+	}
+	if got := w.Header().Get("X-RateLimit-Remaining"); got == "" {
+		t.Fatalf("expected X-RateLimit-Remaining present, got empty")
+	}
+	if got := w.Header().Get("X-RateLimit-Reset"); got == "" {
+		t.Fatalf("expected X-RateLimit-Reset present, got empty")
+	}
+	resetUnix, err := strconv.ParseInt(w.Header().Get("X-RateLimit-Reset"), 10, 64)
+	if err != nil {
+		t.Fatalf("X-RateLimit-Reset must be integer unix ts, got %v: %v", w.Header().Get("X-RateLimit-Reset"), err)
+	}
+	if resetUnix < time.Now().Unix() {
+		t.Fatalf("X-RateLimit-Reset should be in the future or now, got %d (now=%d)", resetUnix, time.Now().Unix())
+	}
+}
+
+func TestRateLimit_429IncludesRetryAfter(t *testing.T) {
+	// burst=2 so we exhaust quickly.
+	router := newRateLimitTestRouter(t, rate.Every(time.Hour), 2)
+	// Drain bucket.
+	_ = doRateLimitedReq(router)
+	_ = doRateLimitedReq(router)
+	// Third request should 429.
+	w := doRateLimitedReq(router)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 on exhaustion, got %d", w.Code)
+	}
+	ra := w.Header().Get("Retry-After")
+	if ra == "" {
+		t.Fatalf("expected Retry-After header on 429, got empty")
+	}
+	secs, err := strconv.Atoi(ra)
+	if err != nil {
+		t.Fatalf("Retry-After must be integer seconds (RFC 6585), got %q: %v", ra, err)
+	}
+	if secs < 1 {
+		t.Fatalf("Retry-After must be >= 1 second, got %d", secs)
+	}
+	// X-RateLimit-* headers should still be present on 429.
+	if got := w.Header().Get("X-RateLimit-Limit"); got != "2" {
+		t.Fatalf("expected X-RateLimit-Limit=2 on 429, got %q", got)
+	}
+	if got := w.Header().Get("X-RateLimit-Remaining"); got != "0" {
+		t.Fatalf("expected X-RateLimit-Remaining=0 on 429, got %q", got)
+	}
+}
+
+func TestRateLimit_RemainingDecrementsCorrectly(t *testing.T) {
+	// burst=5, refill so slow it doesn't matter for the test window.
+	router := newRateLimitTestRouter(t, rate.Every(time.Hour), 5)
+	want := []string{"4", "3", "2", "1", "0"}
+	for i, w := range want {
+		resp := doRateLimitedReq(router)
+		if resp.Code != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d", i+1, resp.Code)
+		}
+		got := resp.Header().Get("X-RateLimit-Remaining")
+		if got != w {
+			t.Fatalf("request %d: expected X-RateLimit-Remaining=%s, got %s", i+1, w, got)
+		}
+	}
+	// Sixth request must 429 with Remaining=0.
+	resp := doRateLimitedReq(router)
+	if resp.Code != http.StatusTooManyRequests {
+		t.Fatalf("6th request: expected 429, got %d", resp.Code)
+	}
+	if got := resp.Header().Get("X-RateLimit-Remaining"); got != "0" {
+		t.Fatalf("6th request: expected Remaining=0, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Hotfix S3.5.1 addressing the two MAJOR findings from QA E2E v0.2.1 (`reports/2026-04-25-qa-e2e-v0.2.1.md`).

### M1 — CORS misconfiguration
- **Files**: `tools/cors_tool.go`, `tools/cors_tool_test.go`, `.env.example`
- **Before**: `Access-Control-Allow-Origin: *` + `Allow-Credentials: true` simultaneously (browser spec violation; latent breakage for cookie/credential flows; arbitrary origins could embed the API).
- **After**: middleware reflects the request `Origin` only when present in an allowlist. `Allow-Origin` is **never** `*`. Disallowed-origin preflights return 403; allowed-origin preflights return 204 with full CORS headers. `Vary: Origin` added so caches behave.
- **Allowlist** (env-driven, with safe default):
  - Env var: `ALLOWED_ORIGINS` (comma-separated)
  - Default when unset: `https://estock.eflowsuite.com`, `https://estock-qa.eflowsuite.com`, `https://estock-dev.eflowsuite.com`, `http://localhost:4200`, `http://localhost:5173`
- **Tests added (5)**: `TestCORS_ReflectsAllowedOrigin`, `TestCORS_RejectsUnknownOrigin`, `TestCORS_AllowsCredentialsOnlyWithSpecificOrigin`, `TestCORS_PreflightRejectsUnknownOrigin`, `TestCORS_PreflightAllowsKnownOrigin`, `TestCORS_DefaultAllowlistWhenEnvUnset` (6 total).

### M2 — Rate limiter without `Retry-After` / `X-RateLimit-*`
- **Files**: `tools/rate_limit_middleware.go`, `tools/rate_limit_middleware_test.go`
- **Before**: 429 response was bare JSON; clients had no way to backoff intelligently.
- **After**: every response (200 and 429) carries `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` (unix ts). 429 additionally carries `Retry-After` (RFC 6585, integer seconds, always >= 1). Computed from `rate.Limiter.TokensAt` — no extra state.
- **Tests added (3)**: `TestRateLimit_ResponseIncludesXRateLimitHeaders`, `TestRateLimit_429IncludesRetryAfter`, `TestRateLimit_RemainingDecrementsCorrectly`.

## Pre-push validation gates (MSSO v2.1)

- [x] `grep -rn "<<<<<<<\|>>>>>>>"` — 0 matches
- [x] `go build ./...` — 0 errors
- [x] `go vet ./...` — 0 issues
- [x] `go test -short -race -count=1 ./...` — all packages pass (controllers, models/database, repositories, services, tools)
- [x] `make sqlc` — 0 diff
- [x] `git status -s` — only CORS + rate-limit files staged

## Test plan

- [ ] After merge + deploy to QA: `curl -sI -H 'Origin: https://estock-qa.eflowsuite.com' https://api.estock-qa.eflowsuite.com/health` → `Access-Control-Allow-Origin: https://estock-qa.eflowsuite.com` (NOT `*`).
- [ ] `curl -sI -H 'Origin: https://attacker.example' https://api.estock-qa.eflowsuite.com/health` → no `Access-Control-Allow-Origin` header.
- [ ] `curl -sI -X OPTIONS -H 'Origin: https://attacker.example' https://api.estock-qa.eflowsuite.com/health` → 403.
- [ ] Spam `POST /api/signup` from same IP → after 5 requests, 429 with `Retry-After: <int>` header and `X-RateLimit-Remaining: 0`.
- [ ] Frontend smoke (estock-qa): login + an authenticated read still works (no regression on auth flow).

## Deploy notes

- `ALLOWED_ORIGINS` is **optional** in env; unset behavior matches the prod allowlist already, so no Helm/k8s manifest change is strictly required to deploy. Recommended: set it explicitly per env to match each frontend host (overrides default).
- No SQL/schema changes. No breaking API changes. Safe rolling deploy.