### PR TITLE
fix(s3.5.3): SeedFarma created_by + repo defensive JOIN (N3 CRITICAL data invisibility)

### DIFF
--- a/repositories/picking_task_repository.go
+++ b/repositories/picking_task_repository.go
@@ -251,7 +251,7 @@ func (r *PickingTaskRepository) GetAllPickingTasks() ([]responses.PickingTaskVie
 			pt.task_id,
 			pt.order_number,
 			pt.created_by,
-			usr.first_name || ' ' || usr.last_name AS user_creator_name,
+			COALESCE(usr.first_name || ' ' || usr.last_name, '') AS user_creator_name,
 			pt.assigned_to,
 			usr_assignee.first_name || ' ' || usr_assignee.last_name AS user_assignee_name,
 			pt.status,
@@ -282,7 +282,7 @@ func (r *PickingTaskRepository) GetAllPickingTasks() ([]responses.PickingTaskVie
 				)
 			) AS items
 		FROM picking_tasks pt
-		INNER JOIN users usr ON pt.created_by = usr.id
+		LEFT JOIN users usr ON pt.created_by = usr.id
 		LEFT JOIN users usr_assignee ON pt.assigned_to = usr_assignee.id
 		LEFT JOIN LATERAL jsonb_array_elements(pt.items) AS item ON TRUE
 		LEFT JOIN articles a ON a.sku = item->>'sku'
@@ -328,7 +328,7 @@ func (r *PickingTaskRepository) GetAllForTenant(tenantID string) ([]responses.Pi
 			pt.task_id,
 			pt.order_number,
 			pt.created_by,
-			usr.first_name || ' ' || usr.last_name AS user_creator_name,
+			COALESCE(usr.first_name || ' ' || usr.last_name, '') AS user_creator_name,
 			pt.assigned_to,
 			usr_assignee.first_name || ' ' || usr_assignee.last_name AS user_assignee_name,
 			pt.status,
@@ -359,7 +359,7 @@ func (r *PickingTaskRepository) GetAllForTenant(tenantID string) ([]responses.Pi
 				)
 			) AS items
 		FROM picking_tasks pt
-		INNER JOIN users usr ON pt.created_by = usr.id
+		LEFT JOIN users usr ON pt.created_by = usr.id
 		LEFT JOIN users usr_assignee ON pt.assigned_to = usr_assignee.id
 		LEFT JOIN LATERAL jsonb_array_elements(pt.items) AS item ON TRUE
 		LEFT JOIN articles a ON a.sku = item->>'sku'

--- a/repositories/receiving_tasks_repository.go
+++ b/repositories/receiving_tasks_repository.go
@@ -136,7 +136,7 @@ func (r *ReceivingTasksRepository) GetAllReceivingTasks() ([]responses.Receiving
 			rt.task_id,
 			rt.inbound_number,
 			rt.created_by,
-			usr.first_name || ' ' || usr.last_name AS user_creator_name,
+			COALESCE(usr.first_name || ' ' || usr.last_name, '') AS user_creator_name,
 			rt.assigned_to,
 			usr_assignee.first_name || ' ' || usr_assignee.last_name AS user_assignee_name,
 			rt.status,
@@ -173,7 +173,7 @@ func (r *ReceivingTasksRepository) GetAllReceivingTasks() ([]responses.Receiving
 				)
 			) AS items
 		FROM receiving_tasks rt
-		INNER JOIN users usr ON rt.created_by = usr.id
+		LEFT JOIN users usr ON rt.created_by = usr.id
 		LEFT JOIN users usr_assignee ON rt.assigned_to = usr_assignee.id
 		LEFT JOIN LATERAL jsonb_array_elements(rt.items) AS item ON TRUE
 		LEFT JOIN articles a ON a.sku = item->>'sku'
@@ -227,7 +227,7 @@ func (r *ReceivingTasksRepository) GetAllForTenant(tenantID string) ([]responses
 			rt.task_id,
 			rt.inbound_number,
 			rt.created_by,
-			usr.first_name || ' ' || usr.last_name AS user_creator_name,
+			COALESCE(usr.first_name || ' ' || usr.last_name, '') AS user_creator_name,
 			rt.assigned_to,
 			usr_assignee.first_name || ' ' || usr_assignee.last_name AS user_assignee_name,
 			rt.status,
@@ -264,7 +264,7 @@ func (r *ReceivingTasksRepository) GetAllForTenant(tenantID string) ([]responses
 				)
 			) AS items
 		FROM receiving_tasks rt
