### PR TITLE
fix(s3.5.4): stock-alerts route 404 + inventory toast root cause (B15+B16)

### DIFF
--- a/controllers/stock_alerts_controller_test.go
+++ b/controllers/stock_alerts_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/eflowcr/eSTOCK_backend/models/database"
@@ -200,4 +201,47 @@ func TestStockAlertsController_ExportAlertsToExcel_ServiceError(t *testing.T) {
 	ctrl := newStockAlertsController(repo)
 	w := performRequest(ctrl.ExportAlertsToExcel, "GET", "/stock-alerts/export", nil, nil)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// S3.5.4 (B15 fix): root listing routes (with and without trailing slash) must respond 200,
+// not 404. Previously only /:resolved was registered, so direct probes / SDK clients hitting
+// /api/stock-alerts/ got page-not-found. We register both /, "" and /:resolved against
+// GetAllStockAlerts; this test guards against accidental regression of the route table.
+func TestStockAlertsRoutes_RootListingNotFoundRegression(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &mockStockAlertsRepoCtrl{alerts: []database.StockAlert{}}
+	ctrl := newStockAlertsController(repo)
+
+	router := gin.New()
+	api := router.Group("/api")
+	route := api.Group("/stock-alerts")
+	{
+		// Mirror routes/stock_alerts_routes.go (without auth/permission middleware).
+		route.GET("", ctrl.GetAllStockAlerts)
+		route.GET("/", ctrl.GetAllStockAlerts)
+		route.GET("/analyze", ctrl.Analyze)
+		route.GET("/lot-expiration", ctrl.LotExpiration)
+		route.GET("/export", ctrl.ExportAlertsToExcel)
+		route.GET("/:resolved", ctrl.GetAllStockAlerts)
+		route.PATCH("/:id/resolve", ctrl.ResolveAlert)
+	}
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"root no slash", "/api/stock-alerts"},
+		{"root with slash", "/api/stock-alerts/"},
+		{"resolved=true", "/api/stock-alerts/true"},
+		{"resolved=false", "/api/stock-alerts/false"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodGet, tc.path, nil)
+			router.ServeHTTP(w, req)
+			assert.NotEqual(t, http.StatusNotFound, w.Code, "GET %s should not return 404 (B15 regression)", tc.path)
+			assert.Equal(t, http.StatusOK, w.Code)
+		})
+	}
 }

