### PR TITLE
feat(s3.7-companion): backend honors seed_demo_data flag from signup payload (B23 complement)

### DIFF
--- a/db/migrations/000036_signup_tokens_seed_demo_data.down.sql
+++ b/db/migrations/000036_signup_tokens_seed_demo_data.down.sql
@@ -1,0 +1,4 @@
+-- 000036_signup_tokens_seed_demo_data.down.sql
+-- Reverses 000036_signup_tokens_seed_demo_data.up.sql.
+
+ALTER TABLE signup_tokens DROP COLUMN IF EXISTS seed_demo_data;

--- a/db/migrations/000036_signup_tokens_seed_demo_data.up.sql
+++ b/db/migrations/000036_signup_tokens_seed_demo_data.up.sql
@@ -1,0 +1,18 @@
+-- Migration 000036: Add seed_demo_data flag to signup_tokens (S3.7 companion).
+--
+-- Sprint S3.7 W3 (frontend) shipped a "Cargar datos de demostración" checkbox
+-- on the signup form (PR #32). The frontend now sends `seed_demo_data` in the
+-- POST /api/signup payload, but until this migration the backend ignored it
+-- and ALWAYS ran SeedFarma — every brand-new tenant got 100 SKUs / 20 receiving
+-- tasks / 15 picking tasks / 10 locations whether they wanted them or not.
+--
+-- This column persists the user's choice on the pending signup_tokens row so
+-- VerifySignup can honor it when finalising the tenant.
+--
+-- Default TRUE preserves backwards compatibility:
+--   * Pre-existing rows (still pending verification) keep seeding as before.
+--   * Old frontend builds that don't send the field default to seeding too.
+--   * Only an explicit `seed_demo_data: false` from the new frontend opts out.
+
+ALTER TABLE signup_tokens
+  ADD COLUMN IF NOT EXISTS seed_demo_data BOOLEAN NOT NULL DEFAULT TRUE;

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -511,6 +511,7 @@ type SignupToken struct {
 	CreatedAt        time.Time          `json:"created_at"`
 	AdminName        string             `json:"admin_name"`
 	AdminPasswordEnc string             `json:"admin_password_enc"`
+	SeedDemoData     bool               `json:"seed_demo_data"`
 }
 
 type StockAlert struct {

--- a/models/database/signup_token.go
+++ b/models/database/signup_token.go
@@ -14,6 +14,7 @@ type SignupToken struct {
 	Token              string     `gorm:"column:token;unique" json:"-"`             // sensitive — omit from JSON
 	AdminName          string     `gorm:"column:admin_name" json:"-"`               // migration 000027
 	AdminPasswordEnc   string     `gorm:"column:admin_password_enc" json:"-"`       // migration 000027 — encrypted at rest
+	SeedDemoData       bool       `gorm:"column:seed_demo_data;default:true" json:"seed_demo_data"` // migration 000036 — S3.7 companion (B23)
 	ExpiresAt          time.Time  `gorm:"column:expires_at" json:"expires_at"`
 	UsedAt             *time.Time `gorm:"column:used_at" json:"used_at,omitempty"`
 	CreatedAt          time.Time  `gorm:"column:created_at;autoCreateTime" json:"created_at"`

--- a/models/requests/signup_request.go
+++ b/models/requests/signup_request.go
@@ -2,12 +2,19 @@ package requests
 
 // SignupRequest is the body for POST /api/signup.
 // All fields are required. TenantSlug must match ^[a-z0-9-]{3,32}$.
+//
+// SeedDemoData (S3.7 companion / B23) is OPTIONAL — pointer so the controller
+// can distinguish "not sent" (nil → default true for backwards compat) from
+// "explicitly false" (opt-out). The frontend's signup form ships this as a
+// checkbox defaulting to OFF; users who want demo data tick it on, signup
+// payloads from older clients that omit the field continue to seed.
 type SignupRequest struct {
 	Email        string `json:"email"         validate:"required,email"`
 	CompanyName  string `json:"company_name"  validate:"required,min=2,max=120"`
 	TenantSlug   string `json:"tenant_slug"   validate:"required,min=3,max=32"`
 	AdminName    string `json:"admin_name"    validate:"required,min=2,max=80"`
 	AdminPassword string `json:"admin_password" validate:"required,min=8"`
+	SeedDemoData *bool  `json:"seed_demo_data,omitempty"`
 }
 
 // SignupVerifyRequest is the body for POST /api/signup/verify.

--- a/repositories/signup_integration_test.go
+++ b/repositories/signup_integration_test.go
@@ -384,3 +384,144 @@ func TestSignup_FailsLoudIfNoAdminRole(t *testing.T) {
 // This is a unit-level smoke test in signup_controller_test.go.
 // The heavy rate-limit test (TCP-level, 6 real requests) is left as a manual
 // smoke test to avoid flakiness in CI (timing-sensitive).
+
+// ─── S3.7 companion (B23): seed_demo_data flag honored ──────────────────────
+//
+// Until S3.7 backend always ran SeedFarma. The frontend (PR #32) shipped a
+// checkbox letting users opt out, but the backend silently ignored the flag.
+// These regression tests pin the new contract:
+//   * seed_demo_data=true            → SeedFarma runs (50 RX articles seeded)
+//   * seed_demo_data=false           → SeedFarma SKIPPED (0 articles)
+//   * seed_demo_data omitted (nil)   → defaults to true (backwards compat)
+//
+// SeedFarma runs in a goroutine, so the "true" cases poll demo_data_seeds.
+// The "false" case asserts the column persisted false AND no demo_data_seeds
+// row appeared after a short wait (proving the goroutine never fired).
+
+func boolPtr(b bool) *bool { return &b }
+
+// waitForFarmaSeed polls demo_data_seeds for up to `d` waiting for the async
+// SeedFarma goroutine to insert its row. Returns true if found.
+func waitForFarmaSeed(t *testing.T, db *gorm.DB, tenantID string, d time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		var count int64
+		if err := db.Model(&database.DemoDataSeed{}).
+			Where("tenant_id = ? AND seed_name = ?", tenantID, tools.FarmaSeedName).
+			Count(&count).Error; err == nil && count > 0 {
+			return true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return false
+}
+
+func TestSignup_SeedDemoDataTrue_RunsSeeder(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	seedAdminRole(t, db)
+	repo := signupRepo(db)
+	ctx := context.Background()
+
+	req := requests.SignupRequest{
+		Email:         "seed.true@test.com",
+		CompanyName:   "Seed True Co",
+		TenantSlug:    "seedtrueco",
+		AdminName:     "Seed True Admin",
+		AdminPassword: "TestP@ssw0rd!",
+		SeedDemoData:  boolPtr(true),
+	}
+	require.Nil(t, repo.InitiateSignup(ctx, req))
+
+	var st database.SignupToken
+	require.NoError(t, db.Where("LOWER(email) = LOWER(?)", req.Email).First(&st).Error)
+	assert.True(t, st.SeedDemoData, "explicit true must persist on signup_tokens row")
+
+	result, errResp := repo.VerifySignup(ctx, st.Token)
+	require.Nil(t, errResp)
+	require.NotNil(t, result)
+
+	// Async SeedFarma should populate demo_data_seeds within a few seconds.
+	assert.True(t, waitForFarmaSeed(t, db, result.TenantID, 10*time.Second),
+		"SeedFarma must run when seed_demo_data=true (no demo_data_seeds row appeared)")
+}
+
+func TestSignup_SeedDemoDataFalse_SkipsSeeder(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	seedAdminRole(t, db)
+	repo := signupRepo(db)
+	ctx := context.Background()
+
+	req := requests.SignupRequest{
+		Email:         "seed.false@test.com",
+		CompanyName:   "Seed False Co",
+		TenantSlug:    "seedfalseco",
+		AdminName:     "Seed False Admin",
+		AdminPassword: "TestP@ssw0rd!",
+		SeedDemoData:  boolPtr(false),
+	}
+	require.Nil(t, repo.InitiateSignup(ctx, req))
+
+	var st database.SignupToken
+	require.NoError(t, db.Where("LOWER(email) = LOWER(?)", req.Email).First(&st).Error)
+	assert.False(t, st.SeedDemoData, "explicit false must persist on signup_tokens row")
+
+	result, errResp := repo.VerifySignup(ctx, st.Token)
+	require.Nil(t, errResp)
+	require.NotNil(t, result)
+
+	// Wait long enough that a real SeedFarma goroutine would have started AND
+	// written its demo_data_seeds marker. If we still see zero rows the skip
+	// branch was taken.
+	time.Sleep(2 * time.Second)
+
+	var seedCount int64
+	require.NoError(t, db.Model(&database.DemoDataSeed{}).
+		Where("tenant_id = ? AND seed_name = ?", result.TenantID, tools.FarmaSeedName).
+		Count(&seedCount).Error)
+	assert.EqualValues(t, 0, seedCount,
+		"SeedFarma must NOT run when seed_demo_data=false (demo_data_seeds row should not exist)")
+
+	var articleCount int64
+	require.NoError(t, db.Model(&database.Article{}).
+		Where("tenant_id = ?", result.TenantID).Count(&articleCount).Error)
+	assert.EqualValues(t, 0, articleCount,
+		"tenant must land on a blank WMS (0 articles) when opted out of demo data")
+}
+
+func TestSignup_SeedDemoDataNil_DefaultsToTrue(t *testing.T) {
+	db, cleanup := setupGORMTestDB(t)
+	defer cleanup()
+
+	seedAdminRole(t, db)
+	repo := signupRepo(db)
+	ctx := context.Background()
+
+	// Backwards-compat: older frontends (pre-S3.7) don't send seed_demo_data.
+	// nil pointer must default to TRUE so existing clients keep seeding.
+	req := requests.SignupRequest{
+		Email:         "seed.nil@test.com",
+		CompanyName:   "Seed Nil Co",
+		TenantSlug:    "seednilco",
+		AdminName:     "Seed Nil Admin",
+		AdminPassword: "TestP@ssw0rd!",
+		// SeedDemoData intentionally omitted (nil)
+	}
+	require.Nil(t, repo.InitiateSignup(ctx, req))
+
+	var st database.SignupToken
+	require.NoError(t, db.Where("LOWER(email) = LOWER(?)", req.Email).First(&st).Error)
+	assert.True(t, st.SeedDemoData,
+		"nil SeedDemoData must default to TRUE for backwards compatibility")
+
+	result, errResp := repo.VerifySignup(ctx, st.Token)
+	require.Nil(t, errResp)
+	require.NotNil(t, result)
+
+	assert.True(t, waitForFarmaSeed(t, db, result.TenantID, 10*time.Second),
+		"SeedFarma must run when seed_demo_data is omitted (nil → default true)")
+}

--- a/repositories/signup_repository.go
+++ b/repositories/signup_repository.go
@@ -100,6 +100,15 @@ func (r *SignupRepository) InitiateSignup(ctx context.Context, req requests.Sign
 		return &responses.InternalResponse{Error: err, Message: "Error al procesar contraseña", Handled: false}
 	}
 
+	// S3.7 companion (B23): persist the user's demo-data choice on the pending
+	// token row so VerifySignup can honor it. nil → default true (backwards
+	// compat with older frontends + pre-existing pending tokens migrated with
+	// DEFAULT TRUE in 000036).
+	seedDemoData := true
+	if req.SeedDemoData != nil {
+		seedDemoData = *req.SeedDemoData
+	}
+
 	id := uuid.NewString()
 	st := database.SignupToken{
 		ID:               id,
@@ -109,6 +118,7 @@ func (r *SignupRepository) InitiateSignup(ctx context.Context, req requests.Sign
 		Token:            token,
 		AdminName:        req.AdminName,
 		AdminPasswordEnc: encryptedPwd,
+		SeedDemoData:     seedDemoData,
 		ExpiresAt:        time.Now().Add(24 * time.Hour),
 	}
 
@@ -273,18 +283,30 @@ func (r *SignupRepository) VerifySignup(ctx context.Context, token string) (*res
 		return nil, &responses.InternalResponse{Error: txErr, Message: "Error al completar registro", Handled: false}
 	}
 
-	// After tx: trigger farma demo seed in background goroutine.
+	// After tx: trigger farma demo seed in background goroutine — but only when
+	// the signup explicitly opted in (or the request omitted the field, which
+	// defaults to true via the column DEFAULT + InitiateSignup nil-check). When
+	// the user opted out we skip SeedFarma entirely so the tenant lands on a
+	// blank WMS (0 articles / 0 tasks / 0 locations).
+	//
 	// SeedFarma is idempotent (checks demo_data_seeds before inserting).
 	// S3.5.3 N3: pass adminID through so seeded receiving + picking tasks reference
 	// a real users.id and survive the repository INNER JOIN to users. Previously
 	// tenantID was implicitly used, dropping every demo row from the dashboard.
-	go func(tID, aID string) {
-		bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
-		if err := tools.SeedFarma(bgCtx, r.DB, tID, aID); err != nil {
-			log.Error().Err(err).Str("tenant_id", tID).Msg("farma demo seed failed (background)")
-		}
-	}(tenantID, adminID)
+	if st.SeedDemoData {
+		go func(tID, aID string) {
+			bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+			if err := tools.SeedFarma(bgCtx, r.DB, tID, aID); err != nil {
+				log.Error().Err(err).Str("tenant_id", tID).Msg("farma demo seed failed (background)")
+			}
+		}(tenantID, adminID)
+	} else {
+		log.Info().
+			Str("tenant_id", tenantID).
+			Str("email", st.Email).
+			Msg("signup verified — demo data seed skipped (seed_demo_data=false)")
+	}
 
 	adminName := st.AdminName
 	if adminName == "" {


### PR DESCRIPTION
## Summary

- **B23 complement (backend half).** S3.7 W3 frontend (PR #32, deployed) added a "Cargar datos de demostración" checkbox (default OFF) to the signup form and now ships `seed_demo_data` in the `POST /api/signup` payload. Backend was silently ignoring it — every new tenant kept receiving SeedFarma's 50 articles / 20 receiving tasks / 15 picking tasks / ~10 locations regardless of user choice.
- **Migration 000036** adds `seed_demo_data BOOLEAN NOT NULL DEFAULT TRUE` to `signup_tokens`. `DEFAULT TRUE` preserves backwards compat with pre-existing pending tokens AND older frontend builds that omit the field; only an explicit `false` opts out.
- **`SignupRequest.SeedDemoData`** is `*bool` (omitempty) so the controller can distinguish "not sent" (nil → default true) from "explicitly false".
- **`SignupRepository.InitiateSignup`** persists the choice on the pending token row.
- **`SignupRepository.VerifySignup`** reads the flag — when true (or default) the existing async SeedFarma goroutine fires; when false the goroutine is skipped entirely and an `INFO` log records the skip for ops visibility. The tenant lands on a blank WMS (0 articles / 0 tasks / 0 locations).
- **Three regression integration tests** (`TestSignup_SeedDemoData{True,False,Nil}_*`) pin the new contract; they skip when Docker is unavailable (matching the rest of the integration suite) and run in CI via testcontainers.

## Test plan

- [x] `grep -rn '<<<<<<<\|>>>>>>>'` → 0 markers
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -short -race -count=1 ./...` → all packages green, 0 NEW failures
- [x] `make sqlc` → only expected diff (new `SeedDemoData` field on auto-generated `SignupToken` struct)
- [x] `git status` → only expected files
- [ ] CI runs the new integration tests against Postgres (testcontainers) and verifies all three branches pass
- [ ] Post-deploy QA: signup with checkbox OFF → tenant has 0 articles / 0 tasks; signup with checkbox ON → 50 articles + tasks seeded as before

## Files

- `db/migrations/000036_signup_tokens_seed_demo_data.{up,down}.sql` (new)
- `db/sqlc/models.go` (sqlc-regenerated)
- `models/database/signup_token.go`
- `models/requests/signup_request.go`
- `repositories/signup_repository.go`
- `repositories/signup_integration_test.go`