### PR TITLE
S7.2 W0 — Idempotency-Key middleware for mobile outbox replay

### DIFF
--- a/db/migrations/000040_idempotency_keys.down.sql
+++ b/db/migrations/000040_idempotency_keys.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS public.idx_idempotency_keys_endpoint;
+DROP INDEX IF EXISTS public.idx_idempotency_keys_expires_at;
+DROP TABLE IF EXISTS public.idempotency_keys;

--- a/db/migrations/000040_idempotency_keys.up.sql
+++ b/db/migrations/000040_idempotency_keys.up.sql
@@ -1,0 +1,32 @@
+-- Idempotency-Key dedup table for mobile S7.2 write-side outbox.
+-- Mobile generates a UUID v4 per mutation before queueing into its local
+-- outbox. The same key is replayed on every retry — backend deduplicates
+-- by (key, user_id) and returns the cached response for hits.
+--
+-- TTL window: 7 days. After that the key entry expires and a replay would
+-- re-apply the mutation. Operators shouldn't be queuing mutations for more
+-- than a week offline; cron sweeps expired rows.
+--
+-- Schema depends on: users(id) (TEXT id from 000004).
+
+CREATE TABLE IF NOT EXISTS public.idempotency_keys (
+    key             TEXT NOT NULL,
+    user_id         TEXT NOT NULL REFERENCES public.users(id),
+    endpoint        VARCHAR(255) NOT NULL,
+    method          VARCHAR(10) NOT NULL,
+    response_status INTEGER NOT NULL,
+    response_body   JSONB NOT NULL,
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at      TIMESTAMP NOT NULL,
+    CONSTRAINT pk_idempotency_keys PRIMARY KEY (key, user_id),
+    CONSTRAINT chk_idempotency_keys_method CHECK (method IN ('PATCH', 'POST'))
+);
+
+-- Hot path: middleware lookup `WHERE key = ? AND user_id = ?` (covered by PK).
+-- Secondary path: cron cleanup `WHERE expires_at < NOW()`.
+CREATE INDEX IF NOT EXISTS idx_idempotency_keys_expires_at
+    ON public.idempotency_keys(expires_at);
+
+-- Optional ops query: "how many cached responses per endpoint" for capacity sizing.
+CREATE INDEX IF NOT EXISTS idx_idempotency_keys_endpoint
+    ON public.idempotency_keys(endpoint);

--- a/db/sqlc/models.go
+++ b/db/sqlc/models.go
@@ -183,6 +183,17 @@ type DemoDataSeed struct {
 	Metadata []byte      `json:"metadata"`
 }
 
