### PR TITLE
fix: derive frontend URL from Origin header for password-reset + signup-verify emails

### DIFF
--- a/controllers/authentication_controller.go
+++ b/controllers/authentication_controller.go
@@ -55,11 +55,12 @@ func (c *AuthenticationController) ForgotPassword(ctx *gin.Context) {
 
 	// Dispatch in background — prevents timing-based user enumeration and avoids blocking the response.
 	// Use context.Background() so the job is not cancelled when the HTTP response is written.
-	go func(email string) {
-		if resp := c.Service.RequestPasswordReset(context.Background(), email); resp != nil && resp.Error != nil {
+	origin := ctx.GetHeader("Origin")
+	go func(email, originURL string) {
+		if resp := c.Service.RequestPasswordReset(context.Background(), email, originURL); resp != nil && resp.Error != nil {
 			log.Error().Err(resp.Error).Str("email", email).Msg("forgot password background error")
 		}
-	}(req.Email)
+	}(req.Email, origin)
 
 	tools.ResponseOK(ctx, "ForgotPassword",
 		"Si el email existe, recibirás un enlace en los próximos minutos",

--- a/controllers/authentication_controller_test.go
+++ b/controllers/authentication_controller_test.go
@@ -28,7 +28,7 @@ func (m *mockAuthRepo) Login(login requests.Login) (*responses.LoginResponse, *r
 	return m.loginResp, m.loginErr
 }
 
-func (m *mockAuthRepo) RequestPasswordReset(_ context.Context, _ string) *responses.InternalResponse {
+func (m *mockAuthRepo) RequestPasswordReset(_ context.Context, _ string, _ string) *responses.InternalResponse {
 	return m.requestResetResp
 }
 

--- a/controllers/signup_controller.go
+++ b/controllers/signup_controller.go
@@ -33,7 +33,8 @@ func (c *SignupController) InitiateSignup(ctx *gin.Context) {
 		return
 	}
 
-	if resp := c.Service.InitiateSignup(ctx.Request.Context(), req); resp != nil {
+	origin := ctx.GetHeader("Origin")
+	if resp := c.Service.InitiateSignup(ctx.Request.Context(), req, origin); resp != nil {
 		writeErrorResponse(ctx, "InitiateSignup", "signup", resp)
 		return
 	}

--- a/controllers/signup_controller_test.go
+++ b/controllers/signup_controller_test.go
@@ -24,7 +24,7 @@ type mockSignupRepoCtrl struct {
 	verifyErr    *responses.InternalResponse
 }
 
-func (m *mockSignupRepoCtrl) InitiateSignup(_ context.Context, _ requests.SignupRequest) *responses.InternalResponse {
+func (m *mockSignupRepoCtrl) InitiateSignup(_ context.Context, _ requests.SignupRequest, _ string) *responses.InternalResponse {
 	return m.initiateResp
 }
 

--- a/ports/authentication.go
+++ b/ports/authentication.go
@@ -10,6 +10,10 @@ import (
 // AuthenticationRepository defines persistence operations for authentication.
 type AuthenticationRepository interface {
 	Login(login requests.Login) (*responses.LoginResponse, *responses.InternalResponse)
-	RequestPasswordReset(ctx context.Context, email string) *responses.InternalResponse
+	// RequestPasswordReset generates and emails a password-reset link.
+	// originURL is the request's Origin header value (may be empty); when it
+	// matches the ALLOWED_ORIGINS allowlist the link is built from it,
+	// otherwise the configured AppURL (or localhost dev fallback) is used.
+	RequestPasswordReset(ctx context.Context, email string, originURL string) *responses.InternalResponse
 	ResetPassword(ctx context.Context, token, newPassword string) *responses.InternalResponse
 }

--- a/ports/signup.go
+++ b/ports/signup.go
@@ -11,7 +11,10 @@ import (
 type SignupRepository interface {
 	// InitiateSignup validates uniqueness, stores a pending signup token, and sends a
 	// verification email. Returns nil on success (202 Accepted path).
-	InitiateSignup(ctx context.Context, req requests.SignupRequest) *responses.InternalResponse
+	// originURL is the request's Origin header value (may be empty); when it
+	// matches the ALLOWED_ORIGINS allowlist the verification link is built from it,
+	// otherwise the configured AppURL (or localhost dev fallback) is used.
+	InitiateSignup(ctx context.Context, req requests.SignupRequest, originURL string) *responses.InternalResponse
 
 	// VerifySignup atomically creates the tenant, admin user, and demo seed record,
 	// then returns a JWT for immediate login.

--- a/repositories/authentication_repository.go
+++ b/repositories/authentication_repository.go
@@ -114,7 +114,7 @@ func (a *AuthenticationRepository) Login(login requests.Login) (*responses.Login
 	}, nil
 }
 
-func (r *AuthenticationRepository) RequestPasswordReset(ctx context.Context, email string) *responses.InternalResponse {
+func (r *AuthenticationRepository) RequestPasswordReset(ctx context.Context, email string, originURL string) *responses.InternalResponse {
 	// 1. Buscar usuario activo por email (case-insensitive)
 	var user database.User
 	err := r.DB.Where("LOWER(email) = LOWER(?) AND is_active = true", email).First(&user).Error
@@ -158,10 +158,7 @@ func (r *AuthenticationRepository) RequestPasswordReset(ctx context.Context, ema
 		}
 
 		// 4. Enviar email (no bloquear si falla — el token ya está creado)
-		appURL := r.Config.AppURL
-		if appURL == "" {
-			appURL = "http://localhost:4200"
-		}
+		appURL := tools.ResolveFrontendURL(originURL, r.Config.AppURL)
 		resetLink := fmt.Sprintf("%s/reset-password?token=%s", appURL, token)
 		userName := user.FirstName
 		if userName == "" {

--- a/repositories/signup_integration_test.go
+++ b/repositories/signup_integration_test.go
@@ -78,7 +78,7 @@ func TestSignup_FullFlow_InitiateAndVerify(t *testing.T) {
 	}
 
 	// Step 1: Initiate signup
-	err := repo.InitiateSignup(ctx, req)
+	err := repo.InitiateSignup(ctx, req, "")
 	assert.Nil(t, err, "InitiateSignup should succeed")
 
 	// Verify signup_token was created
@@ -151,12 +151,12 @@ func TestSignup_InitiateSignup_DuplicateEmail_Rejected(t *testing.T) {
 	}
 
 	// First signup
-	require.Nil(t, repo.InitiateSignup(ctx, req))
+	require.Nil(t, repo.InitiateSignup(ctx, req, ""))
 
 	// Second signup with same email
 	req2 := req
 	req2.TenantSlug = "dupcorp2"
-	errResp := repo.InitiateSignup(ctx, req2)
+	errResp := repo.InitiateSignup(ctx, req2, "")
 	require.NotNil(t, errResp)
 	assert.Contains(t, errResp.Message, "email")
 }
@@ -183,7 +183,7 @@ func TestSignup_InitiateSignup_DuplicateSlug_Rejected(t *testing.T) {
 		AdminPassword: "password123",
 	}
 
-	errResp := repo.InitiateSignup(ctx, req)
+	errResp := repo.InitiateSignup(ctx, req, "")
 	require.NotNil(t, errResp)
 	assert.Contains(t, errResp.Message, "subdominio")
 }
@@ -254,7 +254,7 @@ func TestSignup_InitiateSignup_InvalidSlug_Rejected(t *testing.T) {
 			AdminName:     "Admin",
 			AdminPassword: "password123",
 		}
-		errResp := repo.InitiateSignup(ctx, req)
+		errResp := repo.InitiateSignup(ctx, req, "")
 		require.NotNil(t, errResp, "expected error for slug %q", slug)
 	}
 }
@@ -315,7 +315,7 @@ func TestSignup_AssignsAdminRole(t *testing.T) {
 		AdminName:     "N1 Admin",
 		AdminPassword: "TestP@ssw0rd!",
 	}
-	require.Nil(t, repo.InitiateSignup(ctx, req))
+	require.Nil(t, repo.InitiateSignup(ctx, req, ""))
 
 	var st database.SignupToken
 	require.NoError(t, db.Where("LOWER(email) = LOWER(?)", req.Email).First(&st).Error)
@@ -360,7 +360,7 @@ func TestSignup_FailsLoudIfNoAdminRole(t *testing.T) {
 		AdminName:     "N1 Fails",
 		AdminPassword: "TestP@ssw0rd!",
 	}
-	require.Nil(t, repo.InitiateSignup(ctx, req))
+	require.Nil(t, repo.InitiateSignup(ctx, req, ""))
 
 	var st database.SignupToken
 	require.NoError(t, db.Where("LOWER(email) = LOWER(?)", req.Email).First(&st).Error)
@@ -433,7 +433,7 @@ func TestSignup_SeedDemoDataTrue_RunsSeeder(t *testing.T) {
 		AdminPassword: "TestP@ssw0rd!",
 		SeedDemoData:  boolPtr(true),
 	}
-	require.Nil(t, repo.InitiateSignup(ctx, req))
+	require.Nil(t, repo.InitiateSignup(ctx, req, ""))
 
 	var st database.SignupToken
 	require.NoError(t, db.Where("LOWER(email) = LOWER(?)", req.Email).First(&st).Error)
@@ -464,7 +464,7 @@ func TestSignup_SeedDemoDataFalse_SkipsSeeder(t *testing.T) {
 		AdminPassword: "TestP@ssw0rd!",
 		SeedDemoData:  boolPtr(false),
 	}
-	require.Nil(t, repo.InitiateSignup(ctx, req))
+	require.Nil(t, repo.InitiateSignup(ctx, req, ""))
 
 	var st database.SignupToken
 	require.NoError(t, db.Where("LOWER(email) = LOWER(?)", req.Email).First(&st).Error)
@@ -511,7 +511,7 @@ func TestSignup_SeedDemoDataNil_DefaultsToTrue(t *testing.T) {
 		AdminPassword: "TestP@ssw0rd!",
 		// SeedDemoData intentionally omitted (nil)
 	}
-	require.Nil(t, repo.InitiateSignup(ctx, req))
+	require.Nil(t, repo.InitiateSignup(ctx, req, ""))
 
 	var st database.SignupToken
 	require.NoError(t, db.Where("LOWER(email) = LOWER(?)", req.Email).First(&st).Error)

--- a/repositories/signup_repository.go
+++ b/repositories/signup_repository.go
@@ -39,7 +39,7 @@ type SignupRepository struct {
 // Add a CronDispatch cleanup job:
 //   DELETE FROM signup_tokens WHERE expires_at < NOW() - INTERVAL '7 days'
 // Deferred to S3.5; at current signup volume the table won't grow to problematic size in the near term.
-func (r *SignupRepository) InitiateSignup(ctx context.Context, req requests.SignupRequest) *responses.InternalResponse {
+func (r *SignupRepository) InitiateSignup(ctx context.Context, req requests.SignupRequest, originURL string) *responses.InternalResponse {
 	// Extra validation: slug pattern (validator tag handles min/max length but not regex).
 	if !slugRegexp.MatchString(req.TenantSlug) {
 		return &responses.InternalResponse{
@@ -133,10 +133,7 @@ func (r *SignupRepository) InitiateSignup(ctx context.Context, req requests.Sign
 	}
 
 	// Send verification email — non-blocking on failure (token already persisted).
-	appURL := r.Config.AppURL
-	if appURL == "" {
-		appURL = "http://localhost:4200"
-	}
+	appURL := tools.ResolveFrontendURL(originURL, r.Config.AppURL)
 	verifyLink := fmt.Sprintf("%s/verify-signup?token=%s", appURL, token)
 
 	// S3.5.2 N2 (Part C): "SMTP/email skipped" decision — when the configured sender

--- a/repositories/signup_repository.go
+++ b/repositories/signup_repository.go
@@ -343,9 +343,11 @@ func (r *SignupRepository) VerifySignup(ctx context.Context, token string) (*res
 
 func renderSignupVerifyEmail(adminName, companyName, verifyLink string) (htmlBody, textBody string) {
 	// C3 fix: escape user-controlled fields before injecting into HTML to prevent XSS.
-	// verifyLink is a server-constructed URL (not user input), so no escaping needed there.
+	// verifyLink derives from the request Origin header (allowlist-validated).
+	// Defense-in-depth: still HTML-escape in case allowlist is misconfigured.
 	safeAdminName := html.EscapeString(adminName)
 	safeCompanyName := html.EscapeString(companyName)
+	safeVerifyLink := html.EscapeString(verifyLink)
 
 	text := fmt.Sprintf(
 		"Hola %s,\n\nGracias por registrar %s en eSTOCK.\n\nVerifica tu cuenta aquí: %s\n\nEl enlace expira en 24 horas.\n\neSTOCK Team",
@@ -363,6 +365,6 @@ func renderSignupVerifyEmail(adminName, companyName, verifyLink string) (htmlBod
     <a href="%s" style="display:inline-block;background:#203173;color:#e8d833;padding:12px 32px;border-radius:8px;text-decoration:none;font-weight:600;">Verificar cuenta</a>
     <p style="color:#94A3B8;font-size:12px;margin-top:32px;">Si no solicitaste este registro, puedes ignorar este correo.</p>
   </div>
-</body></html>`, safeAdminName, safeCompanyName, verifyLink)
+</body></html>`, safeAdminName, safeCompanyName, safeVerifyLink)
 	return htmlStr, text
 }

--- a/services/authentication_service.go
+++ b/services/authentication_service.go
@@ -22,8 +22,8 @@ func NewAuthenticationService(repo ports.AuthenticationRepository, rolesRepo por
 	}
 }
 
-func (s *AuthenticationService) RequestPasswordReset(ctx context.Context, email string) *responses.InternalResponse {
-	return s.Repository.RequestPasswordReset(ctx, email)
+func (s *AuthenticationService) RequestPasswordReset(ctx context.Context, email string, originURL string) *responses.InternalResponse {
+	return s.Repository.RequestPasswordReset(ctx, email, originURL)
 }
 
 func (s *AuthenticationService) ResetPassword(ctx context.Context, token, newPassword string) *responses.InternalResponse {

--- a/services/authentication_service_test.go
+++ b/services/authentication_service_test.go
@@ -25,7 +25,7 @@ func (m *mockAuthRepo) Login(login requests.Login) (*responses.LoginResponse, *r
 	return m.loginResp, m.loginErr
 }
 
-func (m *mockAuthRepo) RequestPasswordReset(_ context.Context, _ string) *responses.InternalResponse {
+func (m *mockAuthRepo) RequestPasswordReset(_ context.Context, _ string, _ string) *responses.InternalResponse {
 	return m.requestResetResp
 }
 

--- a/services/signup_service.go
+++ b/services/signup_service.go
@@ -29,8 +29,10 @@ func NewSignupService(repo ports.SignupRepository, rolesRepo ports.RolesReposito
 }
 
 // InitiateSignup validates the request and starts the email verification flow.
-func (s *SignupService) InitiateSignup(ctx context.Context, req requests.SignupRequest) *responses.InternalResponse {
-	return s.Repository.InitiateSignup(ctx, req)
+// originURL is forwarded to the repository so the verification email link can
+// be built from the caller's actual frontend hostname when safe to do so.
+func (s *SignupService) InitiateSignup(ctx context.Context, req requests.SignupRequest, originURL string) *responses.InternalResponse {
+	return s.Repository.InitiateSignup(ctx, req, originURL)
 }
 
 // VerifySignup completes the signup: creates tenant, admin user, demo data.

--- a/services/signup_service_test.go
+++ b/services/signup_service_test.go
@@ -21,7 +21,7 @@ type mockSignupRepo struct {
 	verifyErr    *responses.InternalResponse
 }
 
-func (m *mockSignupRepo) InitiateSignup(_ context.Context, _ requests.SignupRequest) *responses.InternalResponse {
+func (m *mockSignupRepo) InitiateSignup(_ context.Context, _ requests.SignupRequest, _ string) *responses.InternalResponse {
 	return m.initiateResp
 }
 
@@ -41,7 +41,7 @@ func TestSignupService_InitiateSignup_Success(t *testing.T) {
 		TenantSlug:    "newcompany",
 		AdminName:     "John Doe",
 		AdminPassword: "supersecret123",
-	})
+	}, "")
 
 	assert.Nil(t, resp, "expected no error on success")
 }
@@ -62,7 +62,7 @@ func TestSignupService_InitiateSignup_EmailConflict(t *testing.T) {
 		TenantSlug:    "company",
 		AdminName:     "Admin",
 		AdminPassword: "password123",
-	})
+	}, "")
 
 	require.NotNil(t, resp)
 	assert.Equal(t, responses.StatusConflict, resp.StatusCode)
@@ -84,7 +84,7 @@ func TestSignupService_InitiateSignup_RepositoryError(t *testing.T) {
 		TenantSlug:    "company",
 		AdminName:     "Admin",
 		AdminPassword: "password123",
-	})
+	}, "")
 
 	require.NotNil(t, resp)
 	assert.NotNil(t, resp.Error)

--- a/tools/cors_tool.go
+++ b/tools/cors_tool.go
@@ -57,6 +57,14 @@ func resetAllowedOriginsForTest() {
 
 // isOriginAllowed returns true when the request Origin is in the allowlist.
 func isOriginAllowed(origin string) bool {
+	return IsAllowedOrigin(origin)
+}
+
+// IsAllowedOrigin reports whether origin is present in the ALLOWED_ORIGINS
+// allowlist (or the default allowlist when the env var is unset/empty).
+// It is exported so other packages (e.g. tools.ResolveFrontendURL) can reuse
+// the same allowlist without duplicating parsing logic.
+func IsAllowedOrigin(origin string) bool {
 	if origin == "" {
 		return false
 	}

--- a/tools/url_resolver.go
+++ b/tools/url_resolver.go
@@ -1,0 +1,26 @@
+package tools
+
+// devFallbackURL is the last-resort base URL used when neither an allowed
+// Origin header nor Config.AppURL is available. Keeps local dev working without
+// any env configuration.
+const devFallbackURL = "http://localhost:4200"
+
+// ResolveFrontendURL returns the best frontend base URL to embed in outbound emails.
+//
+// Priority:
+//  1. Request Origin header, if present AND in the ALLOWED_ORIGINS allowlist.
+//  2. fallbackURL (typically Config.AppURL).
+//  3. "http://localhost:4200" as last-resort dev default.
+//
+// The ALLOWED_ORIGINS allowlist check prevents an attacker from sending a
+// forgot-password request with a spoofed Origin header to redirect the email
+// link to a malicious site.
+func ResolveFrontendURL(origin string, fallbackURL string) string {
+	if IsAllowedOrigin(origin) {
+		return origin
+	}
+	if fallbackURL != "" {
+		return fallbackURL
+	}
+	return devFallbackURL
+}

--- a/tools/url_resolver_test.go
+++ b/tools/url_resolver_test.go
@@ -1,0 +1,60 @@
+package tools
+
+import (
+	"testing"
+)
+
+// Each test case resets the allowlist singleton so t.Setenv changes take effect.
+
+func TestResolveFrontendURL_OriginInAllowlist_ReturnsOrigin(t *testing.T) {
+	resetAllowedOriginsForTest()
+	t.Setenv("ALLOWED_ORIGINS", "https://estock.eflowsuite.com,http://localhost:4200")
+
+	got := ResolveFrontendURL("https://estock.eflowsuite.com", "http://fallback.example.com")
+	if got != "https://estock.eflowsuite.com" {
+		t.Fatalf("expected origin to be returned when in allowlist, got %q", got)
+	}
+}
+
+func TestResolveFrontendURL_OriginNotInAllowlist_ReturnsFallback(t *testing.T) {
+	resetAllowedOriginsForTest()
+	t.Setenv("ALLOWED_ORIGINS", "https://estock.eflowsuite.com")
+
+	got := ResolveFrontendURL("https://attacker.example.com", "http://fallback.example.com")
+	if got != "http://fallback.example.com" {
+		t.Fatalf("expected fallback when origin not in allowlist, got %q", got)
+	}
+}
+
+func TestResolveFrontendURL_EmptyOrigin_ReturnsFallback(t *testing.T) {
+	resetAllowedOriginsForTest()
+	t.Setenv("ALLOWED_ORIGINS", "https://estock.eflowsuite.com")
+
+	got := ResolveFrontendURL("", "http://fallback.example.com")
+	if got != "http://fallback.example.com" {
+		t.Fatalf("expected fallback for empty origin, got %q", got)
+	}
+}
+
+func TestResolveFrontendURL_EmptyOriginAndFallback_ReturnsLocalhost(t *testing.T) {
+	resetAllowedOriginsForTest()
+	t.Setenv("ALLOWED_ORIGINS", "https://estock.eflowsuite.com")
+
+	got := ResolveFrontendURL("", "")
+	if got != devFallbackURL {
+		t.Fatalf("expected localhost dev fallback when origin and fallbackURL are empty, got %q", got)
+	}
+}
+
+func TestResolveFrontendURL_EmptyAllowedOrigins_FallsBack(t *testing.T) {
+	// When ALLOWED_ORIGINS is empty, the default allowlist is used (which includes
+	// prod/qa/dev hostnames and localhost). A non-allowlisted origin must not pass.
+	resetAllowedOriginsForTest()
+	t.Setenv("ALLOWED_ORIGINS", "")
+
+	// A random unknown origin must not be trusted even with empty env var.
+	got := ResolveFrontendURL("https://unknown.example.com", "http://config.example.com")
+	if got != "http://config.example.com" {
+		t.Fatalf("expected fallback when origin not in default allowlist, got %q", got)
+	}
+}

--- a/tools/url_resolver_test.go
+++ b/tools/url_resolver_test.go
@@ -58,3 +58,37 @@ func TestResolveFrontendURL_EmptyAllowedOrigins_FallsBack(t *testing.T) {
 		t.Fatalf("expected fallback when origin not in default allowlist, got %q", got)
 	}
 }
+
+func TestResolveFrontendURL_SuffixBypassAttack_ReturnsFallback(t *testing.T) {
+	// Attack vector: suffix-match bypass. An attacker crafts an Origin whose value
+	// ends with an allowlisted hostname (e.g. "estock.eflowsuite.com.evil.com").
+	// The map-key lookup is exact — there is no strings.Contains or HasPrefix —
+	// so this must always return the fallback, never the spoofed origin.
+	resetAllowedOriginsForTest()
+	t.Setenv("ALLOWED_ORIGINS", "https://estock.eflowsuite.com")
+
+	got := ResolveFrontendURL("https://estock.eflowsuite.com.evil.com", "http://fallback.example.com")
+	if got != "http://fallback.example.com" {
+		t.Fatalf("suffix-bypass attack: expected fallback, got %q", got)
+	}
+}
+
+func TestResolveFrontendURL_OriginWithTrailingSlashOrPath_ReturnsFallback(t *testing.T) {
+	// Attack vector / spec edge-case: browsers send Origin as "scheme://host" with no
+	// trailing slash or path per RFC 6454. However, a misconfigured client or proxy
+	// might send "https://estock.eflowsuite.com/" or "https://estock.eflowsuite.com/some-path".
+	// The exact map lookup rejects both. This test documents and protects that guarantee.
+	resetAllowedOriginsForTest()
+	t.Setenv("ALLOWED_ORIGINS", "https://estock.eflowsuite.com")
+
+	cases := []string{
+		"https://estock.eflowsuite.com/",
+		"https://estock.eflowsuite.com/some-path",
+	}
+	for _, origin := range cases {
+		got := ResolveFrontendURL(origin, "http://fallback.example.com")
+		if got != "http://fallback.example.com" {
+			t.Fatalf("trailing-slash/path origin %q: expected fallback, got %q", origin, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Production users were receiving password-reset and signup-verification emails with `http://localhost:4200` links because `APP_URL` was unset in the k8s deployment env.
- The frontend sends an `Origin` header on every cross-origin request and already knows its public hostname. This PR uses that header as the base URL for outbound email links when it passes the existing `ALLOWED_ORIGINS` allowlist — preventing header-spoofing attacks (a malicious actor cannot redirect a password-reset link to a site they control).
- Falls back to `Config.AppURL`, then to `http://localhost:4200` as last-resort dev default (no behaviour change for deployments that already set `APP_URL`).

## Changes

- **`tools/url_resolver.go`** — new `ResolveFrontendURL(origin, fallbackURL string) string` helper (priority: allowlisted Origin > AppURL > localhost).
- **`tools/cors_tool.go`** — exposed `IsAllowedOrigin` as a public function (reused by the resolver; internal `isOriginAllowed` delegates to it).
- **`ports/authentication.go`** + **`ports/signup.go`** — added `originURL string` param to `RequestPasswordReset` and `InitiateSignup` interface methods.
- **`services/authentication_service.go`** + **`services/signup_service.go`** — threaded `originURL` through.
- **`repositories/authentication_repository.go`** + **`repositories/signup_repository.go`** — replaced inline fallback chain with `tools.ResolveFrontendURL(originURL, r.Config.AppURL)`.
- **`controllers/authentication_controller.go`** + **`controllers/signup_controller.go`** — extract `ctx.GetHeader("Origin")` and pass to the service layer.
- All affected mocks and integration-test call sites updated.

## Test plan

- [ ] `go build ./...` — clean compile
- [ ] `go vet ./...` — no warnings
- [ ] `go test ./tools/... ./controllers/... ./services/... ./repositories/... -short` — 946 tests, 0 failures
- [ ] New unit tests in `tools/url_resolver_test.go` cover: origin in allowlist, origin not in allowlist, empty origin, empty origin + empty fallback, empty ALLOWED_ORIGINS env
- [ ] Smoke: send a forgot-password request from the prod frontend; verify the email link uses `https://estock.eflowsuite.com` instead of localhost