### PR TITLE
fix(s3.5.2): signup Admin role + SMTP observability (N1+N2 QA E2E)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,22 @@ APP_URL=http://localhost:4200
 # Resend from address (optional; defaults to noreply@estock.app)
 # RESEND_FROM_ADDRESS=noreply@yourdomain.com
 
+# -----------------------------------------------------------------------------
+# SMTP (S3.5.2 N2 — required for signup verify emails + notifications)
+# -----------------------------------------------------------------------------
+# eSTOCK currently delivers email via Resend (RESEND_API_KEY above). The SMTP_*
+# vars below are the canonical signal that "email delivery is configured" and
+# are reserved for the future SMTP-direct sender. If BOTH RESEND_API_KEY and
+# SMTP_HOST are unset in production, emails are skipped silently and the signup
+# verify token is logged to stdout (see startup warning + signup token fallback
+# logging in cmd/main.go and repositories/signup_repository.go).
+# SMTP_HOST=
+# SMTP_PORT=587
+# SMTP_USER=
+# SMTP_PASSWORD=
+# SMTP_FROM=noreply@<your-domain>
+# SMTP_TLS=true
+
 # =============================================================================
 # MULTI-TENANT (S2 — single-tenant default)
 # =============================================================================

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,6 +38,15 @@ func main() {
 		gin.SetMode(gin.ReleaseMode)
 	}
 
