### PR TITLE
fix(s3.5.5): subscription endpoint expose trial_ends_at when null (B4 root cause)

### DIFF
--- a/controllers/billing_controller.go
+++ b/controllers/billing_controller.go
@@ -100,7 +100,23 @@ func (c *BillingController) Checkout(ctx *gin.Context) {
 }
 
 // GetSubscription handles GET /api/billing/subscription (JWT required, tenant-scoped).
-// Returns the current subscription record for the tenant.
+// Returns the current subscription record for the tenant, plus trial_ends_at + tenant_status
+// from the tenants table so the frontend banner can show the real trial deadline regardless of
+// whether a Stripe subscription exists yet (B4 fix — S3.5.5).
+//
+// Response shape:
+//
+//	{
+//	  "data": {
+//	    "subscription": <Subscription | null>,
+//	    "trial_ends_at": "2026-05-11T20:07:37Z" | null,
+//	    "tenant_status": "trial" | "active" | ...
+//	  }
+//	}
+//
+// trial_ends_at is sourced from tenants.trial_ends_at (NOT subscription.trial_end) because the
+// trial period is defined at the tenant level by the signup flow — Stripe's trial_end only
+// applies once a paid plan with a trial is selected.
 func (c *BillingController) GetSubscription(ctx *gin.Context) {
 	tenantID := c.resolveTenantID(ctx)
 	if tenantID == "" {
@@ -112,13 +128,38 @@ func (c *BillingController) GetSubscription(ctx *gin.Context) {
 		writeErrorResponse(ctx, "GetBillingSubscription", "get_billing_subscription", resp)
 		return
 	}
+
+	// Fetch tenant trial info regardless of whether a subscription exists. The frontend
+	// uses tenants.trial_ends_at as the source of truth for the trial banner.
+	// If the tenant lookup fails we log + degrade (return subscription only) — the banner
+	// will fall back to "expires today" but the subscription endpoint stays functional.
+	tenant, tresp := c.Service.GetTenantTrialInfo(tenantID)
+	var trialEndsAt *string
+	tenantStatus := ""
+	if tresp != nil {
+		log.Warn().Err(tresp.Error).Str("tenant_id", tenantID).
+			Msg("billing: failed to load tenant trial info — degrading response without trial_ends_at")
+	} else if tenant != nil {
+		tenantStatus = tenant.Status
+		if !tenant.TrialEndsAt.IsZero() {
+			s := tenant.TrialEndsAt.UTC().Format("2006-01-02T15:04:05Z")
+			trialEndsAt = &s
+		}
+	}
+
+	payload := gin.H{
+		"subscription":  sub,
+		"trial_ends_at": trialEndsAt,
+		"tenant_status": tenantStatus,
+	}
+
 	if sub == nil {
 		tools.ResponseOK(ctx, "GetBillingSubscription", "Sin suscripción activa", "get_billing_subscription",
-			gin.H{"subscription": nil}, false, "")
+			payload, false, "")
 		return
 	}
 	tools.ResponseOK(ctx, "GetBillingSubscription", "Suscripción obtenida", "get_billing_subscription",
-		gin.H{"subscription": sub}, false, "")
+		payload, false, "")
 }
 
 // PortalSession handles POST /api/billing/portal-session (JWT required, tenant-scoped).
@@ -261,4 +302,3 @@ func (c *BillingController) StripeWebhook(ctx *gin.Context) {
 
 	ctx.Status(http.StatusOK)
 }
-

