### PR TITLE
fix(mobile-s1-w7): counts location resolver + receiving contract parity + operator role assignment

### DIFF
--- a/controllers/inventory_counts_controller.go
+++ b/controllers/inventory_counts_controller.go
@@ -1,11 +1,38 @@
 package controllers
 
 import (
+	"strings"
+
 	"github.com/eflowcr/eSTOCK_backend/models/requests"
 	"github.com/eflowcr/eSTOCK_backend/services"
 	"github.com/eflowcr/eSTOCK_backend/tools"
 	"github.com/gin-gonic/gin"
 )
+
+// looksLikeUUID returns true when s matches the canonical 8-4-4-4-12 hex
+// layout. Used to disambiguate a real UUID from a scanned location code in the
+// ScanCountLine body. We deliberately keep the check shape-only (no parse
+// against the locations table) so the resolver path is only entered for
+// strings that cannot be a UUID, preserving back-compat for existing clients
+// that send a real UUID.
+func looksLikeUUID(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	for i, r := range s {
+		switch i {
+		case 8, 13, 18, 23:
+			if r != '-' {
+				return false
+			}
+		default:
+			if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
+				return false
+			}
+		}
+	}
+	return true
+}
 
 type InventoryCountsController struct {
 	Service   services.InventoryCountsService
@@ -114,6 +141,20 @@ func (c *InventoryCountsController) ScanLine(ctx *gin.Context) {
 	if errs := tools.ValidateStruct(&body); errs != nil {
 		tools.ResponseValidationError(ctx, "ScanCountLine", "scan_count_line", errs)
 		return
+	}
+	// W7 N1-A: mobile sends the scanned location code (printed on the bin label),
+	// not the row UUID. inventory_count_lines.location_id is a FK to locations.id
+	// (UUID), so when body.LocationID does not look like a UUID we resolve it
+	// via the unique location_code index. Real UUIDs flow through unchanged for
+	// back-compat with admin/web clients.
+	rawLoc := strings.TrimSpace(body.LocationID)
+	if rawLoc != "" && !looksLikeUUID(rawLoc) {
+		resolvedID, resolveResp := c.Service.ResolveLocationIDByCode(rawLoc)
+		if resolveResp != nil {
+			writeErrorResponse(ctx, "ScanCountLine", "scan_count_line", resolveResp)
+			return
+		}
+		body.LocationID = resolvedID
 	}
 	line, resp := c.Service.ScanLine(id, userID, &body)
 	if resp != nil {

--- a/controllers/mobile_controller.go
+++ b/controllers/mobile_controller.go
@@ -30,6 +30,12 @@ import (
 // contract the backend recovers ExpectedQty per line and rejects pick-overs.
 const mobilePickingOverTolerance = 1.05
 
+// W7 N1-B fix: mirror the picking tolerance for receiving. Same constant value
+// keeps the operator UX consistent across modules — when this needs to diverge
+// per-tenant, split into mobilePickingOverTolerance / mobileReceivingOverTolerance
+// and wire from configuration.
+const mobileReceivingOverTolerance = 1.05
+
 type MobileController struct {
 	Picking            *services.PickingTaskService
 	Receiving          *services.ReceivingTasksService
@@ -107,9 +113,18 @@ func (c *MobileController) ListPickingTasks(ctx *gin.Context) {
 	assignedToMe := strings.EqualFold(ctx.Query("assigned_to_me"), "true")
 	statusFilter := parseCSVFilter(ctx.Query("status"))
 
+	// W7 N2-1: operators are forced to assigned_to_me=true regardless of the
+	// query param to prevent a cross-operator data leak (operator A could
+	// previously list every task in the warehouse including those assigned to
+	// operator B). Admin/warehouse roles can still opt out by omitting the flag.
+	token := ctx.Request.Header.Get("Authorization")
+	role, _ := tools.GetRole(c.Config.JWTSecret, token)
+	if !assignedToMe && tools.IsOperatorRole(role) {
+		assignedToMe = true
+	}
+
 	var userID string
 	if assignedToMe {
-		token := ctx.Request.Header.Get("Authorization")
 		uid, err := tools.GetUserId(c.Config.JWTSecret, token)
 		if err != nil {
 			tools.ResponseUnauthorized(ctx, "MobileListPickingTasks", "Token inválido", "mobile_list_picking_tasks")
@@ -488,9 +503,15 @@ func (c *MobileController) ListReceivingTasks(ctx *gin.Context) {
 	assignedToMe := strings.EqualFold(ctx.Query("assigned_to_me"), "true")
 	statusFilter := parseCSVFilter(ctx.Query("status"))
 
+	// W7 N2-1: operators forced to assigned_to_me=true. See ListPickingTasks.
+	token := ctx.Request.Header.Get("Authorization")
+	role, _ := tools.GetRole(c.Config.JWTSecret, token)
+	if !assignedToMe && tools.IsOperatorRole(role) {
+		assignedToMe = true
+	}
+
 	var userID string
 	if assignedToMe {
-		token := ctx.Request.Header.Get("Authorization")
 		uid, err := tools.GetUserId(c.Config.JWTSecret, token)
 		if err != nil {
 			tools.ResponseUnauthorized(ctx, "MobileListReceivingTasks", "Token inválido", "mobile_list_receiving_tasks")
@@ -522,6 +543,12 @@ func (c *MobileController) ListReceivingTasks(ctx *gin.Context) {
 	tools.ResponseOK(ctx, "MobileListReceivingTasks", "Tareas de recepción obtenidas", "mobile_list_receiving_tasks", out, false, "")
 }
 
+// GetReceivingTask returns the trimmed MobileReceivingTaskDetailDto with flat lines.
+//
+// W7 N1-B fix: mirrors W0.7's picking contract. Previously the endpoint
+// returned database.ReceivingTask raw with the `items` jsonb shape exposed —
+// the mobile client could not echo a stable line_id and the backend had no
+// way to recover ExpectedQuantity for tolerance validation.
 func (c *MobileController) GetReceivingTask(ctx *gin.Context) {
 	id, ok := tools.ParseRequiredParam(ctx, "id", "MobileGetReceivingTask", "mobile_get_receiving_task", "ID de tarea inválido")
 	if !ok {
@@ -536,9 +563,135 @@ func (c *MobileController) GetReceivingTask(ctx *gin.Context) {
 		tools.ResponseNotFound(ctx, "MobileGetReceivingTask", "Tarea no encontrada", "mobile_get_receiving_task")
 		return
 	}
-	tools.ResponseOK(ctx, "MobileGetReceivingTask", "Tarea obtenida", "mobile_get_receiving_task", task, false, "")
+	dto, err := buildMobileReceivingTaskDetail(task)
+	if err != nil {
+		tools.ResponseInternal(ctx, "MobileGetReceivingTask", "Error parseando items: "+err.Error(), "mobile_get_receiving_task")
+		return
+	}
+	tools.ResponseOK(ctx, "MobileGetReceivingTask", "Tarea obtenida", "mobile_get_receiving_task", dto, false, "")
 }
 
+// buildMobileReceivingTaskDetail flattens a database.ReceivingTask into the
+// mobile-facing detail DTO. Mirrors buildMobilePickingTaskDetail (W0.7) — see
+// that function for the rationale on flattening + LineID determinism.
+//
+// Receiving items have a single Location field (no allocations array) so the
+// surface is simpler than picking — no multi-allocation TODO needed here.
+func buildMobileReceivingTaskDetail(task *database.ReceivingTask) (*responses.MobileReceivingTaskDetailDto, error) {
+	dto := &responses.MobileReceivingTaskDetailDto{
+		ID:          task.ID,
+		TaskID:      task.TaskID,
+		OrderNumber: task.InboundNumber,
+		Status:      task.Status,
+		Priority:    task.Priority,
+		AssignedTo:  task.AssignedTo,
+		CompletedAt: task.CompletedAt,
+		Lines:       []responses.MobileReceivingLineDto{},
+	}
+	if !task.CreatedAt.IsZero() {
+		ca := task.CreatedAt
+		dto.CreatedAt = &ca
+	}
+	if len(task.Items) == 0 {
+		return dto, nil
+	}
+	var items []database.ReceivingTaskItem
+	if err := json.Unmarshal(task.Items, &items); err != nil {
+		return nil, err
+	}
+	dto.Lines = make([]responses.MobileReceivingLineDto, 0, len(items))
+	for _, it := range items {
+		dto.Lines = append(dto.Lines, mapReceivingItemToMobileLine(it))
+	}
+	return dto, nil
+}
+
+// mapReceivingItemToMobileLine projects one ReceivingTaskItem to the mobile
+// flat shape. ReceivedQty is derived: prefer accepted_qty (S2 R1 explicit
+// split), fall back to received_qty pointer for legacy data.
+func mapReceivingItemToMobileLine(it database.ReceivingTaskItem) responses.MobileReceivingLineDto {
+	receivedQty := it.AcceptedQty
+	if receivedQty == 0 && it.ReceivedQuantity != nil {
+		receivedQty = *it.ReceivedQuantity
+	}
+	lot := ""
+	if len(it.LotNumbers) > 0 {
+		lot = it.LotNumbers[0].LotNumber
+	}
+	serial := ""
+	if len(it.SerialNumbers) > 0 {
+		serial = it.SerialNumbers[0].SerialNumber
+	}
+	status := "pending"
+	if it.ExpectedQuantity > 0 && receivedQty >= it.ExpectedQuantity {
+		status = "done"
+	} else if receivedQty > 0 {
+		status = "partial"
+	}
+	return responses.MobileReceivingLineDto{
+		LineID:      computePickingLineID(it.SKU, lot, serial, it.Location),
+		SKU:         it.SKU,
+		ExpectedQty: it.ExpectedQuantity,
+		ReceivedQty: receivedQty,
+		Status:      status,
+		Location:    it.Location,
+		Lot:         lot,
+		Serial:      serial,
+	}
+}
+
+// findReceivingItemForRequest mirrors findPickingItemForRequest (W0.7). Returns
+// the matching ReceivingTaskItem so the caller can recover the persisted
+// ExpectedQuantity for tolerance validation. Match order:
+//  1. body.LineID against computePickingLineID(sku, lot, serial, location)
+//  2. fallback: (sku, lot, serial) tuple match (case-insensitive on sku)
+//
+// LineID supplied + no match → explicit miss (caller 400s; never silently fall
+// back, that would mask client/server contract drift).
+func findReceivingItemForRequest(task *database.ReceivingTask, body responses.MobileCompleteLineRequest) (database.ReceivingTaskItem, bool) {
+	if len(task.Items) == 0 {
+		return database.ReceivingTaskItem{}, false
+	}
+	var items []database.ReceivingTaskItem
+	if err := json.Unmarshal(task.Items, &items); err != nil {
+		return database.ReceivingTaskItem{}, false
+	}
+	for _, it := range items {
+		line := mapReceivingItemToMobileLine(it)
+		if body.LineID != "" && line.LineID == body.LineID {
+			return it, true
+		}
+	}
+	if body.LineID != "" {
+		return database.ReceivingTaskItem{}, false
+	}
+	for _, it := range items {
+		if !strings.EqualFold(it.SKU, body.SKU) {
+			continue
+		}
+		itemLot := ""
+		if len(it.LotNumbers) > 0 {
+			itemLot = it.LotNumbers[0].LotNumber
+		}
+		itemSerial := ""
+		if len(it.SerialNumbers) > 0 {
+			itemSerial = it.SerialNumbers[0].SerialNumber
+		}
+		if itemLot == body.Lot && itemSerial == body.Serial {
+			return it, true
+		}
+	}
+	return database.ReceivingTaskItem{}, false
+}
+
+// CompleteReceivingLine validates the request against the persisted task and
+// delegates to the receiving service.
+//
+// W7 N1-B fix: mirrors W0.7 picking. Pre-W7 the controller synthesized
+// ExpectedQuantity = int(body.PickedQty), so any client could over-receive at
+// will and tolerance validation was impossible server-side. Now the backend
+// recovers the real ExpectedQuantity per line via findReceivingItemForRequest
+// and rejects PickedQty > expected_qty * mobileReceivingOverTolerance.
 func (c *MobileController) CompleteReceivingLine(ctx *gin.Context) {
 	id, ok := tools.ParseRequiredParam(ctx, "id", "MobileCompleteReceivingLine", "mobile_complete_receiving_line", "ID de tarea inválido")
 	if !ok {
@@ -559,13 +712,48 @@ func (c *MobileController) CompleteReceivingLine(ctx *gin.Context) {
 		tools.ResponseBadRequest(ctx, "MobileCompleteReceivingLine", "location_scanned es requerido", "mobile_complete_receiving_line")
 		return
 	}
+	if strings.TrimSpace(body.SKU) == "" {
+		tools.ResponseBadRequest(ctx, "MobileCompleteReceivingLine", "sku es requerido", "mobile_complete_receiving_line")
+		return
+	}
+	if body.PickedQty <= 0 {
+		tools.ResponseBadRequest(ctx, "MobileCompleteReceivingLine", "received_qty debe ser mayor a 0", "mobile_complete_receiving_line")
+		return
+	}
+
+	// W7 N1-B: load the task to recover the real ExpectedQuantity for the line.
+	task, resp := c.Receiving.GetReceivingTaskByID(id)
+	if resp != nil {
+		writeErrorResponse(ctx, "MobileCompleteReceivingLine", "mobile_complete_receiving_line", resp)
+		return
+	}
+	if task == nil {
+		tools.ResponseNotFound(ctx, "MobileCompleteReceivingLine", "Tarea no encontrada", "mobile_complete_receiving_line")
+		return
+	}
+	persisted, found := findReceivingItemForRequest(task, body)
+	if !found {
+		tools.ResponseBadRequest(ctx, "MobileCompleteReceivingLine", "Línea no encontrada en la tarea", "mobile_complete_receiving_line_unknown")
+		return
+	}
+	expectedQty := persisted.ExpectedQuantity
+	if expectedQty > 0 && body.PickedQty > expectedQty*mobileReceivingOverTolerance {
+		tools.ResponseBadRequest(
+			ctx,
+			"MobileCompleteReceivingLine",
+			"received_qty excede la tolerancia permitida (5% sobre la cantidad esperada)",
+			"mobile_complete_receiving_line_tolerance",
+		)
+		return
+	}
+
 	item := requests.ReceivingTaskItemRequest{
-		SKU:      body.SKU,
-		Location: body.LocationScanned,
+		SKU:              body.SKU,
+		ExpectedQuantity: int(expectedQty),
+		Location:         body.LocationScanned,
 	}
-	if body.PickedQty > 0 {
-		item.ExpectedQuantity = int(body.PickedQty)
-	}
+	receivedInt := int(body.PickedQty)
+	item.ReceivedQuantity = &receivedInt
 	if body.Lot != "" {
 		item.LotNumbers = []requests.CreateLotRequest{{
 			LotNumber: body.Lot,
@@ -576,7 +764,7 @@ func (c *MobileController) CompleteReceivingLine(ctx *gin.Context) {
 	if body.Serial != "" {
 		item.SerialNumbers = []database.Serial{{SerialNumber: body.Serial, SKU: body.SKU}}
 	}
-	resp := c.Receiving.CompleteReceivingLine(id, body.LocationScanned, userID, item)
+	resp = c.Receiving.CompleteReceivingLine(id, body.LocationScanned, userID, item)
 	if resp != nil {
 		writeErrorResponse(ctx, "MobileCompleteReceivingLine", "mobile_complete_receiving_line", resp)
 		return
@@ -635,9 +823,14 @@ func (c *MobileController) ListStockTransfers(ctx *gin.Context) {
 	}
 
 	assignedToMe := strings.EqualFold(ctx.Query("assigned_to_me"), "true")
+	// W7 N2-1: operators forced to assigned_to_me=true. See ListPickingTasks.
+	token := ctx.Request.Header.Get("Authorization")
+	role, _ := tools.GetRole(c.Config.JWTSecret, token)
+	if !assignedToMe && tools.IsOperatorRole(role) {
+		assignedToMe = true
+	}
 	var userID string
 	if assignedToMe {
-		token := ctx.Request.Header.Get("Authorization")
 		uid, err := tools.GetUserId(c.Config.JWTSecret, token)
 		if err != nil {
 			tools.ResponseUnauthorized(ctx, "MobileListStockTransfers", "Token inválido", "mobile_list_stock_transfers")

--- a/controllers/mobile_controller_test.go
+++ b/controllers/mobile_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/eflowcr/eSTOCK_backend/models/responses"
 	"github.com/eflowcr/eSTOCK_backend/ports"
 	"github.com/eflowcr/eSTOCK_backend/services"
+	"github.com/eflowcr/eSTOCK_backend/tools"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,6 +30,34 @@ func buildTaskItemsJSON(items ...requests.PickingTaskItemRequest) []byte {
 		panic(err)
 	}
 	return b
+}
+
+// buildReceivingItemsJSON returns the jsonb encoding of one or more receiving
+// items, panicking on marshaling errors (test code only).
+func buildReceivingItemsJSON(items ...database.ReceivingTaskItem) []byte {
+	b, err := json.Marshal(items)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// sampleReceivingTaskWithItem returns a ReceivingTask with a single item
+// (SKU-1, expected 10, at LOC-A). Used by the W7 N1-B receiving contract tests
+// — same fixture pattern as sampleTaskWithItem (picking).
+func sampleReceivingTaskWithItem() *database.ReceivingTask {
+	items := buildReceivingItemsJSON(database.ReceivingTaskItem{
+		SKU:              "SKU-1",
+		ExpectedQuantity: 10,
+		Location:         "LOC-A",
+	})
+	return &database.ReceivingTask{
+		ID:            "rt-1",
+		TaskID:        "RT1",
+		InboundNumber: "IB-1",
+		Status:        "in_progress",
+		Items:         items,
+	}
 }
 
 // sampleTaskWithItem returns a PickingTask with a single item (SKU-1, expected 10,
@@ -56,7 +85,7 @@ func newTestMobileController() *MobileController {
 	pickSvc := services.NewPickingTaskService(pickRepo)
 	recvRepo := &mockReceivingTasksRepoCtrl{
 		tasks: []responses.ReceivingTasksView{},
-		byID:  map[string]*database.ReceivingTask{},
+		byID:  map[string]*database.ReceivingTask{"rt-1": sampleReceivingTaskWithItem()},
 	}
 	recvSvc := services.NewReceivingTasksService(recvRepo)
 	cfg := configuration.Config{JWTSecret: testJWTSecret, Version: "test"}
@@ -336,6 +365,25 @@ func (m *ctrlCountsRepoStub) GetExpectedQty(sku, loc, lot string) (float64, *res
 func (m *ctrlCountsRepoStub) GetLocationCodeByID(id string) (string, *responses.InternalResponse) {
 	return "LOC-A", nil
 }
+func (m *ctrlCountsRepoStub) GetLocationIDByCode(code string) (string, *responses.InternalResponse) {
+	// W7 N1-A: stub maps known codes to deterministic UUIDs so the controller
+	// path that calls ResolveLocationIDByCode is observable in tests. The
+	// "BIN-NOEXIST" sentinel exercises the not-found error path. Any other
+	// non-UUID code (e.g. legacy short ids like "loc-1" used by pre-W7 tests)
+	// resolves echo-style to keep back-compat tests green.
+	switch code {
+	case "BIN-A1":
+		return "11111111-1111-1111-1111-111111111111", nil
+	case "BIN-NOEXIST":
+		return "", &responses.InternalResponse{
+			Message:    "Ubicación no encontrada con código " + code,
+			Handled:    true,
+			StatusCode: responses.StatusNotFound,
+		}
+	default:
+		return code, nil
+	}
+}
 
 func newTestCountsController(repo *ctrlCountsRepoStub) *InventoryCountsController {
 	svc := services.NewInventoryCountsService(repo, nil)
@@ -395,4 +443,207 @@ func TestInventoryCountsController_GetDetail_NotFound(t *testing.T) {
 	w := performRequest(ctrl.GetDetail, "GET", "/api/mobile/counts/missing", nil,
 		gin.Params{{Key: "id", Value: "missing"}})
 	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// ─── W7 N1-A: counts location code → UUID resolver ───────────────────────────
+
+// TestScanCountLine_ResolvesLocationCode: mobile sends a printed location code
+// ("BIN-A1") in the location_id field. The controller detects the non-UUID
+// shape, resolves it via GetLocationIDByCode, and ScanLine receives the
+// resolved UUID — which is what the inventory_count_lines.location_id FK
+// expects. Pre-W7 this would have failed with FK violation in production.
+func TestScanCountLine_ResolvesLocationCode(t *testing.T) {
+	repo := &ctrlCountsRepoStub{
+		count:       &database.InventoryCount{ID: "c1", Status: "in_progress"},
+		expectedQty: 5,
+	}
+	ctrl := newTestCountsController(repo)
+	body := requests.ScanCountLine{LocationID: "BIN-A1", SKU: "SKU-1", ScannedQty: 7}
+	w := performRequestWithHeader(ctrl.ScanLine, "POST", "/api/mobile/counts/c1/scan-line", body,
+		gin.Params{{Key: "id", Value: "c1"}}, map[string]string{"Authorization": makeTestToken()})
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Len(t, repo.addedLines, 1)
+	// The resolver mapped BIN-A1 → 11111111-1111-1111-1111-111111111111. The
+	// persisted line MUST carry the resolved UUID, not the scanned code.
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", repo.addedLines[0].LocationID)
+}
+
+// TestScanCountLine_RejectsUnknownLocationCode: a code that doesn't resolve
+// returns 404 (resolver returns NotFound, controller forwards via writeErrorResponse).
+func TestScanCountLine_RejectsUnknownLocationCode(t *testing.T) {
+	repo := &ctrlCountsRepoStub{
+		count: &database.InventoryCount{ID: "c1", Status: "in_progress"},
+	}
+	ctrl := newTestCountsController(repo)
+	body := requests.ScanCountLine{LocationID: "BIN-NOEXIST", SKU: "SKU-1", ScannedQty: 1}
+	w := performRequestWithHeader(ctrl.ScanLine, "POST", "/api/mobile/counts/c1/scan-line", body,
+		gin.Params{{Key: "id", Value: "c1"}}, map[string]string{"Authorization": makeTestToken()})
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Empty(t, repo.addedLines, "line must NOT be persisted when location lookup fails")
+}
+
+// TestScanCountLine_AcceptsUUIDDirectly: when the body carries a real UUID,
+// the controller bypasses the resolver and the value flows straight through
+// to AddLine. Guarantees back-compat with admin/web clients sending the UUID.
+func TestScanCountLine_AcceptsUUIDDirectly(t *testing.T) {
+	uuid := "22222222-2222-2222-2222-222222222222"
+	repo := &ctrlCountsRepoStub{
+		count:       &database.InventoryCount{ID: "c1", Status: "in_progress"},
+		expectedQty: 3,
+	}
+	ctrl := newTestCountsController(repo)
+	body := requests.ScanCountLine{LocationID: uuid, SKU: "SKU-1", ScannedQty: 4}
+	w := performRequestWithHeader(ctrl.ScanLine, "POST", "/api/mobile/counts/c1/scan-line", body,
+		gin.Params{{Key: "id", Value: "c1"}}, map[string]string{"Authorization": makeTestToken()})
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Len(t, repo.addedLines, 1)
+	assert.Equal(t, uuid, repo.addedLines[0].LocationID, "UUID must pass through unchanged")
+}
+
+// ─── W7 N1-B: receiving contract parity (mirrors W0.7 picking tests) ─────────
+
+// TestMobile_GetReceivingTask_ReturnsDetailDto_WithLineIDAndLocation: the
+// receiving GET endpoint must return MobileReceivingTaskDetailDto (flat shape)
+// with a non-empty line_id and location resolved per line — same contract as
+// picking after W0.7.
+func TestMobile_GetReceivingTask_ReturnsDetailDto_WithLineIDAndLocation(t *testing.T) {
+	ctrl := newTestMobileController()
+	w := performRequestWithHeader(ctrl.GetReceivingTask, "GET", "/api/mobile/receiving-tasks/rt-1",
+		nil, gin.Params{{Key: "id", Value: "rt-1"}}, map[string]string{"Authorization": makeTestToken()})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var env responses.APIResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	dataMap, ok := env.Data.(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "rt-1", dataMap["id"])
+	linesAny, ok := dataMap["lines"].([]interface{})
+	require.True(t, ok, "lines must be an array")
+	require.Len(t, linesAny, 1)
+
+	line, ok := linesAny[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "SKU-1", line["sku"])
+	assert.Equal(t, "LOC-A", line["location"], "location must come from item.Location")
+	if lineID, _ := line["line_id"].(string); lineID == "" {
+		t.Fatalf("line_id must be non-empty (got empty)")
+	}
+	assert.Equal(t, float64(10), line["expected_qty"])
+	assert.Equal(t, "pending", line["status"])
+}
+
+// TestMobile_LineID_RoundTripsToCompleteLine: the LineID emitted by the GET
+// receiving detail endpoint MUST match what CompleteReceivingLine recomputes
+// from the same task — making the determinism contract usable without
+// persistence (mirrors picking W0.7).
+func TestMobile_LineID_RoundTripsToCompleteLine(t *testing.T) {
+	ctrl := newTestMobileController()
+	w := performRequestWithHeader(ctrl.GetReceivingTask, "GET", "/api/mobile/receiving-tasks/rt-1",
+		nil, gin.Params{{Key: "id", Value: "rt-1"}}, map[string]string{"Authorization": makeTestToken()})
+	require.Equal(t, http.StatusOK, w.Code)
+	var env responses.APIResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	dataMap := env.Data.(map[string]interface{})
+	line := dataMap["lines"].([]interface{})[0].(map[string]interface{})
+	lineID := line["line_id"].(string)
+	require.NotEmpty(t, lineID)
+
+	body := responses.MobileCompleteLineRequest{
+		LineID:          lineID,
+		SKU:             "SKU-1",
+		PickedQty:       5,
+		LocationScanned: "LOC-A",
+	}
+	w2 := performRequestWithHeader(ctrl.CompleteReceivingLine, "PATCH", "/api/mobile/receiving-tasks/rt-1/complete-line",
+		body, gin.Params{{Key: "id", Value: "rt-1"}}, map[string]string{"Authorization": makeTestToken()})
+	assert.Equal(t, http.StatusOK, w2.Code)
+}
+
+// TestMobile_CompleteReceivingLine_RejectsBeyondTolerance: expected=10, picked=11
+// (>10.5) MUST 400. Pre-W7 the controller synthesized expected=picked=11 so any
+// over-receive passed silently.
+func TestMobile_CompleteReceivingLine_RejectsBeyondTolerance(t *testing.T) {
+	ctrl := newTestMobileController()
+	body := responses.MobileCompleteLineRequest{SKU: "SKU-1", PickedQty: 11, LocationScanned: "LOC-A"}
+	w := performRequestWithHeader(ctrl.CompleteReceivingLine, "PATCH", "/api/mobile/receiving-tasks/rt-1/complete-line",
+		body, gin.Params{{Key: "id", Value: "rt-1"}}, map[string]string{"Authorization": makeTestToken()})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestMobile_CompleteReceivingLine_AcceptsAtToleranceBoundary: at the boundary
+// (10 * 1.05 = 10.5) the request passes — guards against off-by-one.
+func TestMobile_CompleteReceivingLine_AcceptsAtToleranceBoundary(t *testing.T) {
+	ctrl := newTestMobileController()
+	body := responses.MobileCompleteLineRequest{SKU: "SKU-1", PickedQty: 10.5, LocationScanned: "LOC-A"}
+	w := performRequestWithHeader(ctrl.CompleteReceivingLine, "PATCH", "/api/mobile/receiving-tasks/rt-1/complete-line",
+		body, gin.Params{{Key: "id", Value: "rt-1"}}, map[string]string{"Authorization": makeTestToken()})
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestMobile_CompleteReceivingLine_RejectsZeroQty: zero/negative received_qty
+// must 400 with the dedicated error rather than passing through to the service.
+func TestMobile_CompleteReceivingLine_RejectsZeroQty(t *testing.T) {
+	ctrl := newTestMobileController()
+	body := responses.MobileCompleteLineRequest{SKU: "SKU-1", PickedQty: 0, LocationScanned: "LOC-A"}
+	w := performRequestWithHeader(ctrl.CompleteReceivingLine, "PATCH", "/api/mobile/receiving-tasks/rt-1/complete-line",
+		body, gin.Params{{Key: "id", Value: "rt-1"}}, map[string]string{"Authorization": makeTestToken()})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestMobile_CompleteReceivingLine_UnknownLineID_400: an explicit LineID that
+// doesn't resolve must 400 — backend will not silently fall back to (sku,lot,
+// serial) tuple when a deterministic identifier is supplied (would mask
+// client/server contract drift).
+func TestMobile_CompleteReceivingLine_UnknownLineID_400(t *testing.T) {
+	ctrl := newTestMobileController()
+	body := responses.MobileCompleteLineRequest{
+		LineID:          "deadbeefcafe",
+		SKU:             "SKU-1",
+		PickedQty:       1,
+		LocationScanned: "LOC-A",
+	}
+	w := performRequestWithHeader(ctrl.CompleteReceivingLine, "PATCH", "/api/mobile/receiving-tasks/rt-1/complete-line",
+		body, gin.Params{{Key: "id", Value: "rt-1"}}, map[string]string{"Authorization": makeTestToken()})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ─── W7 N2-1: operator role forces assigned_to_me=true ───────────────────────
+
+// makeOperatorTestToken returns a JWT with role="operator" so the mobile list
+// handlers' role override path is exercised.
+func makeOperatorTestToken() string {
+	token, _ := tools.GenerateToken(testJWTSecret, "user-1", "testuser", "test@test.com", "operator")
+	return "Bearer " + token
+}
+
+// TestListPickingTasks_OperatorRoleForcesAssignedToMe: an operator hitting the
+// list endpoint without ?assigned_to_me=true MUST be implicitly filtered to
+// their own tasks. Without the override, operator A could observe operator B's
+// task assignments (W7 N2-1 data leak fix).
+func TestListPickingTasks_OperatorRoleForcesAssignedToMe(t *testing.T) {
+	uid := "user-1"
+	other := "operator-2"
+	pickRepo := &mockPickingTaskRepoCtrl{
+		tasks: []responses.PickingTaskView{
+			{ID: "pt-1", TaskID: "T1", AssignedTo: &uid, Status: "in_progress"},
+			{ID: "pt-2", TaskID: "T2", AssignedTo: &other, Status: "in_progress"},
+			{ID: "pt-3", TaskID: "T3", AssignedTo: nil, Status: "in_progress"},
+		},
+	}
+	pickSvc := services.NewPickingTaskService(pickRepo)
+	cfg := configuration.Config{JWTSecret: testJWTSecret}
+	ctrl := NewMobileController(pickSvc, nil, nil, nil, nil, nil, cfg)
+
+	// Operator role + NO assigned_to_me flag → must be forced.
+	w := performRequestWithHeader(ctrl.ListPickingTasks, "GET", "/api/mobile/picking-tasks",
+		nil, nil, map[string]string{"Authorization": makeOperatorTestToken()})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var env responses.APIResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	arr, ok := env.Data.([]interface{})
+	require.True(t, ok)
+	assert.Len(t, arr, 1, "operator must only see tasks assigned to themselves")
+	first := arr[0].(map[string]interface{})
+	assert.Equal(t, "pt-1", first["id"])
 }

--- a/models/responses/mobile_dtos.go
+++ b/models/responses/mobile_dtos.go
@@ -102,6 +102,48 @@ type MobilePickingTaskDetailDto struct {
 	Lines        []MobilePickingLineDto `json:"lines"`
 }
 
+// MobileReceivingTaskDetailDto is the GET /api/mobile/receiving-tasks/:id payload.
+//
+// W7 N1-B fix: previously the endpoint returned database.ReceivingTask raw,
+// whose `items` jsonb shape is []ReceivingTaskItem with no per-line line_id and
+// no flat location surface. The mobile client could not echo a stable line
+// identifier back into CompleteReceivingLine, so the controller synthesized
+// ExpectedQuantity = picked_qty (W0.7-equivalent picking bug). This DTO mirrors
+// MobilePickingTaskDetailDto so the same line_id round-trip and tolerance
+// validation pattern works for receiving.
+type MobileReceivingTaskDetailDto struct {
+	ID           string                   `json:"id"`
+	TaskID       string                   `json:"task_id"`
+	OrderNumber  string                   `json:"order_number"`
+	Status       string                   `json:"status"`
+	Priority     string                   `json:"priority"`
+	AssignedTo   *string                  `json:"assigned_to,omitempty"`
+	AssigneeName *string                  `json:"assignee_name,omitempty"`
+	CreatedAt    *time.Time               `json:"created_at,omitempty"`
+	CompletedAt  *time.Time               `json:"completed_at,omitempty"`
+	Lines        []MobileReceivingLineDto `json:"lines"`
+}
+
+// MobileReceivingLineDto mirrors MobilePickingLineDto but for receiving lines.
+//
+// LineID is a session-scoped deterministic SHA1[:12] hash of (sku|lot|serial|location)
+// — same scheme as picking. Stable across GET → POST round-trip without
+// requiring a per-line id column on the receiving_task_items jsonb.
+//
+// Status: "pending" (received_qty == 0), "partial" (0 < received_qty < expected),
+// or "done" (received_qty >= expected).
+type MobileReceivingLineDto struct {
+	LineID      string  `json:"line_id"`
+	SKU         string  `json:"sku"`
+	Name        string  `json:"name,omitempty"`
+	ExpectedQty float64 `json:"expected_qty"`
+	ReceivedQty float64 `json:"received_qty"`
+	Status      string  `json:"status"`
+	Location    string  `json:"location"`
+	Lot         string  `json:"lot,omitempty"`
+	Serial      string  `json:"serial,omitempty"`
+}
+
 // MobilePickingLineDto is the per-line shape under MobilePickingTaskDetailDto.
 //
 // LineID is a deterministic identifier for a line within a task: it is a

--- a/ports/inventory_counts.go
+++ b/ports/inventory_counts.go
@@ -33,6 +33,11 @@ type InventoryCountsRepository interface {
 	ResolveSKUByBarcode(barcode string) (string, *responses.InternalResponse)
 	GetExpectedQty(sku, locationCode, lot string) (float64, *responses.InternalResponse)
 	GetLocationCodeByID(locationID string) (string, *responses.InternalResponse)
+	// GetLocationIDByCode is the inverse resolver of GetLocationCodeByID. Used by
+	// the mobile scan-line path because mobile scans a printed location barcode
+	// which encodes the human-readable location code, NOT the row UUID, but the
+	// inventory_count_lines.location_id FK requires the UUID. W7 N1-A.
+	GetLocationIDByCode(locationCode string) (string, *responses.InternalResponse)
 }
 
 // InventoryAdjustmentsCreator is the narrow surface that the inventory-counts

--- a/repositories/inventory_counts_repository.go
+++ b/repositories/inventory_counts_repository.go
@@ -449,3 +449,31 @@ func (r *InventoryCountsRepository) GetLocationCodeByID(locationID string) (stri
 	}
 	return code, nil
 }
+
+// GetLocationIDByCode is the inverse of GetLocationCodeByID — given a printed
+// location barcode (the human-readable code), return the row UUID needed for
+// inventory_count_lines.location_id FK. The locations.location_code column has a
+// UNIQUE index (migration 000002), so the lookup is a single indexed read.
+//
+// W7 N1-A: mobile clients scan the barcode and send the code as `location_id`
+// (because the printed code is the only thing on the bin label). Without this
+// resolver the count's first scan in production fails with FK violation.
+func (r *InventoryCountsRepository) GetLocationIDByCode(locationCode string) (string, *responses.InternalResponse) {
+	code := strings.TrimSpace(locationCode)
+	if code == "" {
+		return "", &responses.InternalResponse{Message: "Código de ubicación vacío", Handled: true, StatusCode: responses.StatusBadRequest}
+	}
+	var id string
+	err := r.DB.Table("locations").Select("id").Where("location_code = ?", code).Limit(1).Scan(&id).Error
+	if err != nil {
+		return "", &responses.InternalResponse{Error: err, Message: "Error al resolver ubicación", Handled: false}
+	}
+	if id == "" {
+		return "", &responses.InternalResponse{
+			Message:    "Ubicación no encontrada con código " + code,
+			Handled:    true,
+			StatusCode: responses.StatusNotFound,
+		}
+	}
+	return id, nil
+}

--- a/services/inventory_counts_service.go
+++ b/services/inventory_counts_service.go
@@ -35,6 +35,13 @@ func (s *InventoryCountsService) List(status, locationID string) ([]database.Inv
 	return s.Repository.List(status, locationID)
 }
 
+// ResolveLocationIDByCode delegates to the repository's inverse resolver for
+// the mobile scan-line path (W7 N1-A). Mobile scans encode the location code,
+// not the UUID; the controller calls this when body.LocationID is not a UUID.
+func (s *InventoryCountsService) ResolveLocationIDByCode(code string) (string, *responses.InternalResponse) {
+	return s.Repository.GetLocationIDByCode(code)
+}
+
 func (s *InventoryCountsService) GetDetail(id string) (*responses.InventoryCountDetail, *responses.InternalResponse) {
 	return s.Repository.GetDetail(id)
 }

--- a/services/inventory_counts_service_test.go
+++ b/services/inventory_counts_service_test.go
@@ -145,6 +145,12 @@ func (m *mockCountsRepo) GetLocationCodeByID(locationID string) (string, *respon
 	}
 	return m.locationCode, nil
 }
+func (m *mockCountsRepo) GetLocationIDByCode(code string) (string, *responses.InternalResponse) {
+	// W7 N1-A: stub for inverse resolver. Tests that exercise the controller
+	// path use the controller-level stub; service-level tests don't need this
+	// path so a permissive default is fine.
+	return code, nil
+}
 
 // ─── mock AdjustmentsRepository (existing port surface, unchanged) ───────────
 

--- a/tools/token_tool.go
+++ b/tools/token_tool.go
@@ -86,6 +86,14 @@ func GetEmail(secret string, tokenString string) (string, error) {
 	return claims.Email, nil
 }
 
+// IsOperatorRole returns true when the role string corresponds to a warehouse
+// operator. Comparison is case-insensitive and trim-tolerant. Used by mobile
+// list handlers to force assigned_to_me=true so an operator never sees tasks
+// assigned to another operator (W7 N2-1: cross-operator data leak fix).
+func IsOperatorRole(role string) bool {
+	return strings.EqualFold(strings.TrimSpace(role), "operator")
+}
+
 func GetRole(secret string, tokenString string) (string, error) {
 	tokenString = tokenString[7:]
 	token, err := jwt.ParseWithClaims(tokenString, &Claims{}, func(token *jwt.Token) (interface{}, error) {


### PR DESCRIPTION
## Summary

W7-backend-fixes wave landing the 3 cross-wave drifts surfaced by the Phase 4.5.2 full-sprint hostile retro of Mobile S1 (N1-A, N1-B, N2-1). Surgical, no refactor, preserves all prior W0/W0.5/W0.6/W0.7 fixes.

### Fix 1 - N1-A: counts location code -> UUID resolver

- Mobile (`CountDetailViewModel.kt:181`) sends the scanned printed location code as `location_id` to `POST /api/mobile/counts/:id/scan-line`. The bin label encodes the human-readable code, never the UUID.
- `inventory_count_lines.location_id` is a FK to `locations.id` (UUID). Pre-W7 the first scan in production failed with FK violation.
- Added `LocationsRepository.GetLocationIDByCode` to the `InventoryCountsRepository` port + repo (single indexed read against the existing `locations.location_code` UNIQUE index from migration 000002).
- `ScanCountLine` now detects non-UUID-shaped input and resolves it via the new repo method. Real UUIDs flow through unchanged for back-compat with admin/web clients.

### Fix 2 - N1-B: receiving contract parity with W0.7 picking

- Pre-W7 `mobile_controller.go:567` was synthesizing `item.ExpectedQuantity = int(body.PickedQty)` for receiving — the exact pattern W0.7 fixed for picking but never propagated to receiving (W2 reused the pre-fix template). Receiving had zero server-side qty validation.
- Added `MobileReceivingTaskDetailDto` + `MobileReceivingLineDto` to `models/responses/mobile_dtos.go` with deterministic `line_id` (SHA1[:12] of `sku|lot|serial|location`, same scheme as picking).
- `GetReceivingTask` now returns the flat DTO via new `buildMobileReceivingTaskDetail` + `mapReceivingItemToMobileLine` helpers.
- `CompleteReceivingLine` now uses new `findReceivingItemForRequest` to recover persisted `ExpectedQuantity`, validates `picked_qty <= expected_qty * mobileReceivingOverTolerance` (1.05) server-side, and rejects zero/negative qty + unknown LineID with explicit 400s.
- The new constant `mobileReceivingOverTolerance` mirrors `mobilePickingOverTolerance` for symmetry — easy to wire from per-tenant config later.

### Fix 3 - N2-1: operator role forces assigned_to_me=true

- Added `tools.IsOperatorRole(role string) bool` helper.
- `ListPickingTasks`, `ListReceivingTasks`, `ListStockTransfers` now read role from JWT and force `assignedToMe=true` when `role == operator` and the query param is absent. Admin/warehouse can still opt out by omitting the flag.
- Closes the W0 hostile review N2-4 / full-sprint retro N2-1 data leak (operator A could previously list every task in the warehouse including operator B's assignments).

## Tests added (10)

- `TestScanCountLine_ResolvesLocationCode` - input \"BIN-A1\" -> backend resolves to UUID, scan persisted with UUID
- `TestScanCountLine_RejectsUnknownLocationCode` - 404 + line NOT persisted
- `TestScanCountLine_AcceptsUUIDDirectly` - UUID passes through unchanged
- `TestMobile_GetReceivingTask_ReturnsDetailDto_WithLineIDAndLocation` - flat DTO shape
- `TestMobile_LineID_RoundTripsToCompleteLine` - GET line_id -> POST same line_id -> 200
- `TestMobile_CompleteReceivingLine_RejectsBeyondTolerance` - expected=10 picked=11 -> 400
- `TestMobile_CompleteReceivingLine_AcceptsAtToleranceBoundary` - picked=10.5 -> 200
- `TestMobile_CompleteReceivingLine_RejectsZeroQty` - 400
- `TestMobile_CompleteReceivingLine_UnknownLineID_400` - explicit LineID miss -> 400 (no silent tuple fallback)
- `TestListPickingTasks_OperatorRoleForcesAssignedToMe` - operator only sees their own tasks

## Gates

| Gate | Result |
|---|---|
| `grep -rn '<<<<<<\|>>>>>>' --include='*.go'` | 0 markers |
| `make sqlc && git diff --exit-code -- db/sqlc` | exit 0 |
| `go build ./...` | OK |
| `go test ./... -short` | PASS (controllers, repositories, services, tools, models/database) |
| `go vet ./...` | clean |
| `git status` | clean post-commit |

No prior W0/W0.5/W0.6/W0.7 tests broken.

## Hard limits respected

- No merge.
- No `/api/*` web endpoints touched (only `/api/mobile/*`).
- All prior fix waves preserved — purely additive/surgical.
- No new dependencies.
- No broad refactor.

## Test plan

- [ ] Manual: mobile counts module against staging — first scan with printed barcode now succeeds
- [ ] Manual: mobile receiving module — over-receive (picked > expected*1.05) returns 400
- [ ] Manual: log in as operator role, hit `GET /api/mobile/picking-tasks` without query, observe only own tasks
- [ ] CI: `make sqlc-ci` workflow green
- [ ] CI: `go test ./...` workflow green

Hostile retro source: \`Mobile S1 / sessions/2026-04-28_full-sprint-hostile-retro\`. PR companion log: \`sessions/2026-04-28_W7-backend-fix-wave\`.