+	// S3.5.2 N2 (Part B): SMTP/email observability. The pod silently skipping signup
+	// verify emails was undetectable until QA caught it in prod. Make the misconfig
+	// loud at startup so ops sees it on first log read instead of debugging a stuck
+	// signup hours later. We treat either RESEND_API_KEY or SMTP_HOST as "email
+	// configured"; only warn if both are empty.
+	if os.Getenv("SMTP_HOST") == "" && config.ResendAPIKey == "" {
+		log.Warn().Msg("SMTP_HOST and RESEND_API_KEY both unset — signup verify emails will be skipped. Tokens will be logged to stdout for ops debugging.")
+	}
+
 	dbURL := configuration.DatabaseURL(config)
 	if err := tools.RunMigrations(config.MigrationURL, dbURL); err != nil {
 		log.Fatal().Err(err).Msg("migrations failed")

--- a/repositories/signup_integration_test.go
+++ b/repositories/signup_integration_test.go
@@ -284,6 +284,98 @@ func TestSeedFarma_Idempotent(t *testing.T) {
 	assert.EqualValues(t, 50, count, "exactly 50 farma articles should exist for tenant")
 }
 
+// ─── S3.5.2 N1: AssignsAdminRole ─────────────────────────────────────────────
+// Regression test for the prod bug where new tenant admins received the
+// "Operator" role because the case-sensitive `name = 'admin'` lookup missed
+// the canonical capitalized "Admin" row inserted by migration 000016.
+
+func TestSignup_AssignsAdminRole(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	// Do NOT seed an extra lower-case "admin" role — rely on the canonical
+	// capitalized "Admin" row from migration 000016. This mirrors prod and
+	// reproduces the exact condition that triggered N1.
+
+	// Discover the canonical Admin role id so we can assert against it.
+	var adminRole database.Role
+	require.NoError(t, db.Where("LOWER(name) = ?", "admin").First(&adminRole).Error,
+		"migration 000016 should have inserted Admin role")
+
+	repo := signupRepo(db)
+	ctx := context.Background()
+
+	req := requests.SignupRequest{
+		Email:         "n1.assignsadmin@test.com",
+		CompanyName:   "N1 Admin Co",
+		TenantSlug:    "n1adminco",
+		AdminName:     "N1 Admin",
+		AdminPassword: "TestP@ssw0rd!",
+	}
+	require.Nil(t, repo.InitiateSignup(ctx, req))
+
+	var st database.SignupToken
+	require.NoError(t, db.Where("LOWER(email) = LOWER(?)", req.Email).First(&st).Error)
+
+	result, errResp := repo.VerifySignup(ctx, st.Token)
+	require.Nil(t, errResp)
+	require.NotNil(t, result)
+
+	var user database.User
+	require.NoError(t, db.Where("LOWER(email) = LOWER(?)", req.Email).First(&user).Error)
+	assert.Equal(t, adminRole.ID, user.RoleID,
+		"new tenant admin must be assigned the Admin role, not Operator/Viewer/etc")
+}
+
+// ─── S3.5.2 N1: FailsLoudIfNoAdminRole ───────────────────────────────────────
+// Regression test for the silent-fallback bug. With no admin role present the
+// signup must fail loudly so ops/devs spot the misconfig instead of inheriting
+// a random "first active role".
+
+func TestSignup_FailsLoudIfNoAdminRole(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	// Hard-delete all admin-named roles (migration may have inserted one).
+	// Cascading FK from users.role_id → roles.id means we also need to detach
+	// any users currently pointing at an admin role; the migration's default
+	// admin user (if any) is fine to retarget at Operator for the test scope.
+	var operatorID string
+	require.NoError(t, db.Raw("SELECT id FROM roles WHERE LOWER(name) = 'operator' LIMIT 1").Scan(&operatorID).Error)
+	if operatorID != "" {
+		require.NoError(t, db.Exec("UPDATE users SET role_id = ? WHERE role_id IN (SELECT id FROM roles WHERE LOWER(name) = 'admin')", operatorID).Error)
+	}
+	require.NoError(t, db.Exec("DELETE FROM roles WHERE LOWER(name) = 'admin'").Error)
+
+	repo := signupRepo(db)
+	ctx := context.Background()
+
+	req := requests.SignupRequest{
+		Email:         "n1.failsloud@test.com",
+		CompanyName:   "N1 Fails Co",
+		TenantSlug:    "n1failsco",
+		AdminName:     "N1 Fails",
+		AdminPassword: "TestP@ssw0rd!",
+	}
+	require.Nil(t, repo.InitiateSignup(ctx, req))
+
+	var st database.SignupToken
+	require.NoError(t, db.Where("LOWER(email) = LOWER(?)", req.Email).First(&st).Error)
+
+	result, errResp := repo.VerifySignup(ctx, st.Token)
+	assert.Nil(t, result, "result must be nil when admin role missing")
+	require.NotNil(t, errResp, "VerifySignup must error loud, not silently assign a random role")
+	if errResp.Error != nil {
+		assert.Contains(t, errResp.Error.Error(), "admin role not found",
+			"error should clearly identify the missing-role root cause")
+	}
+
+	// Sanity: tenant must NOT have been committed (the tx aborted).
+	var tenantCount int64
+	require.NoError(t, db.Model(&database.Tenant{}).Where("slug = ?", req.TenantSlug).Count(&tenantCount).Error)
+	assert.EqualValues(t, 0, tenantCount, "transaction must have rolled back when admin role missing")
+}
+
 // ─── Test: Rate-limit middleware integration (route-level) ───────────────────
 // Note: full rate-limit integration uses net/http/httptest with the router.
 // This is a unit-level smoke test in signup_controller_test.go.

--- a/repositories/signup_repository.go
+++ b/repositories/signup_repository.go
@@ -123,6 +123,26 @@ func (r *SignupRepository) InitiateSignup(ctx context.Context, req requests.Sign
 	}
 	verifyLink := fmt.Sprintf("%s/verify-signup?token=%s", appURL, token)
 
+	// S3.5.2 N2 (Part C): "SMTP/email skipped" decision — when the configured sender
+	// is nil OR the prod-build was started without RESEND_API_KEY (LoggerEmailSender
+	// in a production environment), real users never receive the verify email and
+	// ops needs the raw token to recover the signup. We compute the skip flag here
+	// and log a fallback line *before* attempting to send so the token is recoverable
+	// even if the goroutine never runs to completion.
+	emailSkipped := r.EmailSender == nil
+	if !emailSkipped {
+		if _, isLogger := r.EmailSender.(*tools.LoggerEmailSender); isLogger && r.Config.Environment == "production" {
+			emailSkipped = true
+		}
+	}
+	if emailSkipped {
+		log.Warn().
+			Str("email", req.Email).
+			Str("token", token).
+			Str("verify_url", fmt.Sprintf("%s/api/signup/verify (POST {token})", appURL)).
+			Msg("signup verify token created — email skipped (SMTP/RESEND not configured)")
+	}
+
 	go func() {
 		if r.EmailSender == nil {
 			return
@@ -131,6 +151,14 @@ func (r *SignupRepository) InitiateSignup(ctx context.Context, req requests.Sign
 		htmlBody, textBody := renderSignupVerifyEmail(req.AdminName, req.CompanyName, verifyLink)
 		if err := r.EmailSender.Send(context.Background(), req.Email, subject, htmlBody, textBody); err != nil {
 			log.Error().Err(err).Str("email", req.Email).Msg("signup verify email send failed")
+			// S3.5.2 N2 (Part C): on send failure, surface the token so ops can complete
+			// the signup manually without DB access. Only fires on actual error — the
+			// happy path stays silent and tokens never leak when SMTP is healthy.
+			log.Warn().
+				Str("email", req.Email).
+				Str("token", token).
+				Str("verify_url", fmt.Sprintf("%s/api/signup/verify (POST {token})", appURL)).
+				Msg("signup verify token created — email send failed, fallback log for ops")
 		}
 	}()
 

--- a/repositories/signup_repository.go
+++ b/repositories/signup_repository.go
@@ -182,16 +182,17 @@ func (r *SignupRepository) VerifySignup(ctx context.Context, token string) (*res
 		}
 
 		// 2. Find the "admin" role (by name — canonical identifier per S2 roles migration).
-		var roleID string
+		// S3.5.2 N1: case-insensitive lookup. Postgres equality is case-sensitive and prod
+		// rows are stored capitalized ("Admin"); the previous lower-case match silently
+		// fell through to "first active role" (typically "Operator") and assigned the wrong
+		// role to every freshly signed-up tenant admin. Robust against future renames too.
+		// If no admin role exists at all the signup is unrecoverable — fail loud instead of
+		// quietly assigning a random role.
 		var role database.Role
-		if err := tx.Where("name = ?", "admin").First(&role).Error; err == nil {
-			roleID = role.ID
-		} else {
-			// Fallback: first active role.
-			if err2 := tx.Where("is_active = true").First(&role).Error; err2 == nil {
-				roleID = role.ID
-			}
+		if err := tx.Where("LOWER(name) = ?", "admin").First(&role).Error; err != nil {
+			return fmt.Errorf("admin role not found in roles table — signup cannot complete: %w", err)
 		}
+		roleID := role.ID
 
 		// 3. Create admin user using the pre-encrypted password stored in the token.
 		adminID = uuid.NewString()


### PR DESCRIPTION
## Summary

Hotfix for two prod-confirmed bugs surfaced by post-S3.5.1 QA E2E with real
tenant signup against `estock.eflowsuite.com`.

### N1 — Signup assigns Operator role instead of Admin (CRITICAL UX)

`repositories/signup_repository.go` looked up the admin role via
`tx.Where("name = ?", "admin")`. Production rows are seeded capitalized
("Admin") by migration 000016; Postgres equality is case-sensitive, so the
lookup missed and the silent fallback (`is_active = true LIMIT 1`) assigned
"Operator" to every freshly signed-up tenant admin.

**Fix:**
- Case-insensitive lookup: `LOWER(name) = 'admin'`.
- Removed the silent fallback. If no admin role exists the signup tx errors
  loudly (`admin role not found in roles table — signup cannot complete`)
  rather than assigning a random role and rolling back the tenant cleanly.

### N2 — SMTP not configured in prod, signup verify emails silently dropped

`kubectl exec deploy/estock-prod-backend -- env | grep -iE "smtp|mail"` was
empty. The wired `LoggerEmailSender` in production logs nothing useful and
the signup goroutine swallowed the skip — users never received the link and
ops only noticed via QA escalation.

**Fix (3 parts, no behaviour change when email is healthy):**
- **A. `.env.example`** — documented `SMTP_*` block (HOST/PORT/USER/PASSWORD/FROM/TLS) reserved for the future SMTP-direct sender, alongside the existing `RESEND_API_KEY` block.
- **B. `cmd/main.go`** — startup WARN if both `SMTP_HOST` and `RESEND_API_KEY` are empty, so misconfig is visible on the first log scrape.
- **C. `repositories/signup_repository.go`** — fallback log of the verify token (WARN) when sender is nil, when sender is `LoggerEmailSender` in `production`, or when the email send returns an error. Includes `email`, `token`, `verify_url` so ops can recover stuck signups without DB access. Happy path stays silent — tokens never leak when SMTP is healthy.

## Tests added

- `TestSignup_AssignsAdminRole` — full signup flow against migration-seeded "Admin", asserts `user.role_id` matches the canonical admin row.
- `TestSignup_FailsLoudIfNoAdminRole` — deletes admin rows, asserts `VerifySignup` errors and the tenant transaction rolls back (no orphan tenant/user).

Both gated by `setupGORMTestDB` short-mode skip (Docker testcontainers).

## Validation gates (MSSO v2.1 — all 6)

- [x] `grep -rn "<<<<<<<\|>>>>>>>" .` → 0
- [x] `go build ./...` → clean
- [x] `go vet ./...` → clean
- [x] `go test -short -race -count=1 ./...` → all packages OK
- [x] `make sqlc` → 0 diff
- [x] `git status -s` → clean post-commit

## Manual data-fix to apply post-deploy

The director will run a manual UPDATE for the QA tenant whose admin already
has the wrong role:

- `qa-auto-1777303264` admin user `Jafetlopezch+auto@gmail.com` currently has role Operator → flip to Admin role id `vU56bMZyXqA6wrx33P`.

## Test plan

- [ ] Merge to `main`, deploy to dev, run end-to-end signup → verify new tenant admin gets Admin role.
- [ ] Tail prod logs at boot → confirm no `SMTP_HOST and RESEND_API_KEY both unset` warning once the prod env vars are populated.
- [ ] With `RESEND_API_KEY` deliberately unset in dev → POST `/api/signup` and confirm the WARN line with `token=` appears in logs.
- [ ] Apply the manual UPDATE for the QA tenant admin role.