### PR TITLE
fix(s3.7-companion): drop GORM default:true on SeedDemoData (B23 silent opt-out bug)

### DIFF
--- a/models/database/signup_token.go
+++ b/models/database/signup_token.go
@@ -14,7 +14,10 @@ type SignupToken struct {
 	Token              string     `gorm:"column:token;unique" json:"-"`             // sensitive — omit from JSON
 	AdminName          string     `gorm:"column:admin_name" json:"-"`               // migration 000027
 	AdminPasswordEnc   string     `gorm:"column:admin_password_enc" json:"-"`       // migration 000027 — encrypted at rest
-	SeedDemoData       bool       `gorm:"column:seed_demo_data;default:true" json:"seed_demo_data"` // migration 000036 — S3.7 companion (B23)
+	// S3.7 companion fix (B23): drop GORM `default:true` tag — caused Create() to treat
+	// explicit `false` as zero-value-unset → DB applied SQL DEFAULT TRUE → user opt-out
+	// silently ignored. SQL DEFAULT TRUE en migration 000036 preserved (legacy rows).
+	SeedDemoData       bool       `gorm:"column:seed_demo_data" json:"seed_demo_data"`              // migration 000036 — S3.7 companion (B23)
 	ExpiresAt          time.Time  `gorm:"column:expires_at" json:"expires_at"`
 	UsedAt             *time.Time `gorm:"column:used_at" json:"used_at,omitempty"`
 	CreatedAt          time.Time  `gorm:"column:created_at;autoCreateTime" json:"created_at"`


### PR DESCRIPTION
QA browser smoke caught — signup checkbox false ignored due to GORM zero-value-as-unset gotcha. Drop GORM default tag, keep SQL DEFAULT for backwards compat.