-		INNER JOIN users usr ON rt.created_by = usr.id
+		LEFT JOIN users usr ON rt.created_by = usr.id
 		LEFT JOIN users usr_assignee ON rt.assigned_to = usr_assignee.id
 		LEFT JOIN LATERAL jsonb_array_elements(rt.items) AS item ON TRUE
 		LEFT JOIN articles a ON a.sku = item->>'sku'

--- a/repositories/seedfarma_created_by_integration_test.go
+++ b/repositories/seedfarma_created_by_integration_test.go
@@ -1,0 +1,196 @@
+// Integration tests for S3.5.3 N3 — SeedFarma created_by + repository defensive
+// JOIN. Two scenarios are covered, each in a separate Postgres testcontainer:
+//
+//  1. SeedFarma stamps the supplied adminUserID on receiving + picking
+//     created_by, NOT the tenantID (Fix A regression guard).
+//  2. GetAllForTenant on receiving + picking still returns rows whose
+//     created_by points at a non-existent users.id (Fix B regression guard:
+//     the LEFT JOIN must not silently drop the row).
+//
+// Both tests skip in -short mode (Docker required) via setupGORMTestDB.
+
+package repositories
+
+import (
+	"context"
+	"testing"
+
+	"github.com/eflowcr/eSTOCK_backend/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// insertTenant inserts a tenants row so demo_data_seeds (FK on tenants) and
+// the multi-tenant queries see a valid parent. Idempotent on (id).
+func insertTenant(t *testing.T, db *gorm.DB, tenantID, slug, email string) {
+	t.Helper()
+	require.NoError(t, db.Exec(`
+		INSERT INTO tenants (id, name, slug, email, status, trial_ends_at, is_active)
+		VALUES (?::uuid, ?, ?, ?, 'trial', NOW() + interval '14 days', true)
+		ON CONFLICT (id) DO NOTHING`,
+		tenantID, slug, slug, email).Error)
+}
+
+// insertUserForTenant inserts a real users row owned by tenantID and returns
+// its id. Distinct from the package-shared seedUser helper (which doesn't
+// stamp tenant_id) to keep this test self-contained against multi-tenant
+// schema changes. Reuses the admin role seeded by seedAdminRole (signup tests).
+func insertUserForTenant(t *testing.T, db *gorm.DB, tenantID, email, first, last string) string {
+	t.Helper()
+	roleID := seedAdminRole(t, db) // idempotent
+	id, err := tools.GenerateNanoid(db)
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`
+		INSERT INTO users (id, tenant_id, first_name, last_name, email, password, role_id, is_active, created_at, updated_at)
+		VALUES (?, ?::uuid, ?, ?, ?, 'hashed', ?, true, NOW(), NOW())
+		ON CONFLICT (email) DO NOTHING`,
+		id, tenantID, first, last, email, roleID).Error)
+	var uid string
+	require.NoError(t, db.Raw("SELECT id FROM users WHERE email = ?", email).Scan(&uid).Error)
+	require.NotEmpty(t, uid, "insertUserForTenant produced no user row")
+	return uid
+}
+
+// ─── Test 1 — Fix A regression guard ──────────────────────────────────────────
+
+// TestSeedFarma_AssignsAdminUserIDAsCreatedBy proves that when a real adminUserID
+// is threaded through SeedFarma, every receiving + picking demo row carries that
+// id in created_by — NOT the tenantID. This is the root cause of N3: the
+// previous implementation passed tenantID, the repository INNER-JOINed users on
+// created_by, and the freshly-signed-up tenant's dashboard came up empty.
+func TestSeedFarma_AssignsAdminUserIDAsCreatedBy(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	const tenantID = "33333333-3333-3333-3333-333333333333"
+	insertTenant(t, db, tenantID, "createdby-tenant", "createdby@test.com")
+
+	// A real admin user owned by this tenant.
+	adminID := insertUserForTenant(t, db, tenantID, "admin-createdby@test.com", "Created", "Admin")
+
+	require.NoError(t, tools.SeedFarma(ctx, db, tenantID, adminID),
+		"SeedFarma must succeed when given a real adminUserID")
+
+	// Every demo receiving_task for this tenant must reference adminID, not tenantID.
+	var rtRowsWithAdmin int64
+	require.NoError(t, db.Raw(
+		`SELECT COUNT(*) FROM receiving_tasks WHERE tenant_id = ? AND created_by = ?`,
+		tenantID, adminID,
+	).Scan(&rtRowsWithAdmin).Error)
+	assert.EqualValues(t, 20, rtRowsWithAdmin,
+		"all 20 demo receiving_tasks must carry created_by = adminUserID")
+
+	var rtRowsWithTenant int64
+	require.NoError(t, db.Raw(
+		`SELECT COUNT(*) FROM receiving_tasks WHERE tenant_id = ? AND created_by = ?`,
+		tenantID, tenantID,
+	).Scan(&rtRowsWithTenant).Error)
+	assert.EqualValues(t, 0, rtRowsWithTenant,
+		"no demo receiving_task may carry created_by = tenantID (the N3 bug shape)")
+
+	// Same for picking_tasks (15 demo rows).
+	var ptRowsWithAdmin int64
+	require.NoError(t, db.Raw(
+		`SELECT COUNT(*) FROM picking_tasks WHERE tenant_id = ? AND created_by = ?`,
+		tenantID, adminID,
+	).Scan(&ptRowsWithAdmin).Error)
+	assert.EqualValues(t, 15, ptRowsWithAdmin,
+		"all 15 demo picking_tasks must carry created_by = adminUserID")
+
+	var ptRowsWithTenant int64
+	require.NoError(t, db.Raw(
+		`SELECT COUNT(*) FROM picking_tasks WHERE tenant_id = ? AND created_by = ?`,
+		tenantID, tenantID,
+	).Scan(&ptRowsWithTenant).Error)
+	assert.EqualValues(t, 0, ptRowsWithTenant,
+		"no demo picking_task may carry created_by = tenantID")
+
+	// End-to-end visibility: GetAllForTenant must now return the rows. This
+	// closes the loop on N3 — the real symptom (empty dashboard) is exactly
+	// "GetAllForTenant returned 0 rows" and it must NOT happen anymore.
+	rtRepo := &ReceivingTasksRepository{DB: db}
+	rts, errRT := rtRepo.GetAllForTenant(tenantID)
+	require.Nil(t, errRT)
+	assert.Len(t, rts, 20, "dashboard must surface all 20 demo receiving tasks (N3 symptom guard)")
+
+	ptRepo := &PickingTaskRepository{DB: db}
+	pts, errPT := ptRepo.GetAllForTenant(tenantID)
+	require.Nil(t, errPT)
+	assert.Len(t, pts, 15, "dashboard must surface all 15 demo picking tasks (N3 symptom guard)")
+}
+
+// ─── Test 2 — Fix B regression guard (receiving) ─────────────────────────────
+
+// TestReceivingTasksRepo_GetAllForTenant_ReturnsRowsEvenWithMissingUser proves
+// that the LEFT JOIN to users keeps a row visible when created_by points at a
+// user id that no longer exists (e.g. user deleted, system_seed sentinel,
+// pre-fix legacy data). The previous INNER JOIN dropped such rows silently.
+func TestReceivingTasksRepo_GetAllForTenant_ReturnsRowsEvenWithMissingUser(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	const (
+		tenantID    = "44444444-4444-4444-4444-444444444444"
+		ghostUserID = "00000000-0000-0000-0000-deadbeef0001" // intentionally not in users
+	)
+	insertTenant(t, db, tenantID, "ghost-rt-tenant", "ghost-rt@test.com")
+
+	// Insert a receiving_task whose created_by references no real user.
+	taskUUID, err := tools.GenerateNanoid(db)
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`
+		INSERT INTO receiving_tasks
+			(id, task_id, inbound_number, created_by, status, priority, items, tenant_id, created_at, updated_at)
+		VALUES
+			(?, ?, ?, ?, 'open', 'normal', '[]'::jsonb, ?::uuid, NOW(), NOW())`,
+		taskUUID, "RT-GHOST-"+taskUUID[:4], "IN-GHOST-"+taskUUID[:4], ghostUserID, tenantID,
+	).Error)
+
+	repo := &ReceivingTasksRepository{DB: db}
+	rows, errResp := repo.GetAllForTenant(tenantID)
+	require.Nil(t, errResp)
+	require.Len(t, rows, 1,
+		"row with missing-user created_by must still surface — INNER JOIN regression guard")
+	assert.Equal(t, ghostUserID, rows[0].CreatedBy,
+		"created_by must round-trip even when the user is missing")
+	assert.Empty(t, rows[0].UserCreatorName,
+		"creator name must be empty (COALESCE on NULL JOIN side) — not error, not omit row")
+}
+
+// ─── Test 3 — Fix B regression guard (picking) ───────────────────────────────
+
+// TestPickingTasksRepo_GetAllForTenant_ReturnsRowsEvenWithMissingUser is the
+// picking-side mirror of the receiving test above. Same root cause, same fix,
+// independently guarded so a future refactor of one repo can't silently
+// regress the other.
+func TestPickingTasksRepo_GetAllForTenant_ReturnsRowsEvenWithMissingUser(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	const (
+		tenantID    = "55555555-5555-5555-5555-555555555555"
+		ghostUserID = "00000000-0000-0000-0000-deadbeef0002"
+	)
+	insertTenant(t, db, tenantID, "ghost-pt-tenant", "ghost-pt@test.com")
+
+	taskUUID, err := tools.GenerateNanoid(db)
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`
+		INSERT INTO picking_tasks
+			(id, task_id, order_number, created_by, status, priority, items, tenant_id, created_at, updated_at)
+		VALUES
+			(?, ?, ?, ?, 'open', 'normal', '[]'::jsonb, ?::uuid, NOW(), NOW())`,
+		taskUUID, "PK-GHOST-"+taskUUID[:4], "ORD-GHOST-"+taskUUID[:4], ghostUserID, tenantID,
+	).Error)
+
+	repo := &PickingTaskRepository{DB: db}
+	rows, errResp := repo.GetAllForTenant(tenantID)
+	require.Nil(t, errResp)
+	require.Len(t, rows, 1,
+		"row with missing-user created_by must still surface — INNER JOIN regression guard")
+	assert.Equal(t, ghostUserID, rows[0].CreatedBy)
+	assert.Empty(t, rows[0].UserCreatorName)
+}

