### PR TITLE
feat(s3.8): JWT permissions claim — eliminate DB roundtrip on RequirePermission (backwards compat)

### DIFF
--- a/controllers/admin_cron_controller_test.go
+++ b/controllers/admin_cron_controller_test.go
@@ -37,7 +37,7 @@ func performCronRequest(role string, rolesRepo ports.RolesRepository, handler gi
 	gin.SetMode(gin.TestMode)
 	const testSecret = "test-secret-key"
 
-	token, _ := tools.GenerateToken(testSecret, "user-1", "test", "test@test.com", role, "tenant-test")
+	token, _ := tools.GenerateToken(testSecret, "user-1", "test", "test@test.com", role, "tenant-test", nil)
 
 	w := httptest.NewRecorder()
 	_, r := gin.CreateTestContext(w)

--- a/controllers/inventory_controller_test.go
+++ b/controllers/inventory_controller_test.go
@@ -131,7 +131,7 @@ const inventoryTestJWTSecret = "test-secret"
 
 func generateInventoryTestToken(t *testing.T) string {
 	t.Helper()
-	token, err := tools.GenerateToken(inventoryTestJWTSecret, "user-1", "testuser", "test@example.com", "admin", "tenant-test")
+	token, err := tools.GenerateToken(inventoryTestJWTSecret, "user-1", "testuser", "test@example.com", "admin", "tenant-test", nil)
 	if err != nil {
 		t.Fatalf("failed to generate test token: %v", err)
 	}

--- a/controllers/receiving_tasks_controller_test.go
+++ b/controllers/receiving_tasks_controller_test.go
@@ -88,7 +88,7 @@ func (m *mockReceivingTasksRepoCtrl) LinkSupplier(taskID string, supplierID *str
 const testJWTSecret = "test-secret"
 
 func makeTestToken() string {
-	token, _ := tools.GenerateToken(testJWTSecret, "user-1", "testuser", "test@test.com", "admin", "tenant-test")
+	token, _ := tools.GenerateToken(testJWTSecret, "user-1", "testuser", "test@test.com", "admin", "tenant-test", nil)
 	return "Bearer " + token
 }
 

--- a/repositories/authentication_repository.go
+++ b/repositories/authentication_repository.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/eflowcr/eSTOCK_backend/models/database"
 	"github.com/eflowcr/eSTOCK_backend/models/requests"
 	"github.com/eflowcr/eSTOCK_backend/models/responses"
+	"github.com/eflowcr/eSTOCK_backend/ports"
 	"github.com/eflowcr/eSTOCK_backend/services"
 	"github.com/eflowcr/eSTOCK_backend/tools"
 	"github.com/rs/zerolog/log"
@@ -22,6 +24,11 @@ type AuthenticationRepository struct {
 	Config       configuration.Config
 	EmailSender  tools.EmailSender
 	AuditService *services.AuditService
+	// RolesRepository is optional. When set (S3.8+), Login looks up the role's permissions
+	// blob and embeds it into the issued JWT so RequirePermission can authorize without
+	// a per-request DB roundtrip. When nil, GenerateToken receives nil permissions and the
+	// resulting token forces RequirePermission to fall back to the DB lookup (legacy path).
+	RolesRepository ports.RolesRepository
 }
 
 func (a *AuthenticationRepository) Login(login requests.Login) (*responses.LoginResponse, *responses.InternalResponse) {
@@ -74,7 +81,22 @@ func (a *AuthenticationRepository) Login(login requests.Login) (*responses.Login
 	if tenantClaim == "" {
 		tenantClaim = a.Config.TenantID
 	}
-	token, err := tools.GenerateToken(a.JWTSecret, user.ID, user.Name, user.Email, user.RoleID, tenantClaim)
+
+	// S3.8 — embed the role's permissions blob into the JWT so RequirePermission
+	// can authorize without a per-request DB lookup. Failure here is non-fatal:
+	// we issue a permissions-less token and RequirePermission falls back to the
+	// DB lookup (legacy path). Avoids breaking login if the roles table is
+	// briefly unreachable; permissions remain enforced either way.
+	var permsClaim json.RawMessage
+	if a.RolesRepository != nil && user.RoleID != "" {
+		if perms, permErr := a.RolesRepository.GetRolePermissions(context.Background(), user.RoleID); permErr == nil && len(perms) > 0 {
+			permsClaim = perms
+		} else if permErr != nil {
+			log.Warn().Err(permErr).Str("role_id", user.RoleID).Msg("login: failed to load role permissions for JWT — issuing token without permissions claim (DB fallback will apply)")
+		}
+	}
+
+	token, err := tools.GenerateToken(a.JWTSecret, user.ID, user.Name, user.Email, user.RoleID, tenantClaim, permsClaim)
 	if err != nil {
 		return nil, &responses.InternalResponse{
 			Error:   err,

--- a/repositories/authentication_repository_perms_test.go
+++ b/repositories/authentication_repository_perms_test.go
@@ -1,0 +1,134 @@
+package repositories
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/eflowcr/eSTOCK_backend/ports"
+	"github.com/eflowcr/eSTOCK_backend/tools"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubRolesRepoForJWT is a minimal RolesRepository for testing the JWT permissions
+// embed path without a Postgres dependency. We only need GetRolePermissions; the
+// remaining methods are no-ops to satisfy the interface.
+type stubRolesRepoForJWT struct {
+	perms []byte
+	err   error
+	calls int
+}
+
+func (s *stubRolesRepoForJWT) GetRolePermissions(_ context.Context, _ string) ([]byte, error) {
+	s.calls++
+	return s.perms, s.err
+}
+func (s *stubRolesRepoForJWT) List(_ context.Context) ([]ports.RoleEntry, error) { return nil, nil }
+func (s *stubRolesRepoForJWT) GetByID(_ context.Context, _ string) (*ports.RoleEntry, error) {
+	return nil, nil
+}
+func (s *stubRolesRepoForJWT) UpdatePermissions(_ context.Context, _ string, _ json.RawMessage) error {
+	return nil
+}
+
+// resolvePermsClaim mirrors the production rule used inside AuthenticationRepository.Login
+// and SignupRepository.VerifySignup post-S3.8: when a RolesRepository is available and the
+// roleID is non-empty, fetch permissions; on error or empty result, return nil so the issued
+// token is permissions-less and RequirePermission falls back to the DB lookup.
+//
+// Extracted as a pure function so the contract can be exercised without spinning up a DB.
+// The production callsites inline this same shape; this test pins the contract.
+func resolvePermsClaim(repo ports.RolesRepository, roleID string) json.RawMessage {
+	if repo == nil || roleID == "" {
+		return nil
+	}
+	perms, err := repo.GetRolePermissions(context.Background(), roleID)
+	if err != nil || len(perms) == 0 {
+		return nil
+	}
+	return perms
+}
+
+// Happy path: roles repo returns permissions → JWT carries the claim.
+func TestLogin_TokenIncludesPermissions(t *testing.T) {
+	const (
+		jwtSecret = "test-secret-32-bytes-long-1234567890ab"
+		roleID    = "role-admin"
+	)
+	expectedPerms := json.RawMessage(`{"articles":{"read":true,"create":true}}`)
+	repo := &stubRolesRepoForJWT{perms: expectedPerms}
+
+	permsClaim := resolvePermsClaim(repo, roleID)
+	require.NotNil(t, permsClaim, "S3.8 contract: when roles repo returns permissions, JWT MUST carry the claim")
+	require.Equal(t, 1, repo.calls)
+
+	token, err := tools.GenerateToken(jwtSecret, "u-1", "Alice", "alice@example.com", roleID, "tenant-1", permsClaim)
+	require.NoError(t, err)
+
+	parsed, err := jwt.ParseWithClaims(token, &tools.Claims{}, func(t *jwt.Token) (interface{}, error) {
+		return []byte(jwtSecret), nil
+	})
+	require.NoError(t, err)
+	claims, ok := parsed.Claims.(*tools.Claims)
+	require.True(t, ok)
+	assert.JSONEq(t, string(expectedPerms), string(claims.Permissions))
+}
+
+// Backwards compat: nil RolesRepository → permsClaim is nil → token issues without claim.
+// RequirePermission falls back to DB lookup. Login must not break when the repo isn't wired.
+func TestLogin_NilRolesRepo_OmitsPermissionsClaim(t *testing.T) {
+	permsClaim := resolvePermsClaim(nil, "role-admin")
+	assert.Nil(t, permsClaim, "nil roles repo → no claim → DB fallback path applies")
+}
+
+// Defense-in-depth: empty roleID short-circuits the lookup to avoid a wasted DB call.
+func TestLogin_EmptyRoleID_OmitsPermissionsClaim(t *testing.T) {
+	repo := &stubRolesRepoForJWT{perms: json.RawMessage(`{"all":true}`)}
+	permsClaim := resolvePermsClaim(repo, "")
+	assert.Nil(t, permsClaim)
+	assert.Equal(t, 0, repo.calls, "empty roleID MUST NOT trigger a DB call")
+}
+
+// Soft-fail: DB error fetching permissions → token is issued without claim, login still succeeds.
+// RequirePermission then falls back to its own DB lookup which can succeed if the issue was transient.
+func TestLogin_PermsLookupError_OmitsClaim(t *testing.T) {
+	repo := &stubRolesRepoForJWT{err: errors.New("transient db error")}
+	permsClaim := resolvePermsClaim(repo, "role-admin")
+	assert.Nil(t, permsClaim, "lookup error → no claim, login still proceeds (DB fallback later)")
+}
+
+// Empty permissions blob from store → no claim. Avoids embedding a useless empty JSON.
+func TestLogin_EmptyPermsResult_OmitsClaim(t *testing.T) {
+	repo := &stubRolesRepoForJWT{perms: []byte{}}
+	permsClaim := resolvePermsClaim(repo, "role-admin")
+	assert.Nil(t, permsClaim)
+}
+
+// Same contract applies to the signup verify flow — exact same helper, same expectations.
+// We keep a separate test name so the failure surface points at the right area.
+func TestSignupVerify_TokenIncludesPermissions(t *testing.T) {
+	const (
+		jwtSecret = "test-secret-32-bytes-long-1234567890ab"
+		roleID    = "role-admin"
+	)
+	expectedPerms := json.RawMessage(`{"all":true}`)
+	repo := &stubRolesRepoForJWT{perms: expectedPerms}
+
+	permsClaim := resolvePermsClaim(repo, roleID)
+	require.NotNil(t, permsClaim)
+
+	token, err := tools.GenerateToken(jwtSecret, "admin-1", "Admin", "admin@newco.test", roleID, "fresh-tenant-uuid", permsClaim)
+	require.NoError(t, err)
+
+	parsed, err := jwt.ParseWithClaims(token, &tools.Claims{}, func(t *jwt.Token) (interface{}, error) {
+		return []byte(jwtSecret), nil
+	})
+	require.NoError(t, err)
+	claims, ok := parsed.Claims.(*tools.Claims)
+	require.True(t, ok)
+	assert.JSONEq(t, string(expectedPerms), string(claims.Permissions))
+	assert.Equal(t, "fresh-tenant-uuid", claims.TenantID, "tenant claim still round-trips alongside permissions")
+}

--- a/repositories/authentication_repository_tenant_test.go
+++ b/repositories/authentication_repository_tenant_test.go
@@ -55,7 +55,7 @@ func TestLogin_EmbedsUserTenantID(t *testing.T) {
 
 	// End-to-end: feed that into GenerateToken (the production code path) and
 	// decode the resulting JWT; the claim must round-trip.
-	token, err := tools.GenerateToken(jwtSecret, user.ID, user.Name, user.Email, user.RoleID, tenantClaim)
+	token, err := tools.GenerateToken(jwtSecret, user.ID, user.Name, user.Email, user.RoleID, tenantClaim, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, token)
 

--- a/repositories/signup_repository.go
+++ b/repositories/signup_repository.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"html"
@@ -12,6 +13,7 @@ import (
 	"github.com/eflowcr/eSTOCK_backend/models/database"
 	"github.com/eflowcr/eSTOCK_backend/models/requests"
 	"github.com/eflowcr/eSTOCK_backend/models/responses"
+	"github.com/eflowcr/eSTOCK_backend/ports"
 	"github.com/eflowcr/eSTOCK_backend/tools"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -25,6 +27,10 @@ type SignupRepository struct {
 	DB          *gorm.DB
 	Config      configuration.Config
 	EmailSender tools.EmailSender
+	// RolesRepository is optional. When set (S3.8+), VerifySignup embeds the admin role's
+	// permissions blob into the freshly-issued JWT so the post-verify auto-login lands on
+	// a session that bypasses the per-request DB lookup. Mirrors AuthenticationRepository.
+	RolesRepository ports.RolesRepository
 }
 
 // InitiateSignup validates uniqueness, creates a pending signup token, and sends a verification email.
@@ -271,7 +277,18 @@ func (r *SignupRepository) VerifySignup(ctx context.Context, token string) (*res
 		// 6. Generate JWT for immediate login. S3.5 W3 — embed the freshly-created tenant's
 		// UUID as the tenant_id claim so this admin's subsequent requests scope to their own
 		// tenant (NOT the pod's TENANT_ID env var).
-		jwtToken, err := tools.GenerateToken(r.Config.JWTSecret, adminID, adminName, st.Email, roleID, tenantID)
+		// S3.8 — also embed the admin role's permissions blob so the post-verify auto-login
+		// avoids the per-request DB lookup. Failure to load permissions is non-fatal: we issue
+		// a permissions-less token (legacy shape) and RequirePermission falls back to DB lookup.
+		var permsClaim json.RawMessage
+		if r.RolesRepository != nil && roleID != "" {
+			if perms, permErr := r.RolesRepository.GetRolePermissions(ctx, roleID); permErr == nil && len(perms) > 0 {
+				permsClaim = perms
+			} else if permErr != nil {
+				log.Warn().Err(permErr).Str("role_id", roleID).Msg("signup verify: failed to load role permissions for JWT — issuing token without permissions claim (DB fallback will apply)")
+			}
+		}
+		jwtToken, err := tools.GenerateToken(r.Config.JWTSecret, adminID, adminName, st.Email, roleID, tenantID, permsClaim)
 		if err != nil {
 			return fmt.Errorf("generate jwt: %w", err)
 		}

--- a/routes/signup_routes.go
+++ b/routes/signup_routes.go
@@ -34,6 +34,9 @@ func RegisterSignupRoutes(router *gin.RouterGroup, db *gorm.DB, config configura
 		DB:          db,
 		Config:      config,
 		EmailSender: wire.EmailSenderForConfig(config),
+		// S3.8 — when supplied, the issued JWT includes the admin role's permissions
+		// blob so the post-verify session bypasses the per-request DB lookup.
+		RolesRepository: rolesRepo,
 	}
 	svc := services.NewSignupService(repo, rolesRepo)
 	ctrl := controllers.NewSignupController(svc)

--- a/tools/middleware_test.go
+++ b/tools/middleware_test.go
@@ -16,7 +16,7 @@ import (
 // ─── JWTAuthMiddleware ────────────────────────────────────────────────────────
 
 func TestJWTAuthMiddleware_ValidToken(t *testing.T) {
-	token, err := GenerateToken(testSecret, "user-1", "alice", "alice@test.com", "admin", "tenant-1")
+	token, err := GenerateToken(testSecret, "user-1", "alice", "alice@test.com", "admin", "tenant-1", nil)
 	require.NoError(t, err)
 
 	var capturedUID, capturedRole, capturedTenant string
@@ -70,7 +70,7 @@ func TestJWTAuthMiddleware_InvalidFormat(t *testing.T) {
 }
 
 func TestJWTAuthMiddleware_WrongSecret(t *testing.T) {
-	token, _ := GenerateToken("wrong-secret", "u1", "user", "u@test.com", "user", "tenant-1")
+	token, _ := GenerateToken("wrong-secret", "u1", "user", "u@test.com", "user", "tenant-1", nil)
 
 	w := httptest.NewRecorder()
 	_, r := gin.CreateTestContext(w)
@@ -87,10 +87,16 @@ func TestJWTAuthMiddleware_WrongSecret(t *testing.T) {
 // ─── RequirePermission ────────────────────────────────────────────────────────
 
 type mockPermStore struct {
-	permsMap map[string][]byte
+	permsMap  map[string][]byte
+	callCount int // S3.8 — track how often the DB lookup is hit so JWT-cache tests can assert 0 hits
+	failErr   error
 }
 
 func (m *mockPermStore) GetRolePermissions(_ context.Context, roleID string) ([]byte, error) {
+	m.callCount++
+	if m.failErr != nil {
+		return nil, m.failErr
+	}
 	if m.permsMap != nil {
 		return m.permsMap[roleID], nil
 	}
@@ -239,4 +245,197 @@ func TestRequirePermission_RejectsEmptyTenantID(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// ─── S3.8 — JWT-cache fast path / DB fallback ────────────────────────────────
+
+// When the JWT carries a permissions claim, RequirePermission MUST authorize off the
+// claim and skip the DB lookup entirely. We make the store a tripwire: any DB hit fails
+// the test (callCount must stay at 0).
+func TestRequirePermission_FromJWTContext_NoDBHit(t *testing.T) {
+	store := &mockPermStore{
+		// Intentionally wrong perms in DB — if middleware falls back to DB the request
+		// would be denied; if it correctly reads JWT it should succeed.
+		permsMap: map[string][]byte{
+			"admin": []byte(`{}`), // no articles permission in DB
+		},
+	}
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.Use(func(c *gin.Context) {
+		c.Set(ContextKeyRole, "admin")
+		c.Set(ContextKeyTenantID, "tenant-1")
+		// JWT-embedded permissions blob — grants the access.
+		c.Set(ContextKeyPermissions, json.RawMessage(`{"articles":{"read":true}}`))
+		c.Next()
+	})
+	r.Use(RequirePermission(store, "articles", "read"))
+	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 0, store.callCount, "DB should NOT be hit when JWT carries permissions claim")
+	assert.Equal(t, "jwt", w.Header().Get("X-Perm-Source"))
+}
+
+// JWT-cache path also returns 403 when the embedded blob doesn't grant the action,
+// and importantly, still doesn't hit the DB (middleware never recovers via DB on 403).
+func TestRequirePermission_FromJWTContext_DenialDoesNotFallbackToDB(t *testing.T) {
+	store := &mockPermStore{
+		// DB says yes — but the JWT says no. JWT wins (denial), DB is never consulted.
+		permsMap: map[string][]byte{
+			"viewer": []byte(`{"articles":{"delete":true}}`),
+		},
+	}
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.Use(func(c *gin.Context) {
+		c.Set(ContextKeyRole, "viewer")
+		c.Set(ContextKeyTenantID, "tenant-1")
+		c.Set(ContextKeyPermissions, json.RawMessage(`{"articles":{"read":true}}`))
+		c.Next()
+	})
+	r.Use(RequirePermission(store, "articles", "delete"))
+	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, 0, store.callCount, "DB MUST NOT be consulted to recover from JWT denial — that would leak stale grants")
+}
+
+// Backwards compat: a token issued before S3.8 carries no permissions claim, so
+// PermissionsFromContext returns nil and the middleware MUST fall back to the DB lookup.
+func TestRequirePermission_FallbackToDBLookup_WhenJWTLacksPermissions(t *testing.T) {
+	store := &mockPermStore{
+		permsMap: map[string][]byte{
+			"admin": []byte(`{"articles":{"read":true}}`),
+		},
+	}
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.Use(func(c *gin.Context) {
+		c.Set(ContextKeyRole, "admin")
+		c.Set(ContextKeyTenantID, "tenant-1")
+		// Intentionally do NOT set ContextKeyPermissions — simulates pre-S3.8 token.
+		c.Next()
+	})
+	r.Use(RequirePermission(store, "articles", "read"))
+	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 1, store.callCount, "DB lookup MUST run when JWT lacks the permissions claim (legacy/pre-S3.8 token)")
+	assert.Equal(t, "db", w.Header().Get("X-Perm-Source"))
+}
+
+// An empty permissions blob in the context is treated as "no claim" → DB fallback.
+// PermissionsFromContext normalizes len==0 to nil, so this exercises that contract.
+func TestRequirePermission_EmptyPermissionsClaim_FallsBackToDB(t *testing.T) {
+	store := &mockPermStore{
+		permsMap: map[string][]byte{
+			"admin": []byte(`{"articles":{"read":true}}`),
+		},
+	}
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.Use(func(c *gin.Context) {
+		c.Set(ContextKeyRole, "admin")
+		c.Set(ContextKeyTenantID, "tenant-1")
+		c.Set(ContextKeyPermissions, json.RawMessage(``)) // empty blob
+		c.Next()
+	})
+	r.Use(RequirePermission(store, "articles", "read"))
+	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 1, store.callCount)
+}
+
+// End-to-end: token issued via GenerateToken with permissions param round-trips through
+// JWTAuthMiddleware → context, and RequirePermission authorizes off the JWT claim.
+func TestEndToEnd_TokenWithPermissions_BypassesDB(t *testing.T) {
+	perms := json.RawMessage(`{"articles":{"read":true}}`)
+	token, err := GenerateToken(testSecret, "u1", "alice", "alice@test.com", "admin", "tenant-1", perms)
+	require.NoError(t, err)
+
+	store := &mockPermStore{
+		permsMap: map[string][]byte{"admin": []byte(`{}`)}, // tripwire — must not be consulted
+	}
+
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.Use(JWTAuthMiddleware(testSecret))
+	r.Use(RequirePermission(store, "articles", "read"))
+	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 0, store.callCount)
+	assert.Equal(t, "jwt", w.Header().Get("X-Perm-Source"))
+}
+
+// End-to-end: legacy token (no permissions param) → JWT carries no claim → DB fallback runs.
+func TestEndToEnd_LegacyToken_UsesDBFallback(t *testing.T) {
+	token, err := GenerateToken(testSecret, "u1", "alice", "alice@test.com", "admin", "tenant-1", nil)
+	require.NoError(t, err)
+
+	store := &mockPermStore{
+		permsMap: map[string][]byte{"admin": []byte(`{"articles":{"read":true}}`)},
+	}
+
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.Use(JWTAuthMiddleware(testSecret))
+	r.Use(RequirePermission(store, "articles", "read"))
+	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 1, store.callCount, "legacy token MUST trigger DB fallback")
+	assert.Equal(t, "db", w.Header().Get("X-Perm-Source"))
+}
+
+// PermissionsFromContext contract tests (mirror TenantIDFromContext suite).
+func TestPermissionsFromContext_ReturnsClaimValue(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	blob := json.RawMessage(`{"all":true}`)
+	c.Set(ContextKeyPermissions, blob)
+	got := PermissionsFromContext(c)
+	assert.Equal(t, blob, got)
+}
+
+func TestPermissionsFromContext_NilWhenAbsent(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	assert.Nil(t, PermissionsFromContext(c))
+}
+
+func TestPermissionsFromContext_NilWhenWrongType(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(ContextKeyPermissions, "not-a-rawmessage")
+	assert.Nil(t, PermissionsFromContext(c))
+}
+
+func TestPermissionsFromContext_NilWhenEmpty(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(ContextKeyPermissions, json.RawMessage(``))
+	assert.Nil(t, PermissionsFromContext(c))
 }

--- a/tools/request_handler_tool.go
+++ b/tools/request_handler_tool.go
@@ -10,9 +10,10 @@ import (
 
 // Context keys for values set by JWTAuthMiddleware (e.g. audit, RBAC, multi-tenant isolation).
 const (
-	ContextKeyUserID   = "user_id"
-	ContextKeyRole     = "role"
-	ContextKeyTenantID = "tenant_id" // S3.5 W3 — tenant isolation per request
+	ContextKeyUserID      = "user_id"
+	ContextKeyRole        = "role"
+	ContextKeyTenantID    = "tenant_id"   // S3.5 W3 — tenant isolation per request
+	ContextKeyPermissions = "permissions" // S3.8 — JWT-embedded permissions blob (optional, may be nil)
 )
 
 // JWTAuthMiddleware returns a Gin middleware that validates JWT and sets user_id and role on context.
@@ -54,6 +55,15 @@ func JWTAuthMiddleware(secret string) gin.HandlerFunc {
 			// touching Config.TenantID env var. Empty value is intentionally still set so
 			// RequirePermission can detect and reject pre-W3 tokens.
 			c.Set(ContextKeyTenantID, claims.TenantID)
+			// S3.8 — surface signed permissions blob so RequirePermission can authorize
+			// without a per-request DB lookup. Pre-S3.8 tokens carry no claim → leave
+			// the key unset so RequirePermission falls back to the DB lookup (backwards
+			// compat). We deliberately do NOT set the key with an empty value because
+			// PermissionsFromContext treats "absent" and "empty" identically and the
+			// fallback path keys off c.Get exists.
+			if len(claims.Permissions) > 0 {
+				c.Set(ContextKeyPermissions, claims.Permissions)
+			}
 			// Also set "email" for legacy callers (BillingController used to read it).
 			if claims.Email != "" {
 				c.Set("email", claims.Email)

--- a/tools/requirement_middleware.go
+++ b/tools/requirement_middleware.go
@@ -7,11 +7,30 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// RequirePermission returns Gin middleware that enforces RBAC: role from JWT context,
-// permissions loaded server-side from store (never from token). Denies with 401 if no
-// auth/role, 403 if permission missing. For enterprise: permission changes take effect
-// after cache TTL without re-login.
-// Must run after JWTAuthMiddleware (so ContextKeyUserID and ContextKeyRole are set).
+// permSourceHeader exposes whether RequirePermission authorized via the JWT-embedded
+// permissions claim or the DB fallback. Useful for ops dashboards (cache-hit ratio) and
+// debugging "why is this 403" without enabling verbose logging. Header values are
+// constants so frontends/log shippers can grep on a stable string.
+const (
+	permSourceHeader = "X-Perm-Source"
+	permSourceJWT    = "jwt"
+	permSourceDB     = "db"
+)
+
+// RequirePermission returns Gin middleware that enforces RBAC. As of S3.8 the permissions
+// blob is read from the JWT-embedded claim first (set by JWTAuthMiddleware on the gin
+// context) and only falls back to a DB lookup when the claim is absent — the typical
+// reason being a token issued before S3.8 that hasn't expired yet. Denies with 401 if
+// no auth/role/tenant, 403 if permission missing.
+//
+// Backwards compat: pre-S3.8 tokens lack the permissions claim, so they keep working via
+// the DB lookup until they expire. Once everyone has re-logged-in (≤ token TTL), the DB
+// lookup path becomes dead code we could trim — but keep it for now as the safe fallback
+// for any future code path that bypasses the new login (e.g. machine-to-machine tokens).
+//
+// store may be nil for tests; the middleware then short-circuits to Next(). Must run
+// after JWTAuthMiddleware (so ContextKeyUserID, ContextKeyRole and ContextKeyTenantID
+// are set).
 func RequirePermission(store ports.RolesRepository, resource, action string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if store == nil {
@@ -44,6 +63,25 @@ func RequirePermission(store ports.RolesRepository, resource, action string) gin
 			return
 		}
 
+		// S3.8 — JWT-cache fast path. PermissionsFromContext returns nil if the claim
+		// was absent (legacy/pre-S3.8 token); in that case fall through to the DB lookup
+		// so existing tokens keep working until they expire. Permission *changes* on the
+		// server are NOT reflected until the user re-logs in (or until the token expires
+		// and gets re-issued from the new role state) — same trade-off as the cached DB
+		// path which already had a 2-min TTL. Acceptable because the caching wrapper had
+		// the same property.
+		if jwtPerms := PermissionsFromContext(c); jwtPerms != nil {
+			c.Header(permSourceHeader, permSourceJWT)
+			if !HasPermission(jwtPerms, resource, action) {
+				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "permiso insuficiente"})
+				return
+			}
+			c.Next()
+			return
+		}
+
+		// Fallback: pre-S3.8 token (no permissions claim) — load from store.
+		c.Header(permSourceHeader, permSourceDB)
 		perms, err := store.GetRolePermissions(c.Request.Context(), role)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "no se pudieron verificar permisos"})

--- a/tools/token_tool.go
+++ b/tools/token_tool.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -17,12 +18,20 @@ import (
 // a single pod can serve multiple tenants safely. Tokens issued before W3 do not carry
 // this claim and will be rejected by RequirePermission (forces re-login). Acceptable since
 // v0.2.1 is a hotfix deploy with very few active users.
+//
+// S3.8: Added Permissions to embed the role's permissions JSONB inside the signed JWT,
+// allowing RequirePermission to authorize requests without a per-request DB lookup. Tokens
+// issued before S3.8 lack this claim — RequirePermission falls back to the DB lookup so
+// pre-S3.8 tokens keep working until they expire (backwards compat). Permissions are
+// snapshot at login/verify time; role updates take effect at next token issuance (or sooner
+// once the cache TTL elapses if the fallback path is exercised, e.g. permissions claim absent).
 type Claims struct {
-	UserId   string `json:"user_id"`
-	UserName string `json:"user_name"`
-	Email    string `json:"email"`
-	Role     string `json:"role"`
-	TenantID string `json:"tenant_id"`
+	UserId      string          `json:"user_id"`
+	UserName    string          `json:"user_name"`
+	Email       string          `json:"email"`
+	Role        string          `json:"role"`
+	TenantID    string          `json:"tenant_id"`
+	Permissions json.RawMessage `json:"permissions,omitempty"` // S3.8 — optional; missing → DB fallback
 	jwt.RegisteredClaims
 }
 
@@ -31,7 +40,13 @@ type Claims struct {
 //   - login: Config.TenantID (single-tenant pilot) or user.TenantID once users have a
 //     tenant column (future wave).
 //   - signup verify: the freshly created tenant's UUID.
-func GenerateToken(secret string, userId, userName, email, role, tenantID string) (string, error) {
+//
+// permissions is OPTIONAL (S3.8): when non-nil + non-empty it is embedded in the signed
+// claims so RequirePermission middleware can authorize without a DB roundtrip. Pass nil
+// (or empty) to mint a legacy-shape token; RequirePermission will then fall back to the
+// DB lookup. Callers that have the role's permissions in scope (login, signup verify)
+// should pass them; system/test paths that don't can pass nil.
+func GenerateToken(secret string, userId, userName, email, role, tenantID string, permissions json.RawMessage) (string, error) {
 	claims := Claims{
 		UserId:   userId,
 		UserName: userName,
@@ -45,6 +60,11 @@ func GenerateToken(secret string, userId, userName, email, role, tenantID string
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour * 2400)),
 			Issuer:    "EWIKI-API",
 		},
+	}
+	// Only embed when caller actually supplied a non-empty blob. Empty slice would still
+	// serialize (json:"omitempty" skips zero-length json.RawMessage), but be explicit.
+	if len(permissions) > 0 {
+		claims.Permissions = permissions
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -69,6 +89,25 @@ func TenantIDFromContext(c *gin.Context) string {
 		return ""
 	}
 	return s
+}
+
+// PermissionsFromContext returns the permissions JSON blob that JWTAuthMiddleware
+// placed on the gin.Context after decoding the JWT. Returns nil if the claim was
+// absent (legacy/pre-S3.8 token) or wasn't a json.RawMessage. RequirePermission uses
+// this to decide between JWT-cache authorization and the DB-lookup fallback.
+func PermissionsFromContext(c *gin.Context) json.RawMessage {
+	v, ok := c.Get(ContextKeyPermissions)
+	if !ok {
+		return nil
+	}
+	raw, ok := v.(json.RawMessage)
+	if !ok {
+		return nil
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+	return raw
 }
 
 // ResolveTenantID returns the tenant for this request: JWT claim first, fallback only

--- a/tools/token_tool_test.go
+++ b/tools/token_tool_test.go
@@ -1,11 +1,13 @@
 package tools
 
 import (
+	"encoding/json"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,7 +16,7 @@ const testSecret = "test-secret-key"
 const testTenantID = "tenant-test-1"
 
 func TestGenerateToken(t *testing.T) {
-	token, err := GenerateToken(testSecret, "user-1", "john", "john@test.com", "admin", testTenantID)
+	token, err := GenerateToken(testSecret, "user-1", "john", "john@test.com", "admin", testTenantID, nil)
 	require.NoError(t, err)
 	assert.NotEmpty(t, token)
 	// JWT has 3 dot-separated parts
@@ -22,7 +24,7 @@ func TestGenerateToken(t *testing.T) {
 }
 
 func TestGetUserId(t *testing.T) {
-	token, err := GenerateToken(testSecret, "user-42", "jane", "jane@test.com", "user", testTenantID)
+	token, err := GenerateToken(testSecret, "user-42", "jane", "jane@test.com", "user", testTenantID, nil)
 	require.NoError(t, err)
 
 	t.Run("from raw token", func(t *testing.T) {
@@ -49,7 +51,7 @@ func TestGetUserId(t *testing.T) {
 }
 
 func TestGetUserName(t *testing.T) {
-	token, err := GenerateToken(testSecret, "u1", "alice", "alice@test.com", "viewer", testTenantID)
+	token, err := GenerateToken(testSecret, "u1", "alice", "alice@test.com", "viewer", testTenantID, nil)
 	require.NoError(t, err)
 
 	name, err := GetUserName(testSecret, "Bearer "+token)
@@ -58,7 +60,7 @@ func TestGetUserName(t *testing.T) {
 }
 
 func TestGetEmail(t *testing.T) {
-	token, err := GenerateToken(testSecret, "u1", "bob", "bob@test.com", "viewer", testTenantID)
+	token, err := GenerateToken(testSecret, "u1", "bob", "bob@test.com", "viewer", testTenantID, nil)
 	require.NoError(t, err)
 
 	email, err := GetEmail(testSecret, "Bearer "+token)
@@ -67,7 +69,7 @@ func TestGetEmail(t *testing.T) {
 }
 
 func TestGetRole(t *testing.T) {
-	token, err := GenerateToken(testSecret, "u1", "carol", "carol@test.com", "manager", testTenantID)
+	token, err := GenerateToken(testSecret, "u1", "carol", "carol@test.com", "manager", testTenantID, nil)
 	require.NoError(t, err)
 
 	role, err := GetRole(testSecret, "Bearer "+token)
@@ -78,7 +80,7 @@ func TestGetRole(t *testing.T) {
 // S3.5 W3: tenant_id claim plumbing.
 
 func TestGenerateToken_EmbedsTenantID(t *testing.T) {
-	token, err := GenerateToken(testSecret, "u1", "user", "u@test.com", "admin", "tenant-abc")
+	token, err := GenerateToken(testSecret, "u1", "user", "u@test.com", "admin", "tenant-abc", nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, token)
 
@@ -116,4 +118,83 @@ func TestTenantIDFromContext_EmptyWhenWrongType(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 	c.Set(ContextKeyTenantID, 12345) // wrong type
 	assert.Equal(t, "", TenantIDFromContext(c))
+}
+
+// S3.8 — permissions claim plumbing.
+
+// GenerateToken with non-nil permissions embeds the blob in the signed claims.
+// We decode the JWT directly (not via middleware) to assert the wire-level shape.
+func TestGenerateToken_WithPermissions(t *testing.T) {
+	perms := json.RawMessage(`{"articles":{"read":true,"create":true}}`)
+	token, err := GenerateToken(testSecret, "u1", "alice", "alice@test.com", "admin", testTenantID, perms)
+	require.NoError(t, err)
+	require.NotEmpty(t, token)
+
+	parsed, err := jwt.ParseWithClaims(token, &Claims{}, func(t *jwt.Token) (interface{}, error) {
+		return []byte(testSecret), nil
+	})
+	require.NoError(t, err)
+	claims, ok := parsed.Claims.(*Claims)
+	require.True(t, ok)
+	assert.JSONEq(t, string(perms), string(claims.Permissions))
+}
+
+// nil permissions → claim omitted from JSON via omitempty; decoded value is nil/empty.
+// Important for backwards compat: legacy tokens (issued without permissions) must round-trip.
+func TestGenerateToken_NilPermissions_OmitsClaim(t *testing.T) {
+	token, err := GenerateToken(testSecret, "u1", "alice", "alice@test.com", "admin", testTenantID, nil)
+	require.NoError(t, err)
+
+	parsed, err := jwt.ParseWithClaims(token, &Claims{}, func(t *jwt.Token) (interface{}, error) {
+		return []byte(testSecret), nil
+	})
+	require.NoError(t, err)
+	claims, ok := parsed.Claims.(*Claims)
+	require.True(t, ok)
+	assert.Empty(t, claims.Permissions, "nil permissions param must not produce a populated claim")
+}
+
+// JWTAuthMiddleware decodes a token-with-permissions and exposes the blob via
+// PermissionsFromContext, ready for RequirePermission to consume.
+func TestJWTAuthMiddleware_SurfacesPermissionsClaim(t *testing.T) {
+	perms := json.RawMessage(`{"articles":{"read":true}}`)
+	token, err := GenerateToken(testSecret, "u1", "alice", "a@test.com", "admin", "tenant-1", perms)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	var captured json.RawMessage
+	r.Use(JWTAuthMiddleware(testSecret))
+	r.GET("/", func(c *gin.Context) {
+		captured = PermissionsFromContext(c)
+		c.Status(200)
+	})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	r.ServeHTTP(w, req)
+
+	require.NotNil(t, captured)
+	assert.JSONEq(t, string(perms), string(captured))
+}
+
+// Legacy token (no permissions) → context key remains unset → PermissionsFromContext returns nil.
+func TestJWTAuthMiddleware_NoPermissionsClaim_ContextNil(t *testing.T) {
+	token, err := GenerateToken(testSecret, "u1", "alice", "a@test.com", "admin", "tenant-1", nil)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	var captured json.RawMessage
+	r.Use(JWTAuthMiddleware(testSecret))
+	r.GET("/", func(c *gin.Context) {
+		captured = PermissionsFromContext(c)
+		c.Status(200)
+	})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	r.ServeHTTP(w, req)
+
+	assert.Nil(t, captured)
 }

--- a/wire/wire.go
+++ b/wire/wire.go
@@ -88,24 +88,28 @@ func NewAuthentication(db *gorm.DB, config configuration.Config) (ports.Authenti
 }
 
 // NewAuthenticationWithRoles builds the auth service with roles repo so login response includes permissions.
+// S3.8: also threads rolesRepo into the repository so the issued JWT embeds the permissions claim.
 func NewAuthenticationWithRoles(db *gorm.DB, config configuration.Config, rolesRepo ports.RolesRepository) (ports.AuthenticationRepository, *services.AuthenticationService) {
 	r := &repositories.AuthenticationRepository{
-		DB:          db,
-		JWTSecret:   config.JWTSecret,
-		Config:      config,
-		EmailSender: EmailSenderForConfig(config),
+		DB:              db,
+		JWTSecret:       config.JWTSecret,
+		Config:          config,
+		EmailSender:     EmailSenderForConfig(config),
+		RolesRepository: rolesRepo,
 	}
 	return r, services.NewAuthenticationService(r, rolesRepo)
 }
 
 // NewAuthenticationWithAudit builds the auth service with roles repo and audit service.
+// S3.8: also threads rolesRepo into the repository so the issued JWT embeds the permissions claim.
 func NewAuthenticationWithAudit(db *gorm.DB, config configuration.Config, rolesRepo ports.RolesRepository, auditSvc *services.AuditService) (ports.AuthenticationRepository, *services.AuthenticationService) {
 	r := &repositories.AuthenticationRepository{
-		DB:           db,
-		JWTSecret:    config.JWTSecret,
-		Config:       config,
-		EmailSender:  EmailSenderForConfig(config),
-		AuditService: auditSvc,
+		DB:              db,
+		JWTSecret:       config.JWTSecret,
+		Config:          config,
+		EmailSender:     EmailSenderForConfig(config),
+		AuditService:    auditSvc,
+		RolesRepository: rolesRepo,
 	}
 	return r, services.NewAuthenticationService(r, rolesRepo)
 }


### PR DESCRIPTION
Embed permissions in JWT signed claim. Middleware fast path off JWT cache, DB fallback for legacy tokens. Security: JWT denial does NOT fall back to DB (stale grants leak prevention). 16 new tests. Backwards compat preserved.