+type IdempotencyKey struct {
+	Key            string           `json:"key"`
+	UserID         string           `json:"user_id"`
+	Endpoint       string           `json:"endpoint"`
+	Method         string           `json:"method"`
+	ResponseStatus int32            `json:"response_status"`
+	ResponseBody   json.RawMessage  `json:"response_body"`
+	CreatedAt      pgtype.Timestamp `json:"created_at"`
+	ExpiresAt      pgtype.Timestamp `json:"expires_at"`
+}
+
 type Inventory struct {
 	ID           string           `json:"id"`
 	Sku          string           `json:"sku"`

--- a/models/database/idempotency_key.go
+++ b/models/database/idempotency_key.go
@@ -1,0 +1,26 @@
+package database
+
+import "time"
+
+// IdempotencyKey is a cached response for a mobile mutation client UUID v4.
+// See S7.2 W0 design: mobile generates a key per mutation, sends it on
+// every retry via `Idempotency-Key` header; backend dedupes within a 7-day
+// window so retries return the original response without re-applying.
+//
+// PK is composite (key, user_id) — keys are UUID v4 so cross-user collision
+// is astronomical, but the user_id scope guarantees one user can never
+// observe another user's cached response even in the worst case.
+type IdempotencyKey struct {
+	Key            string    `gorm:"column:key;primaryKey" json:"key"`
+	UserID         string    `gorm:"column:user_id;primaryKey" json:"user_id"`
+	Endpoint       string    `gorm:"column:endpoint" json:"endpoint"`
+	Method         string    `gorm:"column:method" json:"method"`
+	ResponseStatus int       `gorm:"column:response_status" json:"response_status"`
+	ResponseBody   []byte    `gorm:"column:response_body;type:jsonb" json:"response_body"`
+	CreatedAt      time.Time `gorm:"column:created_at;autoCreateTime" json:"created_at"`
+	ExpiresAt      time.Time `gorm:"column:expires_at" json:"expires_at"`
+}
+
+func (IdempotencyKey) TableName() string {
+	return "idempotency_keys"
+}

--- a/ports/idempotency_keys.go
+++ b/ports/idempotency_keys.go
@@ -1,0 +1,27 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/eflowcr/eSTOCK_backend/models/database"
+)
+
+// IdempotencyKeysRepository is the persistence contract for the mobile S7.2
+// outbox replay dedup table. Middleware looks up by (key, user_id) and
+// either returns the cached response or captures the fresh one after the
+// handler runs.
+type IdempotencyKeysRepository interface {
+	// Lookup returns the cached row if it exists AND has not expired.
+	// Returns (nil, nil) when there's no hit; (nil, err) only on real DB errors.
+	Lookup(ctx context.Context, key, userID string) (*database.IdempotencyKey, error)
+
+	// Store inserts the cached response. Uses ON CONFLICT DO NOTHING so a
+	// concurrent duplicate request that completed first wins — the second
+	// request's slightly-different response is dropped, which is correct
+	// idempotency semantics (the operator sees the FIRST observable result).
+	Store(ctx context.Context, entry *database.IdempotencyKey) error
+
+	// SweepExpired deletes rows older than now. Called from a cron worker.
+	// Returns the count of deleted rows for observability.
+	SweepExpired(ctx context.Context) (int64, error)
+}

