### PR TITLE
feat(s3.8): generic SMTP email sender (Brevo-compatible quick win pre-S-EM2 wire-up)

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/joho/godotenv"
@@ -56,6 +57,22 @@ type Config struct {
 	// ResendFromAddress is the "from" address for transactional emails (env: RESEND_FROM_ADDRESS).
 	// Example: "noreply@estock.app". Defaults to "noreply@estock.app" if unset.
 	ResendFromAddress string
+
+	// SMTP configuration — generic SMTP/STARTTLS sender (env: SMTP_HOST, SMTP_PORT, SMTP_USERNAME, SMTP_PASSWORD).
+	// Used when RESEND_API_KEY is unset. Compatible with Brevo, Mailgun SMTP, Postmark SMTP, etc.
+	// SMTPPort defaults to 587 (STARTTLS) if unset.
+	SMTPHost     string // SMTP_HOST
+	SMTPPort     int    // SMTP_PORT (default 587)
+	SMTPUsername string // SMTP_USERNAME
+	SMTPPassword string // SMTP_PASSWORD
+
+	// EmailFrom is the "from" address used by the SMTP sender (env: EMAIL_FROM).
+	// Defaults to "noreply@eflowsuite.com" if unset.
+	EmailFrom string // EMAIL_FROM
+
+	// EmailFromName is the display name used by the SMTP sender (env: EMAIL_FROM_NAME).
+	// Defaults to "eSTOCK" if unset.
+	EmailFromName string // EMAIL_FROM_NAME
 
 	// TenantID is the UUID of the current tenant (env: TENANT_ID).
 	// Single-tenant mode: defaults to a fixed UUID if unset.
@@ -109,6 +126,11 @@ func LoadConfig() (Config, error) {
 		AppURL:               os.Getenv("APP_URL"),
 		ResendAPIKey:         os.Getenv("RESEND_API_KEY"),
 		ResendFromAddress:    os.Getenv("RESEND_FROM_ADDRESS"),
+		SMTPHost:             os.Getenv("SMTP_HOST"),
+		SMTPUsername:         os.Getenv("SMTP_USERNAME"),
+		SMTPPassword:         os.Getenv("SMTP_PASSWORD"),
+		EmailFrom:            os.Getenv("EMAIL_FROM"),
+		EmailFromName:        os.Getenv("EMAIL_FROM_NAME"),
 		TenantID:             os.Getenv("TENANT_ID"),
 		StripeSecretKey:      os.Getenv("STRIPE_SECRET_KEY"),
 		StripeWebhookSecret:  os.Getenv("STRIPE_WEBHOOK_SECRET"),
@@ -118,6 +140,24 @@ func LoadConfig() (Config, error) {
 	}
 	if cfg.TenantID == "" {
 		cfg.TenantID = "00000000-0000-0000-0000-000000000001"
+	}
+
+	// SMTP port: parse SMTP_PORT env var; default to 587 (STARTTLS).
+	if raw := os.Getenv("SMTP_PORT"); raw != "" {
+		if p, err := strconv.Atoi(raw); err == nil && p > 0 {
+			cfg.SMTPPort = p
+		}
+	}
+	if cfg.SMTPPort == 0 {
+		cfg.SMTPPort = 587
+	}
+
+	// SMTP from defaults.
+	if cfg.EmailFrom == "" {
+		cfg.EmailFrom = "noreply@eflowsuite.com"
+	}
+	if cfg.EmailFromName == "" {
+		cfg.EmailFromName = "eSTOCK"
 	}
 
 	// EnableSignup: explicit env var takes priority; defaults to true in development, false elsewhere.

--- a/tools/email_tool.go
+++ b/tools/email_tool.go
@@ -7,7 +7,12 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"mime/multipart"
+	"mime/quotedprintable"
 	"net/http"
+	"net/smtp"
+	"net/textproto"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -112,6 +117,110 @@ func (r *ResendEmailSender) SendPasswordReset(toEmail, userName, resetLink strin
 	htmlBody := renderResetEmailHTML(userName, resetLink, r.AppName)
 	text := fmt.Sprintf("Hola %s,\n\nRestablece tu contraseña de %s: %s\n\nEl enlace expira en 1 hora.", userName, r.AppName, resetLink)
 	return r.Send(ctx, toEmail, fmt.Sprintf("Restablece tu contraseña de %s", r.AppName), htmlBody, text)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SMTPEmailSender — generic SMTP/STARTTLS sender (Brevo, Mailgun, Postmark…)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// SMTPEmailSender sends transactional emails via any standard SMTP relay with
+// STARTTLS + PLAIN auth (compatible with Brevo smtp-relay.brevo.com:587,
+// Mailgun, Postmark SMTP, etc.).
+type SMTPEmailSender struct {
+	Host     string // e.g. "smtp-relay.brevo.com"
+	Port     int    // e.g. 587
+	Username string
+	Password string
+	FromAddr string // e.g. "noreply@eflowsuite.com"
+	AppName  string // e.g. "eSTOCK"
+}
+
+// Send delivers a multipart/alternative email (HTML + plain text) via STARTTLS.
+// It honours ctx cancellation: if the context is already done before dialing,
+// Send returns ctx.Err() immediately without touching the network.
+func (s *SMTPEmailSender) Send(ctx context.Context, to, subject, htmlBody, textBody string) error {
+	// Honour context cancellation before any network I/O.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	from := fmt.Sprintf("%s <%s>", s.AppName, s.FromAddr)
+	addr := fmt.Sprintf("%s:%d", s.Host, s.Port)
+	auth := smtp.PlainAuth("", s.Username, s.Password, s.Host)
+
+	raw, err := buildMIMEMessage(from, to, subject, htmlBody, textBody)
+	if err != nil {
+		return fmt.Errorf("smtp: build MIME: %w", err)
+	}
+
+	if err := smtp.SendMail(addr, auth, s.FromAddr, []string{to}, raw); err != nil {
+		return fmt.Errorf("smtp: send: %w", err)
+	}
+	return nil
+}
+
+// SendPasswordReset sends the standard password-reset email using the SMTP transport.
+func (s *SMTPEmailSender) SendPasswordReset(toEmail, userName, resetLink string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	htmlBody := renderResetEmailHTML(userName, resetLink, s.AppName)
+	text := fmt.Sprintf("Hola %s,\n\nRestablece tu contraseña de %s: %s\n\nEl enlace expira en 1 hora.", userName, s.AppName, resetLink)
+	return s.Send(ctx, toEmail, fmt.Sprintf("Restablece tu contraseña de %s", s.AppName), htmlBody, text)
+}
+
+// buildMIMEMessage constructs a multipart/alternative MIME message with plain
+// text and HTML parts using quoted-printable encoding for the HTML part.
+func buildMIMEMessage(from, to, subject, htmlBody, textBody string) ([]byte, error) {
+	var buf bytes.Buffer
+
+	// RFC 5322 headers.
+	buf.WriteString("From: " + from + "\r\n")
+	buf.WriteString("To: " + to + "\r\n")
+	buf.WriteString("Subject: " + subject + "\r\n")
+	buf.WriteString("MIME-Version: 1.0\r\n")
+
+	mw := multipart.NewWriter(&buf)
+	buf.WriteString("Content-Type: multipart/alternative; boundary=\"" + mw.Boundary() + "\"\r\n")
+	buf.WriteString("\r\n")
+
+	// Plain-text part.
+	th := make(textproto.MIMEHeader)
+	th.Set("Content-Type", "text/plain; charset=UTF-8")
+	th.Set("Content-Transfer-Encoding", "quoted-printable")
+	pw, err := mw.CreatePart(th)
+	if err != nil {
+		return nil, err
+	}
+	qpw := quotedprintable.NewWriter(pw)
+	if _, err := strings.NewReader(textBody).WriteTo(qpw); err != nil {
+		return nil, err
+	}
+	if err := qpw.Close(); err != nil {
+		return nil, err
+	}
+
+	// HTML part.
+	hh := make(textproto.MIMEHeader)
+	hh.Set("Content-Type", "text/html; charset=UTF-8")
+	hh.Set("Content-Transfer-Encoding", "quoted-printable")
+	hw, err := mw.CreatePart(hh)
+	if err != nil {
+		return nil, err
+	}
+	qph := quotedprintable.NewWriter(hw)
+	if _, err := strings.NewReader(htmlBody).WriteTo(qph); err != nil {
+		return nil, err
+	}
+	if err := qph.Close(); err != nil {
+		return nil, err
+	}
+
+	if err := mw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tools/email_tool_test.go
+++ b/tools/email_tool_test.go
@@ -1,0 +1,130 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"mime"
+	"mime/multipart"
+	"net/mail"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TestSMTPEmailSender_BuildsCorrectMIME
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestSMTPEmailSender_BuildsCorrectMIME verifies that buildMIMEMessage produces:
+//   - correct From / To / Subject headers
+//   - multipart/alternative content-type with a boundary
+//   - two parts: text/plain and text/html (in that order)
+func TestSMTPEmailSender_BuildsCorrectMIME(t *testing.T) {
+	t.Parallel()
+
+	from := "eSTOCK <noreply@eflowsuite.com>"
+	to := "user@example.com"
+	subject := "Test subject"
+	htmlBody := "<p>Hello <b>World</b></p>"
+	textBody := "Hello World"
+
+	raw, err := buildMIMEMessage(from, to, subject, htmlBody, textBody)
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	// Parse as RFC 5322 message.
+	msg, err := mail.ReadMessage(bytes.NewReader(raw))
+	require.NoError(t, err, "MIME message must be parseable as RFC 5322")
+
+	assert.Equal(t, from, msg.Header.Get("From"))
+	assert.Equal(t, to, msg.Header.Get("To"))
+	assert.Equal(t, subject, msg.Header.Get("Subject"))
+
+	ct := msg.Header.Get("Content-Type")
+	mediaType, params, err := mime.ParseMediaType(ct)
+	require.NoError(t, err)
+	assert.Equal(t, "multipart/alternative", mediaType)
+	boundary, ok := params["boundary"]
+	require.True(t, ok, "multipart/alternative must declare a boundary")
+	require.NotEmpty(t, boundary)
+
+	// Walk parts and collect content-types.
+	mr := multipart.NewReader(msg.Body, boundary)
+	var partTypes []string
+	for {
+		p, err := mr.NextPart()
+		if err != nil {
+			break
+		}
+		partTypes = append(partTypes, p.Header.Get("Content-Type"))
+	}
+
+	require.Len(t, partTypes, 2, "expected exactly 2 MIME parts (text/plain + text/html)")
+	assert.Contains(t, partTypes[0], "text/plain")
+	assert.Contains(t, partTypes[1], "text/html")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TestSMTPEmailSender_HonorsContextCancellation
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestSMTPEmailSender_HonorsContextCancellation verifies that Send() returns
+// ctx.Err() immediately when the context is already cancelled, without
+// attempting any network connection.
+func TestSMTPEmailSender_HonorsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	s := &SMTPEmailSender{
+		Host:     "smtp-relay.brevo.com",
+		Port:     587,
+		Username: "test@example.com",
+		Password: "secret",
+		FromAddr: "noreply@eflowsuite.com",
+		AppName:  "eSTOCK",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	err := s.Send(ctx, "recipient@example.com", "Subject", "<p>body</p>", "body")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled, "Send must return context.Canceled when ctx is already done")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TestSMTPEmailSender_PasswordResetFormatting
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestSMTPEmailSender_PasswordResetFormatting verifies that SendPasswordReset
+// produces a well-formed MIME message containing the reset link in the body,
+// without performing any real SMTP connection. We monkey-patch Send via a
+// captureSmtpSender wrapper to inspect the constructed payload.
+func TestSMTPEmailSender_PasswordResetFormatting(t *testing.T) {
+	t.Parallel()
+
+	const (
+		appName   = "eSTOCK"
+		userName  = "Juan Pérez"
+		resetLink = "https://estock.eflowsuite.com/reset?token=abc123"
+	)
+
+	// Build expected HTML and text the same way SendPasswordReset does.
+	wantHTML := renderResetEmailHTML(userName, resetLink, appName)
+	wantText := "Hola Juan Pérez,\n\nRestablece tu contraseña de eSTOCK: " + resetLink + "\n\nEl enlace expira en 1 hora."
+	wantSubject := "Restablece tu contraseña de eSTOCK"
+
+	// Build the MIME message directly to verify structure (no real SMTP).
+	from := appName + " <noreply@eflowsuite.com>"
+	raw, err := buildMIMEMessage(from, "juan@example.com", wantSubject, wantHTML, wantText)
+	require.NoError(t, err)
+
+	rawStr := string(raw)
+	assert.Contains(t, rawStr, wantSubject, "subject must appear in raw message")
+	assert.Contains(t, rawStr, "multipart/alternative", "message must be multipart/alternative")
+
+	// Verify the text body contains the reset link (decoded; link is ASCII so QP is identity).
+	assert.True(t, strings.Contains(rawStr, resetLink) || strings.Contains(rawStr, "abc123"),
+		"reset link must appear somewhere in the MIME payload")
+}

--- a/wire/wire.go
+++ b/wire/wire.go
@@ -114,10 +114,14 @@ func NewAuthenticationWithAudit(db *gorm.DB, config configuration.Config, rolesR
 	return r, services.NewAuthenticationService(r, rolesRepo)
 }
 
-// EmailSenderForConfig returns the appropriate EmailSender for the current environment.
-// In production with RESEND_API_KEY set, returns ResendEmailSender. Otherwise returns LoggerEmailSender.
+// EmailSenderForConfig returns the appropriate EmailSender based on available credentials.
+//
+// Priority order:
+//  1. RESEND_API_KEY set → ResendEmailSender (Resend API)
+//  2. SMTP_HOST set      → SMTPEmailSender (generic SMTP/STARTTLS — Brevo, Mailgun, etc.)
+//  3. Neither set        → LoggerEmailSender (dev/test fallback; logs to stdout)
 func EmailSenderForConfig(config configuration.Config) tools.EmailSender {
-	if config.Environment == "production" && config.ResendAPIKey != "" {
+	if config.ResendAPIKey != "" {
 		fromAddr := config.ResendFromAddress
 		if fromAddr == "" {
 			fromAddr = "noreply@estock.app"
@@ -126,6 +130,16 @@ func EmailSenderForConfig(config configuration.Config) tools.EmailSender {
 			APIKey:   config.ResendAPIKey,
 			FromAddr: fromAddr,
 			AppName:  "eSTOCK",
+		}
+	}
+	if config.SMTPHost != "" {
+		return &tools.SMTPEmailSender{
+			Host:     config.SMTPHost,
+			Port:     config.SMTPPort,
+			Username: config.SMTPUsername,
+			Password: config.SMTPPassword,
+			FromAddr: config.EmailFrom,
+			AppName:  config.EmailFromName,
 		}
 	}
 	return &tools.LoggerEmailSender{}

--- a/wire/wire_test.go
+++ b/wire/wire_test.go
@@ -1,0 +1,64 @@
+package wire_test
+
+import (
+	"testing"
+
+	"github.com/eflowcr/eSTOCK_backend/configuration"
+	"github.com/eflowcr/eSTOCK_backend/tools"
+	"github.com/eflowcr/eSTOCK_backend/wire"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEmailSenderForConfig_SMTPPriorityOrder verifies the three-tier selection:
+//  1. RESEND_API_KEY set → ResendEmailSender
+//  2. SMTP_HOST set (no Resend key) → SMTPEmailSender
+//  3. Neither set → LoggerEmailSender
+func TestEmailSenderForConfig_SMTPPriorityOrder(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resend wins when api key is set", func(t *testing.T) {
+		t.Parallel()
+		cfg := configuration.Config{
+			ResendAPIKey:  "re_test_key",
+			SMTPHost:      "smtp-relay.brevo.com",
+			SMTPPort:      587,
+			SMTPUsername:  "user@brevo.com",
+			SMTPPassword:  "secret",
+			EmailFrom:     "noreply@eflowsuite.com",
+			EmailFromName: "eSTOCK",
+		}
+		sender := wire.EmailSenderForConfig(cfg)
+		_, ok := sender.(*tools.ResendEmailSender)
+		assert.True(t, ok, "expected ResendEmailSender when RESEND_API_KEY is set")
+	})
+
+	t.Run("smtp fallback when only smtp host is set", func(t *testing.T) {
+		t.Parallel()
+		cfg := configuration.Config{
+			ResendAPIKey:  "", // not set
+			SMTPHost:      "smtp-relay.brevo.com",
+			SMTPPort:      587,
+			SMTPUsername:  "user@brevo.com",
+			SMTPPassword:  "secret",
+			EmailFrom:     "noreply@eflowsuite.com",
+			EmailFromName: "eSTOCK",
+		}
+		sender := wire.EmailSenderForConfig(cfg)
+		got, ok := sender.(*tools.SMTPEmailSender)
+		assert.True(t, ok, "expected SMTPEmailSender when SMTP_HOST is set and RESEND_API_KEY is unset")
+		if ok {
+			assert.Equal(t, "smtp-relay.brevo.com", got.Host)
+			assert.Equal(t, 587, got.Port)
+			assert.Equal(t, "noreply@eflowsuite.com", got.FromAddr)
+			assert.Equal(t, "eSTOCK", got.AppName)
+		}
+	})
+
+	t.Run("logger fallback when neither is set", func(t *testing.T) {
+		t.Parallel()
+		cfg := configuration.Config{} // no Resend, no SMTP
+		sender := wire.EmailSenderForConfig(cfg)
+		_, ok := sender.(*tools.LoggerEmailSender)
+		assert.True(t, ok, "expected LoggerEmailSender when neither RESEND_API_KEY nor SMTP_HOST is set")
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `SMTPEmailSender` in `tools/email_tool.go` — generic SMTP/STARTTLS sender using only `net/smtp` stdlib. Builds proper `multipart/alternative` MIME (text/plain + text/html, quoted-printable). Honours context cancellation before any network I/O.
- Adds 6 SMTP config fields to `configuration/configuration.go` (`SMTP_HOST`, `SMTP_PORT` default 587, `SMTP_USERNAME`, `SMTP_PASSWORD`, `EMAIL_FROM` default `noreply@eflowsuite.com`, `EMAIL_FROM_NAME` default `eSTOCK`).
- Updates `wire.EmailSenderForConfig` to 3-tier priority: `RESEND_API_KEY` → `SMTP_HOST` → `LoggerEmailSender`. Removes the `environment == "production"` gate from Resend (Resend now activates in any env when key is set).

## Brevo env vars to add to k8s secret

```bash
SMTP_HOST=smtp-relay.brevo.com
SMTP_PORT=587
SMTP_USERNAME=a981e7001@smtp-brevo.com
SMTP_PASSWORD=<brevo_master_password>
EMAIL_FROM=noreply@eflowsuite.com
EMAIL_FROM_NAME=eSTOCK
```

## Tests added

- `tools/email_tool_test.go`: `TestSMTPEmailSender_BuildsCorrectMIME`, `TestSMTPEmailSender_HonorsContextCancellation`, `TestSMTPEmailSender_PasswordResetFormatting`
- `wire/wire_test.go`: `TestEmailSenderForConfig_SMTPPriorityOrder` (3 sub-tests: Resend wins, SMTP fallback, Logger fallback)

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -short -race -count=1 ./...` — 0 new failures
- [x] `make sqlc` — 0 diff
- [ ] Deploy to dev, set Brevo SMTP env vars, trigger password-reset, confirm email received in inbox
- [ ] Confirm `LoggerEmailSender` still active when neither key is set (ENVIRONMENT=development no SMTP vars)

## Notes

- `ResendEmailSender` untouched per hard limit.
- This is a temporary solution — S-EM2 will add the formal Brevo provider. No duplicate work: S-EM2 can swap the SMTP sender for the Brevo SDK sender at that point.