--- a/repositories/stock_alerts_analyze_integration_test.go
+++ b/repositories/stock_alerts_analyze_integration_test.go
@@ -1,0 +1,76 @@
+// stock_alerts_analyze_integration_test.go — S3.5.4 (B16 fix)
+//
+// Regression guard for the "Error al obtener el inventario" toast on /stock-alerts:
+// Analyze() previously did `WHERE tenant_id = ?` directly on inventory and
+// inventory_movements, but neither table has a tenant_id column today (deferred
+// to S3.6 structural migration). The fix scopes via JOIN through articles.tenant_id.
+//
+// This test boots a real Postgres via testcontainers, runs the production
+// migrations, seeds two tenants' worth of articles + inventory, and asserts:
+//   - Analyze(tenantA) succeeds (no SQL error) and only sees tenant A inventory
+//   - Tenant A's analyze run never inserts alerts referencing tenant B SKUs
+//
+// Run: go test -v ./repositories/... -run TestStockAlertsAnalyze
+// Skipped under -short (no Docker required for unit gate).
+
+package repositories
+
+import (
+	"testing"
+
+	"github.com/eflowcr/eSTOCK_backend/models/database"
+	"github.com/eflowcr/eSTOCK_backend/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// seedInventoryRow inserts an inventory row for a SKU. Note that inventory itself
+// has no tenant_id column — multi-tenancy is enforced by the FK to articles.sku.
+func seedInventoryRow(t *testing.T, db *gorm.DB, sku, location string, qty float64) string {
+	t.Helper()
+	id, err := tools.GenerateNanoid(db)
+	require.NoError(t, err)
+	require.NoError(t, db.Exec(`
+		INSERT INTO inventory
+			(id, sku, name, location, quantity, status, presentation, unit_price, created_at, updated_at)
+		VALUES (?, ?, 'Test Item', ?, ?, 'available', 'unit', 1.50, NOW(), NOW())`,
+		id, sku, location, qty).Error)
+	return id
+}
+
+// TestStockAlertsAnalyze_TenantScopedViaArticlesJoin is the B16 regression guard.
+// Before the fix, Analyze() failed with `column "tenant_id" does not exist` on
+// inventory; this test crashes if anyone re-introduces that bug.
+func TestStockAlertsAnalyze_TenantScopedViaArticlesJoin(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	// Seed articles for both tenants.
+	seedArticleRow(t, db, testTenantA, "ANALYZE-SKU-A1", "Tenant A item")
+	seedArticleRow(t, db, testTenantB, "ANALYZE-SKU-B1", "Tenant B item")
+
+	// Seed inventory rows pointing at those SKUs. No tenant_id on this table —
+	// scoping happens via the articles FK.
+	seedInventoryRow(t, db, "ANALYZE-SKU-A1", "LOC-A", 5)
+	seedInventoryRow(t, db, "ANALYZE-SKU-B1", "LOC-B", 7)
+
+	repo := &StockAlertsRepository{DB: db}
+
+	// Tenant A: must NOT error with the old "Error al obtener el inventario" message.
+	respA, errA := repo.Analyze(testTenantA)
+	require.Nil(t, errA, "Analyze must succeed without SQL error (B16 regression)")
+	_ = respA // alerts may be empty for healthy stock; what matters is no error.
+
+	// Verify any alerts written are scoped to tenant A only — no leak from B.
+	var alertsA []database.StockAlert
+	require.NoError(t, db.Table("stock_alerts").Where("tenant_id = ?", testTenantA).Find(&alertsA).Error)
+	for _, a := range alertsA {
+		assert.NotEqual(t, "ANALYZE-SKU-B1", a.SKU,
+			"tenant A's analyze must not generate alerts for tenant B SKUs")
+	}
+
+	// Tenant B Analyze also succeeds independently.
+	_, errB := repo.Analyze(testTenantB)
+	require.Nil(t, errB, "Analyze for second tenant must also succeed")
+}

--- a/repositories/stock_alerts_repository.go
+++ b/repositories/stock_alerts_repository.go
@@ -149,10 +149,16 @@ func (r *StockAlertsRepository) Analyze(tenantID string) (*responses.StockAlertR
 	}
 
 	// Get inventory for this tenant only.
+	// S3.5.4 (B16 fix): inventory + inventory_movements tables do NOT have tenant_id columns
+	// (deferred to S3.6 structural migration). Scope via JOIN through articles.tenant_id,
+	// which is safe because articles.sku has a global UNIQUE index — every SKU belongs to
+	// exactly one tenant.
 	var inventory []database.Inventory
 	err = tx.
-		Table(database.Inventory{}.TableName()).
-		Where("tenant_id = ?", tenantID).
+		Table(database.Inventory{}.TableName()+" AS i").
+		Joins("JOIN articles a ON a.sku = i.sku").
+		Where("a.tenant_id = ?", tenantID).
+		Select("i.*").
 		Find(&inventory).Error
 
 	if err != nil {
@@ -165,13 +171,16 @@ func (r *StockAlertsRepository) Analyze(tenantID string) (*responses.StockAlertR
 	}
 
 	// Batch-fetch all outbound movements in the last 30 days for this tenant — one query.
+	// Same JOIN-via-articles approach: inventory_movements has no tenant_id column.
 	const movementLookbackDays = 30
 	lookbackCutoff := time.Now().AddDate(0, 0, -movementLookbackDays)
 
 	var allMovements []database.InventoryMovement
 	err = tx.
-		Table(database.InventoryMovement{}.TableName()).
-		Where("tenant_id = ? AND movement_type = ? AND created_at >= ?", tenantID, "outbound", lookbackCutoff).
+		Table(database.InventoryMovement{}.TableName()+" AS im").
+		Joins("JOIN articles a ON a.sku = im.sku").
+		Where("a.tenant_id = ? AND im.movement_type = ? AND im.created_at >= ?", tenantID, "outbound", lookbackCutoff).
+		Select("im.*").
 		Find(&allMovements).Error
 
 	if err != nil {

--- a/routes/stock_alerts_routes.go
+++ b/routes/stock_alerts_routes.go
@@ -33,10 +33,16 @@ func RegisterStockAlertsRoutes(router *gin.RouterGroup, db *gorm.DB, config conf
 		read := tools.RequirePermission(rolesRepo, "stock_alerts", "read")
 		update := tools.RequirePermission(rolesRepo, "stock_alerts", "update")
 
-		route.GET("/:resolved", read, stockAlertsController.GetAllStockAlerts)
+		// S3.5.4 (B15 fix): root listing now responds (defaults to active alerts).
+		// Previously GET /stock-alerts/ returned 404 because only /:resolved existed,
+		// breaking probes / frontend search() helper / endpoint discovery. The /:resolved
+		// variant remains for explicit filtering (true|false).
+		route.GET("", read, stockAlertsController.GetAllStockAlerts)
+		route.GET("/", read, stockAlertsController.GetAllStockAlerts)
 		route.GET("/analyze", read, analyzeRateLimiter, stockAlertsController.Analyze)
 		route.GET("/lot-expiration", read, stockAlertsController.LotExpiration)
-		route.PATCH("/:id/resolve", update, stockAlertsController.ResolveAlert)
 		route.GET("/export", read, stockAlertsController.ExportAlertsToExcel)
+		route.GET("/:resolved", read, stockAlertsController.GetAllStockAlerts)
+		route.PATCH("/:id/resolve", update, stockAlertsController.ResolveAlert)
 	}
 }


### PR DESCRIPTION
## Summary

Backend hotfix for two issues from QA browser report v0.2.4 (`/Users/jafetlopez/Documents/obsidian/Jafet/Projects/ePRAC/eSTOCK/plans/sessions/reports/2026-04-27-qa-browser-e2e-v0.2.4.md`, sections B15 + B16). Both manifested when navigating to the `/stock-alerts` page in production.

### B15 — `GET /api/stock-alerts/` returned HTTP 404

Root cause: route group only registered `/:resolved` plus named static routes (analyze, lot-expiration, export, /:id/resolve). Hitting the bare root URL (probes, SDKs, frontend `search()` helper) got page-not-found because Gin had no handler for `""` or `"/"`.

Fix: register `GET ""` and `GET "/"` against `GetAllStockAlerts` (defaults to active alerts since `ctx.Param("resolved")` is empty → `false`). Existing `/:resolved` variant remains for explicit filtering. Static routes still listed before `/:resolved` so they keep precedence.

### B16 — `/stock-alerts` page showed unsolicited toast "Error al obtener el inventario"

Root cause: the page's `analyzeStock()` calls `GET /api/stock-alerts/analyze` on mount, which returned HTTP 400 with that exact message. Backend logs:

```
ERROR: column "tenant_id" does not exist (SQLSTATE 42703)
SELECT * FROM "inventory" WHERE tenant_id = '...'
```

`Analyze()` (added in S3.5 W2-B for tenant isolation) queried `inventory` and `inventory_movements` directly with `WHERE tenant_id = ?`, but neither table has a `tenant_id` column today (deferred to S3.6 structural migration). Frontend was correctly displaying the backend error message → the "scary toast" was a real backend SQL failure.

Fix: rewrite both queries in `Analyze()` to scope via `JOIN articles a ON a.sku = i.sku (or im.sku) WHERE a.tenant_id = ?`. This is the same pattern other inventory repos use, and it works against the production schema as-is (articles owns the SKU→tenant relationship via `articles_tenant_sku_key` and the global `articles_sku_key` UNIQUE). `buildLotExpirationAlerts` already used `lots.tenant_id` correctly (lots HAS the column) so it's untouched.

## Tests added

- `TestStockAlertsRoutes_RootListingNotFoundRegression` (controller) — registers full route table on a test gin.Engine and asserts 200 (not 404) for `/api/stock-alerts`, `/api/stock-alerts/`, `/api/stock-alerts/true`, `/api/stock-alerts/false`. Runs in `-short` mode.
- `TestStockAlertsAnalyze_TenantScopedViaArticlesJoin` (repository, testcontainers + Postgres + real migrations) — seeds two tenants' articles + inventory and asserts `Analyze()` returns nil error and never leaks tenant B SKUs into tenant A alerts. Skipped under `-short`.

## Pre-push validation gates (MSSO v2.2)

- Conflict markers: 0
- `go build ./...`: 0 errors
- `go vet ./...`: 0 issues
- `go test -short -race -count=1 ./...`: all packages pass
- `make sqlc`: 0 diff (no SQL changed)
- `git status -s`: only expected files

## Test plan

- [ ] Deploy v0.2.5 image to prod
- [ ] curl `GET /api/stock-alerts/` with tenant 3 JWT → expect 200 (was 404)
- [ ] curl `GET /api/stock-alerts/analyze` with tenant 3 JWT → expect 200 success envelope (was 400 with "Error al obtener el inventario")
- [ ] Browser: navigate to https://estock.eflowsuite.com/stock-alerts as Admin → expect no scary inventory toast
- [ ] Confirm `kubectl logs` shows zero `column "tenant_id" does not exist` errors after the fix