--- a/controllers/billing_controller_test.go
+++ b/controllers/billing_controller_test.go
@@ -25,14 +25,16 @@ import (
 // ─── mock billing repository ─────────────────────────────────────────────────
 
 type mockBillingRepo struct {
-	sub              *database.Subscription
-	getSubErr        *responses.InternalResponse
-	upsertErr        *responses.InternalResponse
-	updateStatusErr  *responses.InternalResponse
+	sub               *database.Subscription
+	tenant            *database.Tenant
+	getSubErr         *responses.InternalResponse
+	getTenantErr      *responses.InternalResponse
+	upsertErr         *responses.InternalResponse
+	updateStatusErr   *responses.InternalResponse
 	updateCustomerErr *responses.InternalResponse
-	updateTenantErr  *responses.InternalResponse
-	processedEvents  map[string]bool
-	adminUserID      string
+	updateTenantErr   *responses.InternalResponse
+	processedEvents   map[string]bool
+	adminUserID       string
 }
 
 func (m *mockBillingRepo) GetSubscriptionByTenant(_ string) (*database.Subscription, *responses.InternalResponse) {
@@ -95,6 +97,10 @@ func (m *mockBillingRepo) GetTenantAdminUserID(_ string) (string, *responses.Int
 	return m.adminUserID, nil
 }
 
+func (m *mockBillingRepo) GetTenantByID(_ string) (*database.Tenant, *responses.InternalResponse) {
+	return m.tenant, m.getTenantErr
+}
+
 var _ ports.BillingRepository = (*mockBillingRepo)(nil)
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
@@ -107,13 +113,13 @@ const (
 
 func newTestBillingConfig() configuration.Config {
 	return configuration.Config{
-		StripeSecretKey:      "sk_test_dummy",
-		StripeWebhookSecret:  testWebhookSecret,
-		StripePriceStarter:   testPriceStarter,
-		StripePricePro:       "price_pro_test",
+		StripeSecretKey:       "sk_test_dummy",
+		StripeWebhookSecret:   testWebhookSecret,
+		StripePriceStarter:    testPriceStarter,
+		StripePricePro:        "price_pro_test",
 		StripePriceEnterprise: "price_enterprise_test",
-		AppURL:               "http://localhost:4200",
-		TenantID:             testTenantID,
+		AppURL:                "http://localhost:4200",
+		TenantID:              testTenantID,
 	}
 }
 
@@ -226,6 +232,42 @@ func TestBillingController_GetSubscription_WithSub(t *testing.T) {
 	assert.Equal(t, "active", sub["status"])
 }
 
+// TestBillingSubscription_NullSubscriptionReturnsTrialEndsAt verifies the B4 fix (S3.5.5):
+// when the tenant has NO Stripe subscription yet but is in trial period, the response must
+// surface tenant.trial_ends_at + tenant.status so the frontend banner shows the real deadline.
+func TestBillingSubscription_NullSubscriptionReturnsTrialEndsAt(t *testing.T) {
+	trialEnd := time.Date(2026, 5, 11, 20, 7, 37, 0, time.UTC)
+	repo := &mockBillingRepo{
+		sub: nil, // tenant has no Stripe subscription
+		tenant: &database.Tenant{
+			ID:          testTenantID,
+			Name:        "Acme Inc",
+			Status:      "trial",
+			TrialEndsAt: trialEnd,
+			IsActive:    true,
+		},
+	}
+	ctrl := newBillingController(repo)
+	r := newBillingRouter(ctrl)
+
+	req := httptest.NewRequest(http.MethodGet, "/billing/subscription", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].(map[string]interface{})
+
+	// Subscription stays null.
+	assert.Nil(t, data["subscription"])
+
+	// trial_ends_at and tenant_status MUST be present (B4 root cause).
+	require.NotNil(t, data["trial_ends_at"], "trial_ends_at must be exposed when subscription is null")
+	assert.Equal(t, "2026-05-11T20:07:37Z", data["trial_ends_at"])
+	assert.Equal(t, "trial", data["tenant_status"])
+}
+
 func TestBillingController_GetSubscription_RepoError(t *testing.T) {
 	repo := &mockBillingRepo{
 		getSubErr: &responses.InternalResponse{
@@ -322,10 +364,10 @@ func TestBillingController_Webhook_UnknownEventType_Returns200(t *testing.T) {
 		"data": map[string]interface{}{
 			"object": map[string]interface{}{},
 		},
-		"livemode":          false,
-		"pending_webhooks":  0,
-		"request":           nil,
-		"api_version":       "2024-06-20",
+		"livemode":         false,
+		"pending_webhooks": 0,
+		"request":          nil,
+		"api_version":      "2024-06-20",
 	}
 	payload, err := json.Marshal(eventPayload)
 	require.NoError(t, err)
@@ -547,9 +589,9 @@ func TestBillingService_HandleSubscriptionUpdated(t *testing.T) {
 
 	now := time.Now()
 	stripeSub := &stripe.Subscription{
-		ID:                subID,
-		Status:            stripe.SubscriptionStatus("past_due"),
-		CancelAtPeriodEnd: true,
+		ID:                 subID,
+		Status:             stripe.SubscriptionStatus("past_due"),
+		CancelAtPeriodEnd:  true,
 		CurrentPeriodStart: now.Unix(),
 		CurrentPeriodEnd:   now.Add(30 * 24 * time.Hour).Unix(),
 		Metadata: map[string]string{

--- a/ports/billing.go
+++ b/ports/billing.go
@@ -41,4 +41,9 @@ type BillingRepository interface {
 
 	// GetTenantAdminUserID returns the user ID of the admin for a tenant (for notifications).
 	GetTenantAdminUserID(tenantID string) (string, *responses.InternalResponse)
+
+	// GetTenantByID returns the tenant row for a tenant ID, or nil if not found.
+	// Used by GET /api/billing/subscription to expose trial_ends_at + status when the
+	// tenant has no Stripe subscription yet (B4 fix — S3.5.5).
+	GetTenantByID(tenantID string) (*database.Tenant, *responses.InternalResponse)
 }

--- a/repositories/billing_repository.go
+++ b/repositories/billing_repository.go
@@ -169,6 +169,20 @@ func (r *BillingRepository) MarkWebhookEventProcessed(eventID string) *responses
 	return nil
 }
 
+// GetTenantByID returns the tenant row for a tenant ID, or nil if not found.
+// Used by GET /api/billing/subscription to expose trial_ends_at + status (B4 fix — S3.5.5).
+func (r *BillingRepository) GetTenantByID(tenantID string) (*database.Tenant, *responses.InternalResponse) {
+	var tenant database.Tenant
+	err := r.DB.Where("id = ?", tenantID).First(&tenant).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, &responses.InternalResponse{Error: err, Message: "Error obteniendo tenant", Handled: false}
+	}
+	return &tenant, nil
+}
+
 // GetTenantAdminUserID returns the user ID of the first active admin user (for notifications).
 // NOTE: the users table has no tenant_id column and no direct role string — it uses role_id (FK to roles).
 // We JOIN users → roles and filter by LOWER(roles.name) = 'admin'.

--- a/services/billing_service.go
+++ b/services/billing_service.go
@@ -25,12 +25,12 @@ type BillingHandlerError struct {
 
 // validPlans maps plan name → Stripe Price ID (populated at construction from config).
 type BillingService struct {
-	repo        ports.BillingRepository
-	notifSvc    *NotificationsService
-	tenantID    string
-	priceIDs    map[string]string
+	repo          ports.BillingRepository
+	notifSvc      *NotificationsService
+	tenantID      string
+	priceIDs      map[string]string
 	webhookSecret string
-	appURL      string
+	appURL        string
 }
 
 // NewBillingService constructs a BillingService. Stripe API key is set globally (stripe.Key).
@@ -179,6 +179,19 @@ func (s *BillingService) GetSubscription(tenantID string) (*database.Subscriptio
 		tenantID = s.tenantID
 	}
 	return s.repo.GetSubscriptionByTenant(tenantID)
+}
+
+// GetTenantTrialInfo returns the tenant's trial_ends_at + status for the billing endpoint.
+// Used by GET /api/billing/subscription to surface the trial deadline on the frontend banner
+// even when there is no Stripe subscription yet (B4 fix — S3.5.5).
+//
+// Returns (nil, nil) if the tenant row does not exist (defensive — should never happen for an
+// authenticated request, but the controller falls back gracefully).
+func (s *BillingService) GetTenantTrialInfo(tenantID string) (*database.Tenant, *responses.InternalResponse) {
+	if tenantID == "" {
+		tenantID = s.tenantID
+	}
+	return s.repo.GetTenantByID(tenantID)
 }
 
 // HandleCheckoutSessionCompleted processes a checkout.session.completed Stripe event.


### PR DESCRIPTION
## Summary

- Fixes B4 root cause: `GET /api/billing/subscription` returned `{subscription: null}` for trial tenants, leaving the frontend banner without the real `trial_ends_at` and falling back to "Your trial expires today".
- Endpoint now always returns `trial_ends_at` + `tenant_status` from `tenants` table (source of truth for the SaaS trial window), independent of Stripe subscription state.
- Graceful degrade: if tenant lookup fails the endpoint still returns the subscription payload (banner falls back, but billing flow stays functional).

## Response shape (after)

```json
{
  "data": {
    "subscription": null,
    "trial_ends_at": "2026-05-11T20:07:37Z",
    "tenant_status": "trial"
  }
}
```

When a Stripe subscription exists, `subscription` is populated and `trial_ends_at` / `tenant_status` are still surfaced (frontend uses tenant trial as the banner source of truth).

## Changes

- `ports/billing.go` — add `GetTenantByID(tenantID)` to repo interface
- `repositories/billing_repository.go` — GORM impl querying `tenants` by `id`
- `services/billing_service.go` — add `GetTenantTrialInfo(tenantID)` wrapper
- `controllers/billing_controller.go` — enrich `GetSubscription` response with `trial_ends_at` + `tenant_status`; defensive degrade on lookup failure
- `controllers/billing_controller_test.go` — add `TestBillingSubscription_NullSubscriptionReturnsTrialEndsAt`; extend mock with `GetTenantByID` + `tenant` field

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean for touched files
- [x] `go test ./...` passes (controllers + services + repositories + tools + models/database)
- [x] New test `TestBillingSubscription_NullSubscriptionReturnsTrialEndsAt` passes
- [ ] Manual smoke: `GET /api/billing/subscription` for new trial tenant returns `trial_ends_at` matching `tenants.trial_ends_at`
- [ ] Frontend banner shows correct days-left countdown after pulling this fix