--- a/repositories/seedfarma_multitenant_integration_test.go
+++ b/repositories/seedfarma_multitenant_integration_test.go
@@ -61,8 +61,10 @@ func TestSeedFarma_MultiTenantIsolation(t *testing.T) {
 	seedTenantRow(t, db, tenantB, "tenantb-seedtest", "b@seedtest.com")
 
 	// ── Seed both tenants ────────────────────────────────────────────────────
-	require.NoError(t, tools.SeedFarma(ctx, db, tenantA), "seed for tenant A")
-	require.NoError(t, tools.SeedFarma(ctx, db, tenantB), "seed for tenant B (must NOT collide on global UNIQUE indexes)")
+	// adminUserID empty: this test only proves multi-tenant isolation of the data
+	// itself; created_by visibility is covered by separate S3.5.3 N3 tests.
+	require.NoError(t, tools.SeedFarma(ctx, db, tenantA, ""), "seed for tenant A")
+	require.NoError(t, tools.SeedFarma(ctx, db, tenantB, ""), "seed for tenant B (must NOT collide on global UNIQUE indexes)")
 
 	// ── Per-tenant article counts ────────────────────────────────────────────
 	repo := &ArticlesRepository{DB: db}
@@ -116,8 +118,8 @@ func TestSeedFarma_MultiTenantIsolation(t *testing.T) {
 	assert.EqualValues(t, 2, seedCount, "demo_data_seeds should carry exactly one row per tenant")
 
 	// ── Re-running SeedFarma for either tenant is a no-op (idempotency) ──────
-	require.NoError(t, tools.SeedFarma(ctx, db, tenantA), "second seed call for tenant A must be idempotent")
-	require.NoError(t, tools.SeedFarma(ctx, db, tenantB), "second seed call for tenant B must be idempotent")
+	require.NoError(t, tools.SeedFarma(ctx, db, tenantA, ""), "second seed call for tenant A must be idempotent")
+	require.NoError(t, tools.SeedFarma(ctx, db, tenantB, ""), "second seed call for tenant B must be idempotent")
 
 	// Counts unchanged after re-run.
 	var countA, countB int64

--- a/repositories/signup_integration_test.go
+++ b/repositories/signup_integration_test.go
@@ -269,10 +269,13 @@ func TestSeedFarma_Idempotent(t *testing.T) {
 	tenantID := "00000000-0000-0000-0000-000000000001" // default tenant from migration
 
 	// Run SeedFarma twice — should not error on second run.
-	err1 := tools.SeedFarma(ctx, db, tenantID)
+	// Empty adminUserID: legacy behaviour (created_by falls back to tenantID); the
+	// repository LEFT JOIN keeps rows visible regardless. Idempotency does not
+	// depend on the new arg.
+	err1 := tools.SeedFarma(ctx, db, tenantID, "")
 	require.NoError(t, err1, "first SeedFarma should succeed")
 
-	err2 := tools.SeedFarma(ctx, db, tenantID)
+	err2 := tools.SeedFarma(ctx, db, tenantID, "")
 	require.NoError(t, err2, "second SeedFarma should be idempotent (no error)")
 
 	// Verify articles count is not doubled. S3.5 W4: SKUs are now tenant-prefixed

--- a/repositories/signup_repository.go
+++ b/repositories/signup_repository.go
@@ -273,13 +273,16 @@ func (r *SignupRepository) VerifySignup(ctx context.Context, token string) (*res
 
 	// After tx: trigger farma demo seed in background goroutine.
 	// SeedFarma is idempotent (checks demo_data_seeds before inserting).
-	go func(tID string) {
+	// S3.5.3 N3: pass adminID through so seeded receiving + picking tasks reference
+	// a real users.id and survive the repository INNER JOIN to users. Previously
+	// tenantID was implicitly used, dropping every demo row from the dashboard.
+	go func(tID, aID string) {
 		bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
-		if err := tools.SeedFarma(bgCtx, r.DB, tID); err != nil {
+		if err := tools.SeedFarma(bgCtx, r.DB, tID, aID); err != nil {
 			log.Error().Err(err).Str("tenant_id", tID).Msg("farma demo seed failed (background)")
 		}
-	}(tenantID)
+	}(tenantID, adminID)
 
 	adminName := st.AdminName
 	if adminName == "" {

--- a/tools/demo_seeder_farma.go
+++ b/tools/demo_seeder_farma.go
@@ -70,7 +70,17 @@ func prefixedTaskID(tenantID, baseID string) string {
 // demo dataset instead of the second tenant hitting a duplicate-key error or
 // silently inheriting tenant 1's rows. See tenantPrefix and migration 000029 for
 // the full structural-debt context.
-func SeedFarma(ctx context.Context, db *gorm.DB, tenantID string) error {
+//
+// S3.5.3 N3 (CRITICAL): adminUserID is the freshly-created tenant admin's user id
+// and is used as receiving_tasks.created_by + picking_tasks.created_by for every
+// demo row. The previous implementation passed tenantID into created_by, so the
+// repository INNER JOIN to users dropped 100% of demo rows (tenant UUID never
+// matches a users.id). The result was a tenant signup that completed cleanly but
+// served an empty dashboard — silent data invisibility. If adminUserID is empty
+// (legacy callers / direct demo invocations without a real admin), the seeder
+// falls back to tenantID for backwards compatibility and the repository LEFT JOIN
+// fix (S3.5.3 same wave) still keeps rows visible with an empty creator name.
+func SeedFarma(ctx context.Context, db *gorm.DB, tenantID, adminUserID string) error {
 	// ── Idempotency check ────────────────────────────────────────────────────────
 	var existing database.DemoDataSeed
 	err := db.WithContext(ctx).
@@ -120,12 +130,15 @@ func SeedFarma(ctx context.Context, db *gorm.DB, tenantID string) error {
 		}
 
 		// 7. Receiving tasks (10 completed + 10 partial/draft) — uses locationCodes
-		if err := seedReceivingTasks(ctx, tx, tenantID, articles, locationCodes, supplierIDs); err != nil {
+		// S3.5.3 N3: pass adminUserID through so created_by points at a real users.id
+		// and the INNER JOIN in receiving_tasks_repository doesn't silently drop rows.
+		if err := seedReceivingTasks(ctx, tx, tenantID, adminUserID, articles, locationCodes, supplierIDs); err != nil {
 			return fmt.Errorf("seed receiving tasks: %w", err)
 		}
 
 		// 8. Picking tasks (8 completed + 7 partial/draft) — uses locationCodes
-		if err := seedPickingTasks(ctx, tx, tenantID, articles, locationCodes, customerIDs); err != nil {
+		// S3.5.3 N3: same created_by fix as receiving tasks above.
+		if err := seedPickingTasks(ctx, tx, tenantID, adminUserID, articles, locationCodes, customerIDs); err != nil {
 			return fmt.Errorf("seed picking tasks: %w", err)
 		}
 
@@ -461,7 +474,14 @@ func seedInventory(ctx context.Context, tx *gorm.DB, _ string, articles []farmaA
 
 // ─── receiving tasks ─────────────────────────────────────────────────────────
 
-func seedReceivingTasks(ctx context.Context, tx *gorm.DB, tenantID string, articles []farmaArticle, locationIDs, supplierIDs []string) error {
+// seedReceivingTasks accepts adminUserID for the created_by column. Falls back to
+// tenantID if empty (legacy callers without a real admin user); the repository
+// LEFT JOIN guard keeps such rows visible even though the user lookup yields nil.
+func seedReceivingTasks(ctx context.Context, tx *gorm.DB, tenantID, adminUserID string, articles []farmaArticle, locationIDs, supplierIDs []string) error {
+	createdBy := adminUserID
+	if createdBy == "" {
+		createdBy = tenantID
+	}
 	now := time.Now()
 
 	for i := 0; i < 20; i++ {
@@ -522,7 +542,9 @@ func seedReceivingTasks(ctx context.Context, tx *gorm.DB, tenantID string, artic
 			ID:          uuid.NewString(),
 			TaskID:      taskID,
 			InboundNumber: inboundNum,
-			CreatedBy:   tenantID, // system-generated
+			// S3.5.3 N3: real admin user_id (was tenantID — caused INNER JOIN drops
+			// in GetAllForTenant and silent data invisibility on the dashboard).
+			CreatedBy:   createdBy,
 			Status:      status,
 			Priority:    priorityForIndex(i),
 			Items:       json.RawMessage(itemsJSON),
@@ -543,7 +565,13 @@ func seedReceivingTasks(ctx context.Context, tx *gorm.DB, tenantID string, artic
 
 // ─── picking tasks ────────────────────────────────────────────────────────────
 
-func seedPickingTasks(ctx context.Context, tx *gorm.DB, tenantID string, articles []farmaArticle, locationIDs, customerIDs []string) error {
+// seedPickingTasks accepts adminUserID for the created_by column. Falls back to
+// tenantID if empty; see seedReceivingTasks for the same fallback rationale.
+func seedPickingTasks(ctx context.Context, tx *gorm.DB, tenantID, adminUserID string, articles []farmaArticle, locationIDs, customerIDs []string) error {
+	createdBy := adminUserID
+	if createdBy == "" {
+		createdBy = tenantID
+	}
 	now := time.Now()
 
 	for i := 0; i < 15; i++ {
@@ -606,7 +634,8 @@ func seedPickingTasks(ctx context.Context, tx *gorm.DB, tenantID string, article
 			ID:          uuid.NewString(),
 			TaskID:      taskID,
 			OrderNumber: orderNum,
-			CreatedBy:   tenantID,
+			// S3.5.3 N3: real admin user_id (see seedReceivingTasks for full context).
+			CreatedBy:   createdBy,
 			Status:      status,
 			Priority:    priorityForIndex(i),
 			Items:       json.RawMessage(itemsJSON),


### PR DESCRIPTION
## Summary

Hotfix for **N3 (CRITICAL)** from QA E2E v0.2.3: SaaS happy path completed cleanly but the freshly-signed-up tenant's dashboard came up empty. DB carried 20 receiving_tasks + 15 picking_tasks for the tenant; UI showed zero of each. Silent data invisibility.

Two independent root causes — both fixed:

### Root cause #1 — SeedFarma stamped wrong id on created_by
`tools/demo_seeder_farma.go` inserted demo receiving + picking tasks with `created_by = tenantID`. The repository read path `INNER JOIN users ON created_by = users.id` then dropped 100% of those rows because a tenant UUID never matches a real users.id.

**Fix A:** thread `adminUserID` through `SeedFarma` → `seedReceivingTasks` / `seedPickingTasks` and stamp it on `created_by`. Caller in `repositories/signup_repository.go` passes the freshly-created admin's id. Empty `adminUserID` falls back to tenantID for backwards compat with direct callers (legacy demo invocations); the companion fix below keeps even those rows visible.

`inventory_movements.created_by = "system_seed"` is intentionally untouched: that column has no FK to users and the dashboard does not JOIN on it.

### Root cause #2 — Repository INNER JOIN drops orphans silently
`receiving_tasks_repository.go` and `picking_task_repository.go` (4 query sites total) used `INNER JOIN users ON created_by = users.id`. Any task whose `created_by` referenced a deleted/unknown user vanished from the result.

**Fix B:** `INNER JOIN users` → `LEFT JOIN users` on the creator-name lookup edge in both repos, both queries (GetAll + GetAllForTenant). The `SELECT` wraps the name expression in `COALESCE(... , '')` so a NULL JOIN side serialises as `""`. Defensive change with zero functional cost when the user exists.

Out of scope: queries that filter or GROUP BY user (those legitimately require the user to exist) — only the display-name JOIN was relaxed.

## Tests

`repositories/seedfarma_created_by_integration_test.go` — three real-Postgres regression guards:
- `TestSeedFarma_AssignsAdminUserIDAsCreatedBy` — proves Fix A: 20/20 RT + 15/15 PT carry `created_by = adminID`, 0 carry `tenantID`. Closes the loop end-to-end via `GetAllForTenant`.
- `TestReceivingTasksRepo_GetAllForTenant_ReturnsRowsEvenWithMissingUser` — proves Fix B (receiving): orphan-`created_by` row still surfaces, creator name empty.
- `TestPickingTasksRepo_GetAllForTenant_ReturnsRowsEvenWithMissingUser` — proves Fix B (picking).

All three skip in `-short` mode (Docker required), consistent with the rest of the integration suite.

## Validation gates (MSSO v2.1)

- [x] markers 0
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -short -race ./...` 0 NEW failures
- [x] `make sqlc` 0 diff
- [x] `git status` only expected files

## Manual fix for the existing qa-auto tenant

The tenant `qa-auto-1777303264` (id `13d5a64d-1c59-4dc5-984f-d129900b9281`) was seeded with the buggy created_by before this PR. The defensive LEFT JOIN already makes its data visible after deploy, but to also restore the creator name in the UI, run:

```sql
UPDATE receiving_tasks
SET created_by = 'e35c92f3-cf50-45f4-87ec-c41df20c0a1a'
WHERE tenant_id = '13d5a64d-1c59-4dc5-984f-d129900b9281';

UPDATE picking_tasks
SET created_by = 'e35c92f3-cf50-45f4-87ec-c41df20c0a1a'
WHERE tenant_id = '13d5a64d-1c59-4dc5-984f-d129900b9281';
```

This is **optional** — the LEFT JOIN fix alone restores visibility (creator name comes through empty until the UPDATE).

## Test plan

- [ ] Fresh signup via `/api/signup` → verify token → confirm dashboard shows 20 RT + 15 PT
- [ ] Manual UPDATE on qa-auto tenant → verify creator name now populates
- [ ] Existing tenants (single-tenant prod) unaffected — INNER → LEFT is non-breaking when users exist