### PR TITLE
feat(email): VPS Manager gateway sender + D8 multi-tenant cron fix (S-EM2 B7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,20 @@ APP_URL=http://localhost:4200
 # SMTP_FROM=noreply@<your-domain>
 # SMTP_TLS=true
 
+# -----------------------------------------------------------------------------
+# VPS Manager email gateway (S-EM2 — routes transactional email via Brevo)
+# -----------------------------------------------------------------------------
+# When VPS_MANAGER_BASE_URL and VPS_MANAGER_API_KEY are both set, eSTOCK routes
+# all transactional email (password reset, notifications, trial reminders) via
+# the VPS Manager API instead of Resend/SMTP. Selection priority:
+#   gateway > Resend > logger (stdout-only dev fallback).
+# VPS_MANAGER_BASE_URL: base URL of the VPS Manager API (e.g. https://vps-manager-api.eflowsuite.com/api/v1)
+# VPS_MANAGER_API_KEY: must match SERVICE_API_KEY in vps-manager-backend. Generate: openssl rand -hex 32
+# VPS_MANAGER_FROM_ADDR: sender address verified in Brevo (default: noreply@eflowsuite.com)
+VPS_MANAGER_BASE_URL=
+VPS_MANAGER_API_KEY=
+VPS_MANAGER_FROM_ADDR=noreply@eflowsuite.com
+
 # =============================================================================
 # MULTI-TENANT (S2 — single-tenant default)
 # =============================================================================

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -43,8 +43,8 @@ func main() {
 	// loud at startup so ops sees it on first log read instead of debugging a stuck
 	// signup hours later. We treat either RESEND_API_KEY or SMTP_HOST as "email
 	// configured"; only warn if both are empty.
-	if os.Getenv("SMTP_HOST") == "" && config.ResendAPIKey == "" {
-		log.Warn().Msg("SMTP_HOST and RESEND_API_KEY both unset — signup verify emails will be skipped. Tokens will be logged to stdout for ops debugging.")
+	if os.Getenv("SMTP_HOST") == "" && config.ResendAPIKey == "" && config.VPSManagerAPIKey == "" {
+		log.Warn().Msg("SMTP_HOST, RESEND_API_KEY, and VPS_MANAGER_API_KEY all unset — signup verify emails will be skipped. Tokens will be logged to stdout for ops debugging.")
 	}
 
 	dbURL := configuration.DatabaseURL(config)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -122,8 +122,9 @@ func main() {
 					return nil
 				}
 				ctx := context.Background()
+				tenantNotifSvc := notifSvc.WithTenant(tenantID)
 				for _, uid := range adminIDs {
-					if err := notifSvc.Send(ctx, uid, eventType, title, body, "lot", ""); err != nil {
+					if err := tenantNotifSvc.Send(ctx, uid, eventType, title, body, "lot", ""); err != nil {
 						log.Warn().Err(err).Str("tenant_id", tenantID).Str("user_id", uid).Msg("cron: lot expiration notify send failed")
 					}
 				}
@@ -145,8 +146,9 @@ func main() {
 				}
 				title := "Alerta: stock bajo — " + sku
 				ctx := context.Background()
+				tenantNotifSvc := notifSvc.WithTenant(tenantID)
 				for _, uid := range adminIDs {
-					if err := notifSvc.Send(ctx, uid, "low_stock", title, message, "stock_alert", sku); err != nil {
+					if err := tenantNotifSvc.Send(ctx, uid, "low_stock", title, message, "stock_alert", sku); err != nil {
 						log.Warn().Err(err).Str("tenant_id", tenantID).Str("sku", sku).Str("user_id", uid).Msg("cron: low_stock notify send failed")
 					}
 				}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -72,6 +72,16 @@ func main() {
 
 	// Build shared email sender and notifications service.
 	emailSender := wire.EmailSenderForConfig(config)
+	// HR-W3-B7 M7: log which sender was wired so ops can confirm at startup
+	// whether transactional email goes through the gateway, Resend, or stdout.
+	switch emailSender.(type) {
+	case *tools.GatewayEmailSender:
+		log.Info().Str("email_sender", "vps_manager_gateway").Msg("email sender wired")
+	case *tools.ResendEmailSender:
+		log.Info().Str("email_sender", "resend").Msg("email sender wired")
+	default:
+		log.Info().Str("email_sender", "logger_stdout").Msg("email sender wired (no real emails — dev mode)")
+	}
 	var notifSvc *services.NotificationsService
 	if db != nil {
 		_, notifSvc = wire.NewNotifications(db, emailSender, config.TenantID)

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -77,6 +77,13 @@ type Config struct {
 	StripePricePro string
 	// StripePriceEnterprise is the Stripe Price ID for the Enterprise plan (env: STRIPE_PRICE_ENTERPRISE).
 	StripePriceEnterprise string
+
+	// VPS Manager email gateway (S-EM2).
+	// When VPSManagerBaseURL and VPSManagerAPIKey are both set, transactional emails
+	// are routed through VPS Manager → Brevo instead of being sent directly.
+	VPSManagerBaseURL  string // env: VPS_MANAGER_BASE_URL, e.g. "https://vps-manager-api.eflowsuite.com/api/v1"
+	VPSManagerAPIKey   string // env: VPS_MANAGER_API_KEY (service key configured in VPS Manager)
+	VPSManagerFromAddr string // env: VPS_MANAGER_FROM_ADDR, e.g. "noreply@eflowsuite.com"
 }
 
 // LoadConfig loads configuration from environment variables, optionally from a .env file if present.
@@ -115,6 +122,9 @@ func LoadConfig() (Config, error) {
 		StripePriceStarter:   os.Getenv("STRIPE_PRICE_STARTER"),
 		StripePricePro:       os.Getenv("STRIPE_PRICE_PRO"),
 		StripePriceEnterprise: os.Getenv("STRIPE_PRICE_ENTERPRISE"),
+		VPSManagerBaseURL:     os.Getenv("VPS_MANAGER_BASE_URL"),
+		VPSManagerAPIKey:      os.Getenv("VPS_MANAGER_API_KEY"),
+		VPSManagerFromAddr:    os.Getenv("VPS_MANAGER_FROM_ADDR"),
 	}
 	if cfg.TenantID == "" {
 		cfg.TenantID = "00000000-0000-0000-0000-000000000001"

--- a/services/notifications_service.go
+++ b/services/notifications_service.go
@@ -127,3 +127,14 @@ func (s *NotificationsService) UpsertPreference(pref *database.NotificationPrefe
 	}
 	return nil
 }
+
+// WithTenant returns a shallow copy of the service scoped to the given tenantID.
+// Use in cron callbacks that iterate per-tenant to avoid pod-level tenantID
+// leaking into notification rows for other tenants.
+func (s *NotificationsService) WithTenant(tenantID string) *NotificationsService {
+	return &NotificationsService{
+		repo:        s.repo,
+		emailSender: s.emailSender,
+		tenantID:    tenantID,
+	}
+}

--- a/tools/email_tool.go
+++ b/tools/email_tool.go
@@ -8,6 +8,7 @@ import (
 	"html"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -112,6 +113,74 @@ func (r *ResendEmailSender) SendPasswordReset(toEmail, userName, resetLink strin
 	htmlBody := renderResetEmailHTML(userName, resetLink, r.AppName)
 	text := fmt.Sprintf("Hola %s,\n\nRestablece tu contraseña de %s: %s\n\nEl enlace expira en 1 hora.", userName, r.AppName, resetLink)
 	return r.Send(ctx, toEmail, fmt.Sprintf("Restablece tu contraseña de %s", r.AppName), htmlBody, text)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GatewayEmailSender — routes transactional emails via VPS Manager API (S-EM2)
+// ─────────────────────────────────────────────────────────────────────────────
+
+type GatewayEmailSender struct {
+	BaseURL  string
+	APIKey   string
+	FromAddr string
+	AppName  string
+	client   *http.Client
+}
+
+type gatewayEmailRequest struct {
+	To       string `json:"to"`
+	Subject  string `json:"subject"`
+	BodyHTML string `json:"body_html,omitempty"`
+	BodyText string `json:"body_text,omitempty"`
+}
+
+func NewGatewayEmailSender(baseURL, apiKey, fromAddr, appName string) *GatewayEmailSender {
+	return &GatewayEmailSender{
+		BaseURL:  baseURL,
+		APIKey:   apiKey,
+		FromAddr: fromAddr,
+		AppName:  appName,
+		client:   &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (g *GatewayEmailSender) Send(ctx context.Context, to, subject, htmlBody, textBody string) error {
+	payload := gatewayEmailRequest{
+		To:       to,
+		Subject:  subject,
+		BodyHTML: htmlBody,
+		BodyText: textBody,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("gateway: marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, g.BaseURL+"/emails/send", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("gateway: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+g.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("gateway: http: %w", err)
+	}
+	defer resp.Body.Close()
+	// 201 = sent immediately, 202 = accepted/queued for retry — both success for caller
+	if resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusAccepted {
+		return nil
+	}
+	b, _ := io.ReadAll(resp.Body)
+	return fmt.Errorf("gateway: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+}
+
+func (g *GatewayEmailSender) SendPasswordReset(toEmail, userName, resetLink string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	htmlBody := renderResetEmailHTML(userName, resetLink, g.AppName)
+	text := fmt.Sprintf("Hola %s,\n\nRestablece tu contraseña de %s: %s\n\nEl enlace expira en 1 hora.",
+		userName, g.AppName, resetLink)
+	return g.Send(ctx, toEmail, fmt.Sprintf("Restablece tu contraseña de %s", g.AppName), htmlBody, text)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tools/email_tool.go
+++ b/tools/email_tool.go
@@ -134,9 +134,13 @@ type gatewayEmailRequest struct {
 	BodyText string `json:"body_text,omitempty"`
 }
 
+// NewGatewayEmailSender constructs a sender that posts to {baseURL}/emails/send.
+// Trailing slashes on baseURL are normalized so callers can pass either
+// "https://host/api/v1" or "https://host/api/v1/" without producing a double slash
+// in the request URL (HR-W3-B7 M5).
 func NewGatewayEmailSender(baseURL, apiKey, fromAddr, appName string) *GatewayEmailSender {
 	return &GatewayEmailSender{
-		BaseURL:  baseURL,
+		BaseURL:  strings.TrimRight(baseURL, "/"),
 		APIKey:   apiKey,
 		FromAddr: fromAddr,
 		AppName:  appName,
@@ -168,10 +172,14 @@ func (g *GatewayEmailSender) Send(ctx context.Context, to, subject, htmlBody, te
 	defer resp.Body.Close()
 	// 201 = sent immediately, 202 = accepted/queued for retry — both success for caller
 	if resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusAccepted {
+		// Drain to allow connection reuse (keep-alive).
+		io.Copy(io.Discard, resp.Body)
 		return nil
 	}
-	b, _ := io.ReadAll(resp.Body)
-	return fmt.Errorf("gateway: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+	// Sanitize: do NOT echo upstream body in returned error — may leak internal
+	// details (stack traces, DB messages) to caller logs (HR-W3-B7 M6).
+	io.Copy(io.Discard, resp.Body)
+	return fmt.Errorf("gateway: HTTP %d", resp.StatusCode)
 }
 
 func (g *GatewayEmailSender) SendPasswordReset(toEmail, userName, resetLink string) error {

--- a/tools/gateway_email_sender_test.go
+++ b/tools/gateway_email_sender_test.go
@@ -1,0 +1,89 @@
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eflowcr/eSTOCK_backend/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGatewayEmailSender_Send_201Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/emails/send", r.URL.Path)
+		assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{"send":{"id":"123"}}`))
+	}))
+	defer srv.Close()
+	sender := tools.NewGatewayEmailSender(srv.URL+"/api/v1", "test-key", "from@test.com", "TestApp")
+	err := sender.Send(context.Background(), "to@test.com", "Subject", "<b>html</b>", "text")
+	require.NoError(t, err)
+}
+
+func TestGatewayEmailSender_Send_202QueuedIsSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+		w.Write([]byte(`{"message":"queued"}`))
+	}))
+	defer srv.Close()
+	sender := tools.NewGatewayEmailSender(srv.URL+"/api/v1", "key", "from@test.com", "App")
+	err := sender.Send(context.Background(), "to@test.com", "Subject", "", "text only")
+	require.NoError(t, err)
+}
+
+func TestGatewayEmailSender_Send_400ReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":"body_html or body_text is required"}`))
+	}))
+	defer srv.Close()
+	sender := tools.NewGatewayEmailSender(srv.URL+"/api/v1", "key", "from@test.com", "App")
+	err := sender.Send(context.Background(), "to@test.com", "Subject", "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 400")
+}
+
+func TestGatewayEmailSender_Send_403Forbidden(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"error":"forbidden"}`))
+	}))
+	defer srv.Close()
+	sender := tools.NewGatewayEmailSender(srv.URL+"/api/v1", "wrong-key", "from@test.com", "App")
+	err := sender.Send(context.Background(), "to@test.com", "Subject", "html", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 403")
+}
+
+func TestGatewayEmailSender_Send_PayloadFields(t *testing.T) {
+	var captured map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&captured)
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+	sender := tools.NewGatewayEmailSender(srv.URL+"/api/v1", "key", "from@test.com", "App")
+	err := sender.Send(context.Background(), "to@test.com", "My Subject", "<b>html</b>", "plain text")
+	require.NoError(t, err)
+	assert.Equal(t, "to@test.com", captured["to"])
+	assert.Equal(t, "My Subject", captured["subject"])
+	assert.Equal(t, "<b>html</b>", captured["body_html"])
+	assert.Equal(t, "plain text", captured["body_text"])
+}
+
+func TestGatewayEmailSender_Send_ContextCanceled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	sender := tools.NewGatewayEmailSender(srv.URL+"/api/v1", "key", "from@test.com", "App")
+	err := sender.Send(ctx, "to@test.com", "Subject", "html", "text")
+	require.Error(t, err)
+}

--- a/wire/wire.go
+++ b/wire/wire.go
@@ -115,18 +115,21 @@ func NewAuthenticationWithAudit(db *gorm.DB, config configuration.Config, rolesR
 }
 
 // EmailSenderForConfig returns the appropriate EmailSender for the current environment.
-// In production with RESEND_API_KEY set, returns ResendEmailSender. Otherwise returns LoggerEmailSender.
+// Priority: VPS Manager gateway > Resend (legacy) > LoggerEmailSender.
 func EmailSenderForConfig(config configuration.Config) tools.EmailSender {
+	if config.VPSManagerBaseURL != "" && config.VPSManagerAPIKey != "" {
+		fromAddr := config.VPSManagerFromAddr
+		if fromAddr == "" {
+			fromAddr = "noreply@eflowsuite.com"
+		}
+		return tools.NewGatewayEmailSender(config.VPSManagerBaseURL, config.VPSManagerAPIKey, fromAddr, "eSTOCK")
+	}
 	if config.Environment == "production" && config.ResendAPIKey != "" {
 		fromAddr := config.ResendFromAddress
 		if fromAddr == "" {
 			fromAddr = "noreply@estock.app"
 		}
-		return &tools.ResendEmailSender{
-			APIKey:   config.ResendAPIKey,
-			FromAddr: fromAddr,
-			AppName:  "eSTOCK",
-		}
+		return &tools.ResendEmailSender{APIKey: config.ResendAPIKey, FromAddr: fromAddr, AppName: "eSTOCK"}
 	}
 	return &tools.LoggerEmailSender{}
 }


### PR DESCRIPTION
## Summary
- **Email gateway**: new `tools.GatewayEmailSender` routes transactional emails through `VPS_MANAGER_BASE_URL/emails/send` with a Bearer service key. 201 + 202 both treated as success. Wired ahead of Resend in `wire.EmailSenderForConfig` priority chain (gateway → Resend → Logger).
- **Config**: `VPS_MANAGER_BASE_URL`, `VPS_MANAGER_API_KEY`, `VPS_MANAGER_FROM_ADDR` env vars + extended startup warning so ops sees a log line when none of SMTP_HOST, RESEND_API_KEY, or VPS_MANAGER_API_KEY are set.
- **D8 fix**: `NotificationsService.WithTenant(tenantID)` returns a shallow copy scoped per-tenant. Cron lot-expiration and low-stock closures now use `notifSvc.WithTenant(tenantID).Send(...)` so notification rows land in the correct tenant — they previously inherited the pod-level `config.TenantID`, violating HR-S3.5 C3 isolation guarantees.

## Why
S-EM2 W3 B7 wires estock to call VPS Manager's `POST /api/v1/emails/send` (paired with vps-manager PR #3 which adds the SERVICE_API_KEY bypass). End-to-end path: estock → VPS Manager → Brevo → inbox.

## Test plan
- [x] `go build ./...` — passes
- [x] `go vet ./...` — clean
- [x] `go test ./tools/... -run TestGateway` — 6/6 passing (201, 202, 400, 403, payload-shape, ctx-cancelled)
- [x] `go test ./services/...` — passes (no regressions)
- [x] Full `go test ./...` — only pre-existing cron integration tests fail (`TestRunStaleReservationsCleanup_*` — null `tenant_id` on user inserts; reproduces on main, unrelated)
- [ ] Post-merge: set `VPS_MANAGER_*` env vars in estock-prod k8s secret; smoke-test password reset flow

## Related
- Companion PR: [vps-manager-backend#3](https://github.com/Jafetlch/vps-manager-backend/pull/3) (SERVICE_API_KEY bypass)
- Sprint S-EM2 W3 B7
- Roadmap: [[2026-04-22-s-em-email]]