--- a/repositories/idempotency_keys_repository.go
+++ b/repositories/idempotency_keys_repository.go
@@ -1,0 +1,50 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/eflowcr/eSTOCK_backend/models/database"
+	"github.com/eflowcr/eSTOCK_backend/ports"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// IdempotencyKeysRepository implements ports.IdempotencyKeysRepository
+// over GORM. See the port doc for semantics.
+type IdempotencyKeysRepository struct {
+	DB *gorm.DB
+}
+
+var _ ports.IdempotencyKeysRepository = (*IdempotencyKeysRepository)(nil)
+
+func (r *IdempotencyKeysRepository) Lookup(ctx context.Context, key, userID string) (*database.IdempotencyKey, error) {
+	var row database.IdempotencyKey
+	err := r.DB.WithContext(ctx).
+		Where("key = ? AND user_id = ? AND expires_at > ?", key, userID, time.Now()).
+		First(&row).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (r *IdempotencyKeysRepository) Store(ctx context.Context, entry *database.IdempotencyKey) error {
+	// ON CONFLICT DO NOTHING — the first writer wins. A concurrent retry that
+	// raced and completed first already populated the row; preserving that
+	// row keeps the operator's observed response stable across replays.
+	return r.DB.WithContext(ctx).
+		Clauses(clause.OnConflict{DoNothing: true}).
+		Create(entry).Error
+}
+
+func (r *IdempotencyKeysRepository) SweepExpired(ctx context.Context) (int64, error) {
+	res := r.DB.WithContext(ctx).
+		Where("expires_at < ?", time.Now()).
+		Delete(&database.IdempotencyKey{})
+	return res.RowsAffected, res.Error
+}

--- a/routes/mobile_routes.go
+++ b/routes/mobile_routes.go
@@ -4,6 +4,7 @@ import (
 	"github.com/eflowcr/eSTOCK_backend/configuration"
 	"github.com/eflowcr/eSTOCK_backend/controllers"
 	"github.com/eflowcr/eSTOCK_backend/ports"
+	"github.com/eflowcr/eSTOCK_backend/repositories"
 	"github.com/eflowcr/eSTOCK_backend/services"
 	"github.com/eflowcr/eSTOCK_backend/tools"
 	"github.com/eflowcr/eSTOCK_backend/wire"
@@ -65,11 +66,22 @@ func RegisterMobileRoutes(
 	_, countsSvc := wire.NewInventoryCounts(db, pool)
 	countsCtrl := controllers.NewInventoryCountsController(*countsSvc, config.JWTSecret)
 
+	// S7.2 W0 — Idempotency-Key middleware for mobile write paths. Wraps the
+	// 5 mutation endpoints that mobile can replay from its offline outbox.
+	// Repo may be nil when db is nil (test mode) — middleware handles that.
+	var idempotencyRepo ports.IdempotencyKeysRepository
+	if db != nil {
+		idempotencyRepo = &repositories.IdempotencyKeysRepository{DB: db}
+	}
+
 	mobile := router.Group("/mobile")
 	mobile.Use(tools.JWTAuthMiddleware(config.JWTSecret))
 	{
 		readInventory := tools.RequirePermission(rolesRepo, "inventory", "read")
 		updateInventory := tools.RequirePermission(rolesRepo, "inventory", "update")
+		// Mount AFTER auth + permission so we never cache 401/403 responses
+		// (those depend on the token, not the request body).
+		dedupeMutation := tools.IdempotencyMiddleware(idempotencyRepo)
 
 		// Health (no permission check — just JWT validation).
 		mobile.GET("/health", mobileCtrl.Health)
@@ -78,19 +90,19 @@ func RegisterMobileRoutes(
 		mobile.GET("/picking-tasks", readInventory, mobileCtrl.ListPickingTasks)
 		mobile.GET("/picking-tasks/:id", readInventory, mobileCtrl.GetPickingTask)
 		mobile.PATCH("/picking-tasks/:id/start", updateInventory, mobileCtrl.StartPickingTask)
-		mobile.PATCH("/picking-tasks/:id/complete-line", updateInventory, mobileCtrl.CompletePickingLine)
+		mobile.PATCH("/picking-tasks/:id/complete-line", updateInventory, dedupeMutation, mobileCtrl.CompletePickingLine)
 		mobile.PATCH("/picking-tasks/:id/complete", updateInventory, mobileCtrl.CompletePickingTask)
 
 		// Receiving
 		mobile.GET("/receiving-tasks", readInventory, mobileCtrl.ListReceivingTasks)
 		mobile.GET("/receiving-tasks/:id", readInventory, mobileCtrl.GetReceivingTask)
-		mobile.PATCH("/receiving-tasks/:id/complete-line", updateInventory, mobileCtrl.CompleteReceivingLine)
+		mobile.PATCH("/receiving-tasks/:id/complete-line", updateInventory, dedupeMutation, mobileCtrl.CompleteReceivingLine)
 		mobile.PATCH("/receiving-tasks/:id/complete", updateInventory, mobileCtrl.CompleteReceivingTask)
 
 		// Stock Transfers
 		mobile.GET("/stock-transfers", readInventory, mobileCtrl.ListStockTransfers)
 		mobile.GET("/stock-transfers/:id", readInventory, mobileCtrl.GetStockTransfer)
-		mobile.POST("/stock-transfers/:id/execute", updateInventory, mobileCtrl.ExecuteStockTransfer)
+		mobile.POST("/stock-transfers/:id/execute", updateInventory, dedupeMutation, mobileCtrl.ExecuteStockTransfer)
 
 		// Inventory query
 		mobile.GET("/inventory", readInventory, mobileCtrl.QueryInventory)
@@ -107,8 +119,8 @@ func RegisterMobileRoutes(
 			counts.GET("/:id", readInventory, countsCtrl.GetDetail)
 			counts.POST("", updateInventory, countsCtrl.Create)
 			counts.PATCH("/:id/start", updateInventory, countsCtrl.Start)
-			counts.POST("/:id/scan-line", updateInventory, countsCtrl.ScanLine)
-			counts.POST("/:id/submit", updateInventory, countsCtrl.Submit)
+			counts.POST("/:id/scan-line", updateInventory, dedupeMutation, countsCtrl.ScanLine)
+			counts.POST("/:id/submit", updateInventory, dedupeMutation, countsCtrl.Submit)
 			counts.PATCH("/:id/cancel", updateInventory, countsCtrl.Cancel)
 		}
 	}

--- a/tools/cron.go
+++ b/tools/cron.go
@@ -462,5 +462,28 @@ func CronDispatch(db *gorm.DB, analyzer func(tenantID string) error, lotNotifyFn
 	if err := RunTrialExpirationCheck(db, trialSendFn); err != nil {
 		log.Error().Err(err).Msg("cron: trial expiration check failed")
 	}
+	// S7.2 W0 — Mobile Idempotency-Key dedup sweep. 7-day TTL on cached
+	// response rows; cron removes expired entries each tick so the table
+	// stays bounded.
+	if err := RunIdempotencyKeysSweep(db); err != nil {
+		log.Error().Err(err).Msg("cron: idempotency keys sweep failed")
+	}
+}
+
+// RunIdempotencyKeysSweep deletes idempotency_keys rows whose expires_at is
+// in the past. Bounded operation: scales with the number of EXPIRED rows,
+// not the table size, thanks to the idx_idempotency_keys_expires_at index.
+func RunIdempotencyKeysSweep(db *gorm.DB) error {
+	if db == nil {
+		return nil
+	}
+	res := db.Exec("DELETE FROM idempotency_keys WHERE expires_at < NOW()")
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected > 0 {
+		log.Info().Int64("rows_swept", res.RowsAffected).Msg("cron: idempotency keys swept")
+	}
+	return nil
 }
 

--- a/tools/idempotency_middleware.go
+++ b/tools/idempotency_middleware.go
@@ -1,0 +1,140 @@
+package tools
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/eflowcr/eSTOCK_backend/models/database"
+	"github.com/eflowcr/eSTOCK_backend/ports"
+	"github.com/gin-gonic/gin"
+)
+
+// idempotencyKeyHeader is the HTTP header mobile sends per mutation. Value
+// is a client-generated UUID v4. The same value is sent on every retry so
+// the backend can dedupe.
+const idempotencyKeyHeader = "Idempotency-Key"
+
+// idempotencyTTL is the window during which a cached response is replayed.
+// After this, a replay re-applies the mutation — operators shouldn't be
+// queuing offline writes for longer than a week, and the cron sweep frees
+// the row.
+const idempotencyTTL = 7 * 24 * time.Hour
+
+// Cache only response status codes that semantically indicate a *completed*
+// mutation. Caching 5xx would defeat the point — operator retries to RECOVER
+// from a transient backend failure. Caching client errors (4xx) is correct
+// because the same key replayed would produce the same validation rejection.
+func isCacheableStatus(status int) bool {
+	return status >= 200 && status < 500
+}
+
+// IdempotencyMiddleware returns a Gin middleware that dedupes mobile mutations
+// by `Idempotency-Key` header. Mount it AFTER JWTAuthMiddleware (needs user_id
+// on context) and AFTER RequirePermission (don't want to cache 403s).
+//
+// Behavior:
+//  1. No header → pass-through (legacy mobile clients + non-mobile callers).
+//  2. Header + cache hit + not expired → return cached status + body; the
+//     downstream handler does NOT run.
+//  3. Header + cache miss → run handler, capture response, store if cacheable.
+//
+// Repo may be nil for tests, in which case the middleware short-circuits to
+// Next() (same pattern as RequirePermission).
+func IdempotencyMiddleware(repo ports.IdempotencyKeysRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if repo == nil {
+			c.Next()
+			return
+		}
+
+		key := c.GetHeader(idempotencyKeyHeader)
+		if key == "" {
+			c.Next()
+			return
+		}
+
+		userID := c.GetString(ContextKeyUserID)
+		if userID == "" {
+			// No user context = before JWT middleware. The route is misconfigured
+			// (idempotency relies on user scoping) but don't 500 the operator;
+			// just pass through and let the handler decide.
+			c.Next()
+			return
+		}
+
+		// Hit path: return cached response and short-circuit.
+		ctx := c.Request.Context()
+		cached, err := repo.Lookup(ctx, key, userID)
+		if err == nil && cached != nil {
+			c.Header("X-Idempotent-Replayed", "true")
+			c.Data(cached.ResponseStatus, "application/json; charset=utf-8", cached.ResponseBody)
+			c.Abort()
+			return
+		}
+		// Lookup error → log via gin and proceed without dedup (better to
+		// re-apply than to fail the operator's request).
+		if err != nil {
+			c.Error(err)
+		}
+
+		// Miss path: wrap the writer so we can capture the response body, run
+		// the handler chain, then persist the response under the key.
+		writer := &responseCaptureWriter{
+			ResponseWriter: c.Writer,
+			buf:            &bytes.Buffer{},
+		}
+		c.Writer = writer
+
+		c.Next()
+
+		if c.IsAborted() {
+			// The handler aborted (auth, permission, validation). Still cache
+			// the response if the status is in the cacheable range — replay
+			// will surface the same 4xx, which is the desired idempotent
+			// behavior (the same input produces the same rejection).
+		}
+
+		if !isCacheableStatus(writer.Status()) {
+			return
+		}
+
+		// Best-effort store: never bubble a DB error to the operator after
+		// the handler succeeded. Logged via gin.Context for observability.
+		entry := &database.IdempotencyKey{
+			Key:            key,
+			UserID:         userID,
+			Endpoint:       c.FullPath(),
+			Method:         c.Request.Method,
+			ResponseStatus: writer.Status(),
+			ResponseBody:   writer.buf.Bytes(),
+			ExpiresAt:      time.Now().Add(idempotencyTTL),
+		}
+		if storeErr := repo.Store(context.Background(), entry); storeErr != nil {
+			c.Error(storeErr)
+		}
+	}
+}
+
+// responseCaptureWriter buffers the response body so the middleware can
+// persist it after the handler completes. Delegates everything else to the
+// underlying Gin writer.
+type responseCaptureWriter struct {
+	gin.ResponseWriter
+	buf *bytes.Buffer
+}
+
+func (w *responseCaptureWriter) Write(b []byte) (int, error) {
+	w.buf.Write(b)
+	return w.ResponseWriter.Write(b)
+}
+
+func (w *responseCaptureWriter) WriteString(s string) (int, error) {
+	w.buf.WriteString(s)
+	return w.ResponseWriter.WriteString(s)
+}
+
+// http.ResponseWriter sanity — gin.ResponseWriter already embeds it but the
+// compiler needs an explicit signature when we override Write/WriteString.
+var _ http.ResponseWriter = (*responseCaptureWriter)(nil)

--- a/tools/idempotency_middleware_test.go
+++ b/tools/idempotency_middleware_test.go
@@ -1,0 +1,227 @@
+package tools
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eflowcr/eSTOCK_backend/models/database"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeIdempotencyRepo is a thread-safe in-memory mock used across the
+// middleware test matrix. Each test instantiates its own to avoid bleed.
+type fakeIdempotencyRepo struct {
+	mu      sync.Mutex
+	rows    map[string]*database.IdempotencyKey // composite key = key + "|" + userID
+	lookErr error
+}
+
+func newFakeRepo() *fakeIdempotencyRepo {
+	return &fakeIdempotencyRepo{rows: map[string]*database.IdempotencyKey{}}
+}
+
+func (f *fakeIdempotencyRepo) Lookup(_ context.Context, key, userID string) (*database.IdempotencyKey, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.lookErr != nil {
+		return nil, f.lookErr
+	}
+	row, ok := f.rows[key+"|"+userID]
+	if !ok {
+		return nil, nil
+	}
+	if row.ExpiresAt.Before(time.Now()) {
+		return nil, nil
+	}
+	return row, nil
+}
+
+func (f *fakeIdempotencyRepo) Store(_ context.Context, entry *database.IdempotencyKey) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	// ON CONFLICT DO NOTHING semantics — first writer wins.
+	composite := entry.Key + "|" + entry.UserID
+	if _, exists := f.rows[composite]; exists {
+		return nil
+	}
+	f.rows[composite] = entry
+	return nil
+}
+
+func (f *fakeIdempotencyRepo) SweepExpired(_ context.Context) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var n int64
+	for k, row := range f.rows {
+		if row.ExpiresAt.Before(time.Now()) {
+			delete(f.rows, k)
+			n++
+		}
+	}
+	return n, nil
+}
+
+// runRequest fires a single request through a router with JWT + idempotency
+// middleware in front. handlerCalls counts invocations so tests can assert
+// replays short-circuit the handler.
+func runRequest(t *testing.T, repo *fakeIdempotencyRepo, key, body string, handler gin.HandlerFunc) (*httptest.ResponseRecorder, *int) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	calls := 0
+	wrapped := gin.HandlerFunc(func(c *gin.Context) {
+		calls++
+		handler(c)
+	})
+
+	r := gin.New()
+	// Fake auth — set user_id directly.
+	r.Use(func(c *gin.Context) {
+		c.Set(ContextKeyUserID, "user-1")
+		c.Next()
+	})
+	r.Use(IdempotencyMiddleware(repo))
+	r.POST("/api/mobile/picking-tasks/:id/complete-line", wrapped)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/mobile/picking-tasks/abc123/complete-line", nil)
+	if body != "" {
+		req.Body = http.NoBody // request body not needed for middleware behavior
+	}
+	if key != "" {
+		req.Header.Set("Idempotency-Key", key)
+	}
+	r.ServeHTTP(w, req)
+	return w, &calls
+}
+
+func TestIdempotencyMiddleware_NoHeaderPassthrough(t *testing.T) {
+	repo := newFakeRepo()
+	w, calls := runRequest(t, repo, "", "", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 1, *calls, "handler must run when header absent")
+	assert.Empty(t, repo.rows, "no cache entry when header absent")
+}
+
+func TestIdempotencyMiddleware_FirstHitStoresResponse(t *testing.T) {
+	repo := newFakeRepo()
+	w, calls := runRequest(t, repo, "key-abc", "", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"line_id": "L1", "picked_qty": 5})
+	})
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 1, *calls)
+	require.Len(t, repo.rows, 1, "cache must contain the response after first hit")
+	row := repo.rows["key-abc|user-1"]
+	assert.Equal(t, http.StatusOK, row.ResponseStatus)
+	assert.Contains(t, string(row.ResponseBody), `"line_id":"L1"`)
+}
+
+func TestIdempotencyMiddleware_ReplayReturnsCachedShortCircuit(t *testing.T) {
+	repo := newFakeRepo()
+	repo.rows["key-abc|user-1"] = &database.IdempotencyKey{
+		Key:            "key-abc",
+		UserID:         "user-1",
+		ResponseStatus: http.StatusOK,
+		ResponseBody:   []byte(`{"replayed":true}`),
+		ExpiresAt:      time.Now().Add(time.Hour),
+	}
+
+	w, calls := runRequest(t, repo, "key-abc", "", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"should_not_fire": true})
+	})
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 0, *calls, "handler must NOT run on replay")
+	assert.JSONEq(t, `{"replayed":true}`, w.Body.String())
+	assert.Equal(t, "true", w.Header().Get("X-Idempotent-Replayed"))
+}
+
+func TestIdempotencyMiddleware_ExpiredEntryRunsHandler(t *testing.T) {
+	repo := newFakeRepo()
+	repo.rows["key-abc|user-1"] = &database.IdempotencyKey{
+		Key:            "key-abc",
+		UserID:         "user-1",
+		ResponseStatus: http.StatusOK,
+		ResponseBody:   []byte(`{"stale":true}`),
+		ExpiresAt:      time.Now().Add(-1 * time.Hour),
+	}
+
+	w, calls := runRequest(t, repo, "key-abc", "", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"fresh": true})
+	})
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 1, *calls, "handler must run when cache entry is expired")
+	assert.Contains(t, w.Body.String(), `"fresh":true`)
+}
+
+func TestIdempotencyMiddleware_5xxNotCached(t *testing.T) {
+	repo := newFakeRepo()
+	w, calls := runRequest(t, repo, "key-abc", "", func(c *gin.Context) {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "transient"})
+	})
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, 1, *calls)
+	assert.Empty(t, repo.rows, "5xx responses must not be cached — retry should re-attempt")
+}
+
+func TestIdempotencyMiddleware_4xxCached(t *testing.T) {
+	// Validation rejections SHOULD be cached: replay returns the same 4xx
+	// instead of re-running validation. This is the desired idempotent
+	// semantic — same input, same rejection.
+	repo := newFakeRepo()
+	w, calls := runRequest(t, repo, "key-abc", "", func(c *gin.Context) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_qty"})
+	})
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, 1, *calls)
+	require.Len(t, repo.rows, 1, "4xx responses cached so replays surface the same rejection")
+}
+
+func TestIdempotencyMiddleware_NilRepoPassthrough(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	calls := 0
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(ContextKeyUserID, "user-1")
+		c.Next()
+	})
+	r.Use(IdempotencyMiddleware(nil))
+	r.POST("/x", func(c *gin.Context) {
+		calls++
+		c.Status(http.StatusOK)
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/x", nil)
+	req.Header.Set("Idempotency-Key", "key-abc")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 1, calls)
+}
+
+func TestIdempotencyMiddleware_MissingUserIDPassthrough(t *testing.T) {
+	// If JWT middleware didn't run or set ContextKeyUserID, the idempotency
+	// middleware should pass through rather than 500.
+	gin.SetMode(gin.TestMode)
+	repo := newFakeRepo()
+	calls := 0
+	r := gin.New()
+	r.Use(IdempotencyMiddleware(repo))
+	r.POST("/x", func(c *gin.Context) {
+		calls++
+		c.Status(http.StatusOK)
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/x", nil)
+	req.Header.Set("Idempotency-Key", "key-abc")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, 1, calls)
+	assert.Empty(t, repo.rows, "no caching without user scope")
+}


### PR DESCRIPTION
## Summary

Backend contract for the mobile S7.2 write-side outbox. Mobile generates a UUID v4 per mutation and sends it on every retry via `Idempotency-Key` header. Backend dedupes by `(key, user_id)` within a 7-day window — replays return the cached response without re-applying the mutation.

**Without this PR, mobile's offline replay would duplicate picks/receivings/transfers/counts in production.**

## What's in the box

| File | Purpose |
|---|---|
| `db/migrations/000040_idempotency_keys.up.sql` (+ down) | Composite PK `(key, user_id)`, JSONB response body, expires_at index for sweep |
| `models/database/idempotency_key.go` | GORM model |
| `ports/idempotency_keys.go` | Repository contract (`Lookup`/`Store`/`SweepExpired`) |
| `repositories/idempotency_keys_repository.go` | GORM impl with `ON CONFLICT DO NOTHING` (first writer wins) |
| `tools/idempotency_middleware.go` | Gin middleware with response capture writer |
| `tools/idempotency_middleware_test.go` | 8 unit tests, all paths |
| `tools/cron.go` | `RunIdempotencyKeysSweep` wired into `CronDispatch` (7-day TTL) |
| `routes/mobile_routes.go` | Middleware applied to 5 mutation endpoints |

## Endpoints affected

- `PATCH /api/mobile/picking-tasks/:id/complete-line`
- `PATCH /api/mobile/receiving-tasks/:id/complete-line`
- `POST /api/mobile/stock-transfers/:id/execute`
- `POST /api/mobile/counts/:id/scan-line`
- `POST /api/mobile/counts/:id/submit`

## Caching policy

| Status | Cached? | Why |
|---|---|---|
| 2xx | ✅ | Successful mutation — replay returns the same observable result |
| 4xx | ✅ | Validation rejection — same input deserves same rejection (idempotent semantic) |
| 5xx | ❌ | Transient backend failure — operator retries to RECOVER; caching defeats it |

## Observability

- `X-Idempotent-Replayed: true` header on cache hits
- Cron logs `rows_swept` when sweep removes expired entries

## Backwards compatibility

- No `Idempotency-Key` header → middleware passes through, current mobile clients unchanged
- New mobile build (S7.2 W1+) starts sending the header
- Web frontend never sends the header → unaffected

## Test plan

- [x] 8 unit tests pass (`go test ./tools/ -run Idempotency`)
- [x] `go build ./...` clean
- [ ] Deploy to dev, send a manual `curl` with same `Idempotency-Key` twice → second returns cached body with `X-Idempotent-Replayed: true` header
- [ ] Verify cron sweep deletes expired rows (manual SQL backdate + wait for tick)
- [ ] Mobile S7.2 W1 integration test once outbox lands